### PR TITLE
Update costs no matter the status.

### DIFF
--- a/src/dispatch/cli.py
+++ b/src/dispatch/cli.py
@@ -688,7 +688,7 @@ def revision_database(
 def dispatch_scheduler():
     """Container for all dispatch scheduler commands."""
     # we need scheduled tasks to be imported
-    from .incident.scheduled import daily_summary, active_incidents_cost  # noqa
+    from .incident.scheduled import daily_summary, calculate_incidents_cost  # noqa
     from .task.scheduled import sync_tasks, create_task_reminders  # noqa
     from .term.scheduled import sync_terms  # noqa
     from .document.scheduled import sync_document_terms  # noqa

--- a/src/dispatch/incident/scheduled.py
+++ b/src/dispatch/incident/scheduled.py
@@ -27,7 +27,12 @@ from dispatch.scheduler import scheduler
 from dispatch.service import service as service_service
 
 from .enums import IncidentStatus
-from .service import calculate_cost, get_all_by_status, get_all_last_x_hours_by_status
+from .service import (
+    calculate_cost,
+    get_all,
+    get_all_by_status,
+    get_all_last_x_hours_by_status,
+)
 
 # TODO figure out a way to do mapping in the config file
 # reminder (in hours)
@@ -218,14 +223,20 @@ def daily_summary(db_session=None):
 
 @scheduler.add(every(5).minutes, name="calculate-incident-cost")
 @background_task
-def active_incidents_cost(db_session=None):
-    """Calculates the cost of all active incidents."""
-    active_incidents = get_all_by_status(db_session=db_session, status=IncidentStatus.active)
+def incidents_cost(db_session=None):
+    """Calculates the cost of all incidents."""
 
-    for incident in active_incidents:
+    # we want to update all incidents, all the time
+    incidents = get_all(db_session=db_session)
+
+    for incident in incidents:
         # we calculate the cost
         try:
             incident_cost = calculate_cost(incident.id, db_session)
+
+            # if the cost hasn't changed don't continue
+            if incident.cost == incident_cost:
+                continue
 
             # we update the incident
             incident.cost = incident_cost

--- a/src/dispatch/incident/scheduled.py
+++ b/src/dispatch/incident/scheduled.py
@@ -221,9 +221,9 @@ def daily_summary(db_session=None):
         convo_plugin.send(c, "Incident Daily Summary", {}, "", blocks=blocks)
 
 
-@scheduler.add(every(5).minutes, name="calculate-incident-cost")
+@scheduler.add(every(5).minutes, name="calculate-incidents-cost")
 @background_task
-def incidents_cost(db_session=None):
+def calcuate_incidents_cost(db_session=None):
     """Calculates the cost of all incidents."""
 
     # we want to update all incidents, all the time

--- a/src/dispatch/incident/service.py
+++ b/src/dispatch/incident/service.py
@@ -5,7 +5,6 @@ from typing import List, Optional
 
 from dispatch.config import ANNUAL_COST_EMPLOYEE, BUSINESS_HOURS_YEAR
 from dispatch.database import SessionLocal
-from dispatch.individual import service as individual_service
 from dispatch.incident_priority import service as incident_priority_service
 from dispatch.incident_priority.models import IncidentPriorityType
 from dispatch.incident_type import service as incident_type_service


### PR DESCRIPTION
The actual query should be pretty cheap (on a five minute interval), but we make sure that we don't update external resources if the cost hasn't changed. 