### PR TITLE
Add Python 3.8 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -390,6 +390,7 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     package_dir={"": "src"},
     packages=find_packages("src"),


### PR DESCRIPTION
Thanks for creating useful library. As it already runs on Python 3.8 in CI I think it is good to add Python 3.8 classifier.