### PR TITLE
Fix docker image startup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -121,8 +121,7 @@ RUN set -x \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* 
 
-COPY ./docker/docker-entrypoint.sh ./docker/.env $DISPATCH_CONF/
-RUN chmod u+x $DISPATCH_CONF/docker-entrypoint.sh 
+COPY ./docker/docker-entrypoint.sh $DISPATCH_CONF/
 
 EXPOSE 8000
 VOLUME /var/lib/dispatch/files

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -127,7 +127,7 @@ EXPOSE 8000
 VOLUME /var/lib/dispatch/files
 
 ENTRYPOINT exec $DISPATCH_CONF/docker-entrypoint.sh $0 $@
-CMD ["server"]
+CMD ["'server start'"]
 
 ARG SOURCE_COMMIT
 LABEL org.opencontainers.image.revision=$SOURCE_COMMIT

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -109,7 +109,7 @@ RUN set -x \
     && apt-get update \
     && apt-get install -y --no-install-recommends $buildDeps \
     # remove internal index when internal plugins are seperated
-    && pip install /tmp/dist/*.whl \  
+    && pip install /tmp/dist/*.whl \
     && apt-get purge -y --auto-remove $buildDeps \
     # We install run-time dependencies strictly after
     # build dependencies to prevent accidental collusion.
@@ -119,7 +119,7 @@ RUN set -x \
     pkg-config \
     \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* 
+    && rm -rf /var/lib/apt/lists/*
 
 COPY ./docker/docker-entrypoint.sh $DISPATCH_CONF/
 
@@ -127,7 +127,7 @@ EXPOSE 8000
 VOLUME /var/lib/dispatch/files
 
 ENTRYPOINT exec $DISPATCH_CONF/docker-entrypoint.sh $0 $@
-CMD ["'server start'"]
+CMD ["server", "start"]
 
 ARG SOURCE_COMMIT
 LABEL org.opencontainers.image.revision=$SOURCE_COMMIT

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,16 +2,19 @@
 
 set -e
 
-# first check if we're passing flags, if so
-# prepend with dispatch
+# first check if we're passing flags, if so prepend with dispatch
+# Example ./docker-entrypoint.sh -flag=1 server start
 if [ "${1:0:1}" = '-' ]; then
 	set -- dispatch "$@"
 fi
 
-case "$1" in
-	"server start" | "database upgrade" | "database downgrade" )
+# Intercept known "dispatch $command $sub-command" combinations and append them
+# to the "dispatch" binary. Other parameters are passed through
+# Example: "./docker-entrpoint.sh server start" becomes "dispatch server start"
+case "${@:1:2}" in
+	"server start" | "database upgrade" | "database downgrade" | "scheduler start" )
 		set -- dispatch "$@"
-	  ;;
+		;;
 esac
 
 exec "$@"


### PR DESCRIPTION
Summary of changes:

- improve parsing in startup script
 -- fix how 2-word commands are parsed by bash
 -- add the "scheduler" command as a recognized command to support the scheduler container in [docker-compose](https://github.com/Netflix/dispatch-docker/blob/f65df7ca90e51ae2c72e87175efb5c275e6b21e0/docker-compose.yml#L20-L21)

- exclude the `.env` file in the build step
 -- adjustments to the environment file shouldn't trigger a rebuild since it configures run-time settings
 -- it's not used for the build
 -- the file is more appropriately supplied at run-time via `docker run` or via `docker-compose`
- set the default command
 -- reading through the [documentation](https://hawkins.gitbook.io/dispatch/cli#start) it appears this image is trying to boot up the server as the default invocation
 -- even so, this will _still_ fail because the command expects an app
 -- the more appropriate action should be to better document how to control startup behavior in a docker environment