### PR TITLE
Fix dump database to use DATABASE_NAME from config

### DIFF
--- a/src/dispatch/cli.py
+++ b/src/dispatch/cli.py
@@ -540,7 +540,7 @@ def restore_database():
 def dump_database():
     """Dumps the database via pg_dump."""
     from sh import pg_dump
-    from dispatch.config import DATABASE_HOSTNAME, DATABASE_PORT, DATABASE_CREDENTIALS
+    from dispatch.config import DATABASE_HOSTNAME, DATABASE_NAME, DATABASE_PORT, DATABASE_CREDENTIALS
 
     username, password = str(DATABASE_CREDENTIALS).split(":")
 
@@ -553,7 +553,7 @@ def dump_database():
         DATABASE_PORT,
         "-U",
         username,
-        "dispatch",
+        DATABASE_NAME,
         _env={"PGPASSWORD": password},
     )
 


### PR DESCRIPTION
This small patch fixes the database dump command to use the configured DATABASE_NAME instead of the hard coded `dispatch` name.

