### PR TITLE
Update login redirect to session storage uri and add VS Code debug fo…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,14 @@
       "type": "python",
       "request": "launch",
       "program": "${workspaceFolder}/src/dispatch/run.py"
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Front End Debug",
+      "url": "http://localhost:8080",
+      "webRoot": "${workspaceFolder}/src/dispatch/static/dispatch",
+      "breakOnLoad": true
     }
   ]
 }


### PR DESCRIPTION
Auth providers such as Okta do not allow a wildcard `redirect_uri` in the application setup so they enforce each route be whitelisted.  This I think is in accordance with the Oauth2.0 RFC. 

Because of this, this PR creates a single path to be whitelisted `/implicit/callback`.

On auth redirect, the frontend stores the `redirect_uri` in the session storage, tells the auth provider the `redirect_uri` is `/implicit/callback` and after being returned from the auth provider, retrieves the `redirect_uri` from session storage, deletes it, and redirects to it.

This also adds a sample frontend debug setup for VS Code in `launch.json`