### PR TITLE
Fixing issue where stable time would always be overwritten with utcnow()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,5 @@ release
 
 # exclude docker env files
 docker/.env
+
+*.dump

--- a/src/dispatch/cli.py
+++ b/src/dispatch/cli.py
@@ -504,11 +504,23 @@ def init_database():
 @dispatch_database.command("restore")
 def restore_database():
     """Restores the database via pg_restore."""
-    from sh import psql
+    from sh import psql, createdb
     from dispatch.config import DATABASE_HOSTNAME, DATABASE_PORT, DATABASE_CREDENTIALS
 
     username, password = str(DATABASE_CREDENTIALS).split(":")
 
+    print(
+        createdb(
+            "-h",
+            DATABASE_HOSTNAME,
+            "-p",
+            DATABASE_PORT,
+            "-U",
+            username,
+            "dispatch",
+            _env={"PGPASSWORD": password},
+        )
+    )
     print(
         psql(
             "-h",

--- a/src/dispatch/incident/flows.py
+++ b/src/dispatch/incident/flows.py
@@ -769,15 +769,15 @@ def incident_update_flow(
     # we load the incident instance
     incident = incident_service.get(db_session=db_session, incident_id=incident_id)
 
-    if incident_in.type != incident.incident_type.name:
+    if incident_in.incident_type.name != incident.incident_type.name:
         conversation_topic_change = True
 
-    if incident_in.incident_priority != incident.incident_priority.name:
+    if incident_in.incident_priority.name != incident.incident_priority.name:
         conversation_topic_change = True
 
     if notify == "Yes":
         send_incident_change_notifications(
-            incident, incident.title, incident.incident_type, incident.incident_priority
+            incident, incident.title, incident.incident_type.name, incident.incident_priority.name
         )
 
     if conversation_topic_change:
@@ -796,8 +796,8 @@ def incident_update_flow(
         incident.ticket.resource_id,
         title=incident.title,
         description=incident.description,
-        incident_type=incident.incident_type,
-        priority=incident.incident_priority,
+        incident_type=incident.incident_type.name,
+        priority=incident.incident_priority.name,
         commander_email=incident.commander.email,
         conversation_weblink=incident.conversation.weblink,
         document_weblink=incident_document.weblink,

--- a/src/dispatch/incident/flows.py
+++ b/src/dispatch/incident/flows.py
@@ -8,6 +8,7 @@
 .. moduleauthor:: Marc Vilanova <mvilanova@netflix.com>
 """
 import logging
+from datetime import datetime
 from typing import Any, List, Optional
 
 from dispatch.config import (
@@ -40,6 +41,7 @@ from dispatch.document.service import get_by_incident_id_and_resource_type as ge
 from dispatch.group import service as group_service
 from dispatch.group.models import GroupCreate
 from dispatch.incident import service as incident_service
+from dispatch.incident.models import IncidentUpdate
 from dispatch.incident_priority import service as incident_priority_service
 from dispatch.incident_priority.models import IncidentPriorityRead
 from dispatch.incident_type import service as incident_type_service
@@ -569,6 +571,8 @@ def incident_stable_flow(incident_id: int, command: Optional[dict] = None, db_se
 
     log.debug(f"We have updated the status of the incident to {IncidentStatus.stable}.")
 
+    incident.stable_at = datetime.utcnow()
+
     # we update the incident cost
     incident_cost = incident_service.calculate_cost(incident_id, db_session)
 
@@ -627,9 +631,6 @@ def incident_stable_flow(incident_id: int, command: Optional[dict] = None, db_se
             document_service.create(db_session=db_session, document_in=document_in)
         )
 
-        db_session.add(incident)
-        db_session.commit()
-
         log.debug("We have added the incident review document to the incident.")
 
         # we get the incident investigation and faq documents
@@ -668,6 +669,9 @@ def incident_stable_flow(incident_id: int, command: Optional[dict] = None, db_se
     # we send the stable notifications
     send_incident_status_notifications(incident, db_session)
 
+    db_session.add(incident)
+    db_session.commit()
+
     log.debug("We have sent the incident stable notifications.")
 
 
@@ -693,6 +697,10 @@ def incident_closed_flow(incident_id: int, command: Optional[dict] = None, db_se
                 ],
             )
         incident_stable_flow(incident_id, command=command, db_session=db_session)
+
+    incident.closed_at = datetime.utcnow()
+    db_session.add(incident)
+    db_session.commit()
 
     # we update the status of the incident
     update_incident_status(db_session=db_session, incident=incident, status=IncidentStatus.closed)
@@ -752,64 +760,25 @@ def incident_closed_flow(incident_id: int, command: Optional[dict] = None, db_se
 
 
 @background_task
-def incident_edit_flow(user_email: str, incident_id: int, action: dict, db_session=None):
-    """Runs the incident edit flow."""
-    notify = action["submission"]["notify"]
-    incident_title = action["submission"]["title"]
-    incident_description = action["submission"]["description"]
-    incident_type = action["submission"]["type"]
-    incident_priority = action["submission"]["priority"]
-    incident_visibility = action["submission"]["visibility"]
-
+def incident_update_flow(
+    user_email: str, incident_id: int, incident_in: IncidentUpdate, notify=True, db_session=None
+):
+    """Runs the incident update flow."""
     conversation_topic_change = False
 
     # we load the incident instance
     incident = incident_service.get(db_session=db_session, incident_id=incident_id)
 
-    # we update the incident title
-    incident.title = incident_title
-    log.debug(f"Updated the incident title to {incident_title}.")
-
-    # we update the incident description
-    incident.description = incident_description
-    log.debug(f"Updated the incident description to {incident_description}.")
-
-    if incident_type != incident.incident_type.name:
-        # we update the incident type
-        incident_type_obj = incident_type_service.get_by_name(
-            db_session=db_session, name=incident_type
-        )
-        incident.incident_type_id = incident_type_obj.id
-
-        log.debug(f"Updated the incident type to {incident_type}.")
-
+    if incident_in.type != incident.incident_type.name:
         conversation_topic_change = True
 
-    if incident_priority != incident.incident_priority.name:
-        # we update the incident priority
-        incident_priority_obj = incident_priority_service.get_by_name(
-            db_session=db_session, name=incident_priority
-        )
-        incident.incident_priority_id = incident_priority_obj.id
-
-        log.debug(f"Updated the incident priority to {incident_priority}.")
-
+    if incident_in.incident_priority != incident.incident_priority.name:
         conversation_topic_change = True
-
-    if incident_visibility != incident.visibility:
-        # we update the incident visibility
-        incident.visibility = incident_visibility
-
-        log.debug(f"Updated the incident visibility to {incident_visibility}.")
 
     if notify == "Yes":
         send_incident_change_notifications(
-            incident, incident_title, incident_type, incident_priority
+            incident, incident.title, incident.incident_type, incident.incident_priority
         )
-
-    # we commit the changes to the incident
-    db_session.add(incident)
-    db_session.commit()
 
     if conversation_topic_change:
         # we update the conversation topic
@@ -827,8 +796,8 @@ def incident_edit_flow(user_email: str, incident_id: int, action: dict, db_sessi
         incident.ticket.resource_id,
         title=incident.title,
         description=incident.description,
-        incident_type=incident_type,
-        priority=incident_priority,
+        incident_type=incident.incident_type,
+        priority=incident.incident_priority,
         commander_email=incident.commander.email,
         conversation_weblink=incident.conversation.weblink,
         document_weblink=incident_document.weblink,
@@ -861,6 +830,14 @@ def incident_edit_flow(user_email: str, incident_id: int, action: dict, db_sessi
     group_plugin.add(notification_group.email, team_participant_emails)
 
     log.debug(f"Resolved and added new participants to the incident.")
+
+    if incident_in.status.name != incident.status:
+        if incident_in.status == IncidentStatus.active:
+            incident_active_flow(incident_id=incident.id, db_session=db_session)
+        elif incident_in.status == IncidentStatus.closed:
+            incident_closed_flow(incident_id=incident.id, db_session=db_session)
+        elif incident_in.status == IncidentStatus.stable:
+            incident_stable_flow(incident_id=incident.id, db_session=db_session)
 
 
 @background_task

--- a/src/dispatch/incident/models.py
+++ b/src/dispatch/incident/models.py
@@ -19,8 +19,12 @@ from sqlalchemy_utils import TSVectorType
 from dispatch.conversation.models import ConversationRead
 from dispatch.database import Base
 from dispatch.document.models import DocumentRead
-from dispatch.incident_priority.models import IncidentPriorityCreate, IncidentPriorityRead
-from dispatch.incident_type.models import IncidentTypeCreate, IncidentTypeRead
+from dispatch.incident_priority.models import (
+    IncidentPriorityCreate,
+    IncidentPriorityRead,
+    IncidentPriorityBase,
+)
+from dispatch.incident_type.models import IncidentTypeCreate, IncidentTypeRead, IncidentTypeBase
 from dispatch.models import DispatchBase, IndividualReadNested, TimeStampMixin
 from dispatch.participant_role.models import ParticipantRoleType
 from dispatch.storage.models import StorageRead
@@ -127,12 +131,12 @@ class IncidentCreate(IncidentBase):
 
 class IncidentUpdate(IncidentBase):
     visibility: IncidentVisibility
-    incident_priority: IncidentPriorityRead
-    incident_type: IncidentTypeRead
+    incident_priority: IncidentPriorityBase
+    incident_type: IncidentTypeBase
     reported_at: Optional[datetime] = None
     stable_at: Optional[datetime] = None
-    commander: IndividualReadNested
-    reporter: IndividualReadNested
+    commander: Optional[IndividualReadNested]
+    reporter: Optional[IndividualReadNested]
 
 
 class IncidentRead(IncidentBase):

--- a/src/dispatch/incident/models.py
+++ b/src/dispatch/incident/models.py
@@ -104,7 +104,8 @@ class Incident(Base, TimeStampMixin):
     @staticmethod
     def _status_time(mapper, connection, target):
         if target.status == IncidentStatus.stable:
-            target.stable_at = datetime.utcnow()
+            if not target.stable_at:
+                target.stable_at = datetime.utcnow()
         elif target.status == IncidentStatus.closed:
             target.closed_at = datetime.utcnow()
 

--- a/src/dispatch/incident/models.py
+++ b/src/dispatch/incident/models.py
@@ -11,7 +11,6 @@ from sqlalchemy import (
     PrimaryKeyConstraint,
     String,
     Table,
-    event,
 )
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
@@ -100,18 +99,6 @@ class Incident(Base, TimeStampMixin):
     status_reports = relationship("StatusReport", backref="incident")
     tasks = relationship("Task", backref="incident")
     terms = relationship("Term", secondary=assoc_incident_terms, backref="incidents")
-
-    @staticmethod
-    def _status_time(mapper, connection, target):
-        if target.status == IncidentStatus.stable:
-            if not target.stable_at:
-                target.stable_at = datetime.utcnow()
-        elif target.status == IncidentStatus.closed:
-            target.closed_at = datetime.utcnow()
-
-    @classmethod
-    def __declare_last__(cls):
-        event.listen(cls, "before_update", cls._status_time)
 
 
 # Pydantic models...

--- a/src/dispatch/incident/service.py
+++ b/src/dispatch/incident/service.py
@@ -1,7 +1,8 @@
 import math
 from datetime import datetime, timedelta
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
+from fastapi import BackgroundTasks
 from fastapi.encoders import jsonable_encoder
 
 from dispatch.config import ANNUAL_COST_EMPLOYEE, BUSINESS_HOURS_YEAR
@@ -184,7 +185,6 @@ def create(
 
 def update(*, db_session, incident: Incident, incident_in: IncidentUpdate) -> Incident:
     incident_data = jsonable_encoder(incident)
-
     incident_priority = incident_priority_service.get_by_name(
         db_session=db_session, name=incident_in.incident_priority.name
     )
@@ -206,6 +206,7 @@ def update(*, db_session, incident: Incident, incident_in: IncidentUpdate) -> In
 
     db_session.add(incident)
     db_session.commit()
+
     return incident
 
 

--- a/src/dispatch/incident/views.py
+++ b/src/dispatch/incident/views.py
@@ -6,7 +6,9 @@ from sqlalchemy.orm import Session
 from dispatch.auth.service import get_current_user
 from dispatch.database import get_db, search_filter_sort_paginate
 
-from .flows import incident_create_flow, incident_update_flow
+from dispatch.participant_role.models import ParticipantRoleType
+
+from .flows import incident_create_flow, incident_update_flow, incident_assign_role_flow
 from .models import IncidentCreate, IncidentPagination, IncidentRead, IncidentUpdate
 from .service import create, delete, get, update
 
@@ -79,6 +81,7 @@ def update_incident(
     db_session: Session = Depends(get_db),
     incident_id: str,
     incident_in: IncidentUpdate,
+    current_user_email: str = Depends(get_current_user),
     background_tasks: BackgroundTasks,
 ):
     """
@@ -87,10 +90,35 @@ def update_incident(
     incident = get(db_session=db_session, incident_id=incident_id)
     if not incident:
         raise HTTPException(status_code=404, detail="The requested incident does not exist.")
+
+    previous_incident = IncidentRead.from_orm(incident)
+
+    # NOTE: Order matters we have to get the previous state for change detection
     incident = update(db_session=db_session, incident=incident, incident_in=incident_in)
 
     background_tasks.add_task(
-        incident_update_flow, incident_id=incident.id, incident_in=incident_in
+        incident_update_flow,
+        user_email=current_user_email,
+        incident_id=incident.id,
+        previous_incident=previous_incident,
+    )
+
+    # assign commander
+    background_tasks.add_task(
+        incident_assign_role_flow,
+        current_user_email,
+        incident_id=incident.id,
+        assignee_email=incident_in.commander.email,
+        assignee_role=ParticipantRoleType.incident_commander,
+    )
+
+    # assign reporter
+    background_tasks.add_task(
+        incident_assign_role_flow,
+        current_user_email,
+        incident_id=incident.id,
+        assignee_email=incident_in.reporter.email,
+        assignee_role=ParticipantRoleType.reporter,
     )
 
     return incident

--- a/src/dispatch/plugins/dispatch_jira/plugin.py
+++ b/src/dispatch/plugins/dispatch_jira/plugin.py
@@ -212,20 +212,18 @@ class JiraTicketPlugin(TicketPlugin):
 
     _schema = None
 
-    def __init__(self):
-        self.client = JIRA(str(JIRA_API_URL), basic_auth=(JIRA_USERNAME, str(JIRA_PASSWORD)))
-
     def create(
         self, title: str, incident_type: str, incident_priority: str, commander: str, reporter: str
     ):
         """Creates a Jira ticket."""
+        client = JIRA(str(JIRA_API_URL), basic_auth=(JIRA_USERNAME, str(JIRA_PASSWORD)))
         commander_username = get_user_name(commander)
         reporter_username = get_user_name(reporter)
         if incident_type == "vulnerability":
-            return create_vul_issue(self.client, title, commander_username, reporter_username)
+            return create_vul_issue(client, title, commander_username, reporter_username)
         else:
             return create_sec_issue(
-                self.client,
+                client,
                 title,
                 incident_priority,
                 incident_type,
@@ -253,7 +251,9 @@ class JiraTicketPlugin(TicketPlugin):
         commander_username = get_user_name(commander_email) if commander_email else None
         reporter_username = get_user_name(reporter_email) if reporter_email else None
 
-        issue = self.client.issue(ticket_id)
+        client = JIRA(str(JIRA_API_URL), basic_auth=(JIRA_USERNAME, str(JIRA_PASSWORD)))
+
+        issue = client.issue(ticket_id)
         issue_fields = create_issue_fields(
             title=title,
             description=description,
@@ -267,4 +267,4 @@ class JiraTicketPlugin(TicketPlugin):
             labels=labels,
             cost=cost,
         )
-        return update(self.client, issue, issue_fields, status)
+        return update(client, issue, issue_fields, status)

--- a/src/dispatch/plugins/dispatch_slack/config.py
+++ b/src/dispatch/plugins/dispatch_slack/config.py
@@ -29,10 +29,6 @@ SLACK_COMMAND_LIST_PARTICIPANTS_SLUG = config(
 SLACK_COMMAND_ASSIGN_ROLE_SLUG = config(
     "SLACK_COMMAND_ASSIGN_ROLE_SLUG", default="/dispatch-assign-role"
 )
-# remove after slack deployment
-SLACK_COMMAND_UPDATE_INCIDENT_SLUG = config(
-    "SLACK_COMMAND_UPDATE_INCIDENT_SLUG", default="/dispatch-edit-incident"
-)
 SLACK_COMMAND_UPDATE_INCIDENT_SLUG = config(
     "SLACK_COMMAND_UPDATE_INCIDENT_SLUG", default="/dispatch-update-incident"
 )

--- a/src/dispatch/plugins/dispatch_slack/config.py
+++ b/src/dispatch/plugins/dispatch_slack/config.py
@@ -29,8 +29,12 @@ SLACK_COMMAND_LIST_PARTICIPANTS_SLUG = config(
 SLACK_COMMAND_ASSIGN_ROLE_SLUG = config(
     "SLACK_COMMAND_ASSIGN_ROLE_SLUG", default="/dispatch-assign-role"
 )
-SLACK_COMMAND_EDIT_INCIDENT_SLUG = config(
-    "SLACK_COMMAND_EDIT_INCIDENT_SLUG", default="/dispatch-edit-incident"
+# remove after slack deployment
+SLACK_COMMAND_UPDATE_INCIDENT_SLUG = config(
+    "SLACK_COMMAND_UPDATE_INCIDENT_SLUG", default="/dispatch-edit-incident"
+)
+SLACK_COMMAND_UPDATE_INCIDENT_SLUG = config(
+    "SLACK_COMMAND_UPDATE_INCIDENT_SLUG", default="/dispatch-update-incident"
 )
 SLACK_COMMAND_ENGAGE_ONCALL_SLUG = config(
     "SLACK_COMMAND_ENGAGE_ONCALL_SLUG", default="/dispatch-engage-oncall"

--- a/src/dispatch/plugins/dispatch_slack/messaging.py
+++ b/src/dispatch/plugins/dispatch_slack/messaging.py
@@ -17,7 +17,7 @@ from dispatch.messaging import (
 
 from .config import (
     SLACK_COMMAND_ASSIGN_ROLE_SLUG,
-    SLACK_COMMAND_EDIT_INCIDENT_SLUG,
+    SLACK_COMMAND_UPDATE_INCIDENT_SLUG,
     SLACK_COMMAND_ENGAGE_ONCALL_SLUG,
     SLACK_COMMAND_LIST_PARTICIPANTS_SLUG,
     SLACK_COMMAND_LIST_RESOURCES_SLUG,
@@ -65,9 +65,9 @@ INCIDENT_CONVERSATION_COMMAND_MESSAGE = {
         "response_type": "ephemeral",
         "text": "Opening a dialog to assign a role to a participant...",
     },
-    SLACK_COMMAND_EDIT_INCIDENT_SLUG: {
+    SLACK_COMMAND_UPDATE_INCIDENT_SLUG: {
         "response_type": "ephemeral",
-        "text": "Opening a dialog to edit incident information...",
+        "text": "Opening a dialog to update incident information...",
     },
     SLACK_COMMAND_ENGAGE_ONCALL_SLUG: {
         "response_type": "ephemeral",

--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -21,7 +21,7 @@ from dispatch.plugins.bases import ConversationPlugin, DocumentPlugin, ContactPl
 from .config import (
     SLACK_API_BOT_TOKEN,
     SLACK_COMMAND_ASSIGN_ROLE_SLUG,
-    SLACK_COMMAND_EDIT_INCIDENT_SLUG,
+    SLACK_COMMAND_UPDATE_INCIDENT_SLUG,
     SLACK_COMMAND_ENGAGE_ONCALL_SLUG,
     SLACK_COMMAND_LIST_PARTICIPANTS_SLUG,
     SLACK_COMMAND_LIST_RESOURCES_SLUG,
@@ -64,7 +64,7 @@ command_mappings = {
     ConversationCommands.list_tasks: SLACK_COMMAND_LIST_TASKS_SLUG,
     ConversationCommands.list_participants: SLACK_COMMAND_LIST_PARTICIPANTS_SLUG,
     ConversationCommands.assign_role: SLACK_COMMAND_ASSIGN_ROLE_SLUG,
-    ConversationCommands.edit_incident: SLACK_COMMAND_EDIT_INCIDENT_SLUG,
+    ConversationCommands.edit_incident: SLACK_COMMAND_UPDATE_INCIDENT_SLUG,
     ConversationCommands.engage_oncall: SLACK_COMMAND_ENGAGE_ONCALL_SLUG,
     ConversationCommands.list_resources: SLACK_COMMAND_LIST_RESOURCES_SLUG,
 }

--- a/src/dispatch/static/dispatch/src/incident/Table.vue
+++ b/src/dispatch/static/dispatch/src/incident/Table.vue
@@ -46,9 +46,7 @@
                 <v-icon small class="mr-2" @click="createEditShow(item)">edit</v-icon>
               </template>
               <template v-slot:item.created_at="{ item }">
-                {{
-                item.created_at | formatDate
-                }}
+                {{ item.reported_at | formatDate }}
               </template>
             </v-data-table>
           </v-card>
@@ -80,7 +78,7 @@ export default {
         { text: "Priority", value: "incident_priority.name", width: "10%" },
         { text: "Commander", value: "commander" },
         { text: "Reporter", value: "reporter" },
-        { text: "Created At", value: "created_at" },
+        { text: "Reported At", value: "reported_at" },
         { text: "Actions", value: "actions", sortable: false, align: "right", width: "5%" }
       ]
     }

--- a/src/dispatch/static/dispatch/src/incident/Table.vue
+++ b/src/dispatch/static/dispatch/src/incident/Table.vue
@@ -45,9 +45,7 @@
               <template v-slot:item.actions="{ item }">
                 <v-icon small class="mr-2" @click="createEditShow(item)">edit</v-icon>
               </template>
-              <template v-slot:item.created_at="{ item }">
-                {{ item.reported_at | formatDate }}
-              </template>
+              <template v-slot:item.reported_at="{ item }">{{ item.reported_at | formatDate }}</template>
             </v-data-table>
           </v-card>
         </v-flex>

--- a/src/dispatch/static/dispatch/src/incident/store.js
+++ b/src/dispatch/static/dispatch/src/incident/store.js
@@ -43,7 +43,7 @@ const state = {
       q: "",
       page: 1,
       itemsPerPage: 10,
-      sortBy: ["created_at"],
+      sortBy: ["reported_at"],
       descending: [true]
     },
     loading: false


### PR DESCRIPTION
When updating the stable_at field, we were always setting this field to be utcnow(), this first checks for an existing stable_at before setting the field. 