### PR TITLE
Fixed 'pkce_auth' always set to 'true', ignoring env var 'VUE_APP_DISPATCH_PKCE_AUTH'

### DIFF
--- a/src/dispatch/static/dispatch/src/router/index.js
+++ b/src/dispatch/static/dispatch/src/router/index.js
@@ -22,7 +22,7 @@ import store from "@/store"
 const requestor = new FetchRequestor()
 const routes = publicRoute.concat(protectedRoute)
 
-const pkce_auth = env.getBool(process.env.VUE_APP_DISPATCH_PKCE_AUTH) || true
+const pkce_auth = env.getBool(process.env.VUE_APP_DISPATCH_PKCE_AUTH) !== false;  //default to true
 const clientId = process.env.VUE_APP_DISPATCH_CLIENT_ID
 const openIdConnectUrl = process.env.VUE_APP_DISPATCH_OPEN_ID_CONNECT_URL
 const scope = "openid profile email"


### PR DESCRIPTION
Closes #144.