### PR TITLE
fix uvicorn port binding for docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -125,7 +125,7 @@ EXPOSE 8000
 VOLUME /var/lib/dispatch/files
 
 ENTRYPOINT ["dispatch"]
-CMD ["server", "start", "dispatch.main:app"]
+CMD ["server", "start", "dispatch.main:app", "--host=0.0.0.0"]
 
 ARG SOURCE_COMMIT
 LABEL org.opencontainers.image.revision=$SOURCE_COMMIT

--- a/src/dispatch/run.py
+++ b/src/dispatch/run.py
@@ -1,4 +1,4 @@
 import uvicorn
 
 if __name__ == "__main__":
-    uvicorn.run("dispatch.main:app")
+    uvicorn.run("dispatch.main:app" "host=0.0.0.0")


### PR DESCRIPTION
This allows us to reach dispatch behind a reverse proxy and fixes: https://github.com/Netflix/dispatch-docker/issues/19