### PR TITLE
Allows upgrade to create the database if it doesn't exist.

### DIFF
--- a/src/dispatch/cli.py
+++ b/src/dispatch/cli.py
@@ -8,7 +8,6 @@ from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
 from tabulate import tabulate
 from uvicorn import main as uvicorn_main
-from sqlalchemy_utils import create_database, database_exists, drop_database
 
 from dispatch import __version__, config
 from dispatch.application.models import *  # noqa
@@ -588,6 +587,8 @@ def drop_database():
 @click.option("--revision", nargs=1, default="head", help="Revision identifier.")
 def upgrade_database(tag, sql, revision):
     """Upgrades database schema to newest version."""
+    from sqlalchemy_utils import database_exists, create_database
+
     alembic_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "alembic.ini")
     alembic_cfg = AlembicConfig(alembic_path)
     if not database_exists(str(config.SQLALCHEMY_DATABASE_URI)):


### PR DESCRIPTION
We want to allow simple in-place upgrades, running the `database upgrade` command will get the database up to date even if it doesn't yet exist.