### PR TITLE
skip db creation in init if already exist

### DIFF
--- a/src/dispatch/cli.py
+++ b/src/dispatch/cli.py
@@ -489,9 +489,10 @@ def database_trigger_sync():
 @dispatch_database.command("init")
 def init_database():
     """Initializes a new database."""
-    from sqlalchemy_utils import create_database
+    from sqlalchemy_utils import create_database, database_exists
 
-    create_database(str(config.SQLALCHEMY_DATABASE_URI))
+    if not database_exists(str(config.SQLALCHEMY_DATABASE_URI)):
+        create_database(str(config.SQLALCHEMY_DATABASE_URI))
     Base.metadata.create_all(engine)
     alembic_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "alembic.ini")
     alembic_cfg = AlembicConfig(alembic_path)


### PR DESCRIPTION
I'm experimenting with dispatch for internal use at [work](https://www.platform.sh). We want to be able to deploy it in our own infrastructure and I ran into an issue during db initialization. The `dispatch database initi` code assumes the user has permissions to create/delete databases. In a PaaS like Platform.sh, you already start with an existing database and the user doesn't have permission to create new ones. Only to create/delete tables. This patch makes database init work during deployment in such case. Do you think this is the right thing to do? If you would prefer another direction, please let me know. I can further describe the use case as well.

Any feedback much appreciated! Thanks for the work on this.