### PR TITLE
Adds ability to restrict access to and sharing of content in the incident drive

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -136,6 +136,10 @@ By default, the config will be read from environment variables and/or `.env` fil
 
 > Controls the folder where to archive incident information.
 
+#### `INCIDENT_STORAGE_RESTRICTED` \[default: 'True'\]
+
+> Controls whether a set of restrictions and capabilities to prevent content sharing need to be applied.
+
 #### `INCIDENT_NOTIFICATION_CONVERSATIONS` \[default: ''\]
 
 > Comma separated list of conversations \(e.g. Slack channels\) to be notified of new incidents.

--- a/src/dispatch/config.py
+++ b/src/dispatch/config.py
@@ -45,7 +45,9 @@ except Exception:
             def __init__(self, value: str):
                 self._value = value
                 self._decrypted_value = (
-                    boto3.client('kms').decrypt(CiphertextBlob=base64.b64decode(value))['Plaintext'].decode("utf-8")
+                    boto3.client("kms")
+                    .decrypt(CiphertextBlob=base64.b64decode(value))["Plaintext"]
+                    .decode("utf-8")
                 )
 
             def __repr__(self) -> str:
@@ -54,6 +56,7 @@ except Exception:
 
             def __str__(self) -> str:
                 return self._decrypted_value
+
     except Exception:
         from starlette.datastructures import Secret
 
@@ -144,6 +147,7 @@ INCIDENT_DOCUMENT_INVESTIGATION_SHEET_ID = config("INCIDENT_DOCUMENT_INVESTIGATI
 INCIDENT_FAQ_DOCUMENT_ID = config("INCIDENT_FAQ_DOCUMENT_ID")
 INCIDENT_STORAGE_ARCHIVAL_FOLDER_ID = config("INCIDENT_STORAGE_ARCHIVAL_FOLDER_ID")
 INCIDENT_STORAGE_INCIDENT_REVIEW_FILE_ID = config("INCIDENT_STORAGE_INCIDENT_REVIEW_FILE_ID")
+INCIDENT_STORAGE_RESTRICTED = config("INCIDENT_STORAGE_RESTRICTED", default=True)
 
 INCIDENT_NOTIFICATION_CONVERSATIONS = config(
     "INCIDENT_NOTIFICATION_CONVERSATIONS", cast=CommaSeparatedStrings, default=""

--- a/src/dispatch/incident/flows.py
+++ b/src/dispatch/incident/flows.py
@@ -33,6 +33,7 @@ from dispatch.config import (
     INCIDENT_RESOURCE_TACTICAL_GROUP,
     INCIDENT_STORAGE_ARCHIVAL_FOLDER_ID,
     INCIDENT_STORAGE_INCIDENT_REVIEW_FILE_ID,
+    INCIDENT_STORAGE_RESTRICTED,
 )
 from dispatch.conversation import service as conversation_service
 from dispatch.conversation.models import ConversationCreate
@@ -205,6 +206,11 @@ def create_incident_storage(name: str, participant_group_emails: List[str]):
     p = plugins.get(INCIDENT_PLUGIN_STORAGE_SLUG)
     storage = p.create(name, participant_group_emails)
     storage.update({"resource_type": INCIDENT_PLUGIN_STORAGE_SLUG, "resource_id": storage["id"]})
+
+    if INCIDENT_STORAGE_RESTRICTED:
+        p.restrict(storage["resource_id"])
+        log.debug("The storage drive has been restricted.")
+
     return storage
 
 

--- a/src/dispatch/incident/flows.py
+++ b/src/dispatch/incident/flows.py
@@ -209,7 +209,7 @@ def create_incident_storage(name: str, participant_group_emails: List[str]):
 
     if INCIDENT_STORAGE_RESTRICTED:
         p.restrict(storage["resource_id"])
-        log.debug("The storage drive has been restricted.")
+        log.debug("The incident storage has been restricted.")
 
     return storage
 

--- a/src/dispatch/plugins/dispatch_google/drive/drive.py
+++ b/src/dispatch/plugins/dispatch_google/drive/drive.py
@@ -193,9 +193,27 @@ def create_team_drive(client: Any, name: str, members: List[str], role: Roles):
     return drive_data
 
 
+@retry(stop=stop_after_attempt(5), retry=retry_if_exception_type(TryAgain))
+def restrict_team_drive(client: Any, team_drive_id: str):
+    """Applies a set of restrictions and capabilities to the shared drive."""
+    body = {
+        "restrictions": {
+            "domainUsersOnly": True,
+            "driveMembersOnly": True,
+            "copyRequiresWriterPermission": True,
+        },
+        "capabilities": {
+            "canChangeDomainUsersOnlyRestriction": False,
+            "canChangeDriveMembersOnlyRestriction": False,
+            "canChangeCopyRequiresWriterPermissionRestriction": False,
+            "canShare": False,
+        },
+    }
+    return make_call(client.drives(), "update", driveId=team_drive_id, body=body)
+
+
 def create_file(client: Any, parent_id: str, name: str, file_type: str = "folder"):
     """Creates a new folder with the specified parents."""
-
     if file_type == "folder":
         mimetype = "application/vnd.google-apps.folder"
 

--- a/src/dispatch/plugins/dispatch_google/drive/drive.py
+++ b/src/dispatch/plugins/dispatch_google/drive/drive.py
@@ -193,7 +193,6 @@ def create_team_drive(client: Any, name: str, members: List[str], role: Roles):
     return drive_data
 
 
-@retry(stop=stop_after_attempt(5), retry=retry_if_exception_type(TryAgain))
 def restrict_team_drive(client: Any, team_drive_id: str):
     """Applies a set of restrictions and capabilities to the shared drive."""
     body = {

--- a/src/dispatch/plugins/dispatch_google/drive/plugin.py
+++ b/src/dispatch/plugins/dispatch_google/drive/plugin.py
@@ -15,6 +15,7 @@ from dispatch.plugins.dispatch_google.common import get_service
 from .drive import (
     Roles,
     add_permission,
+    archive_team_drive,
     copy_file,
     create_file,
     create_team_drive,
@@ -25,7 +26,7 @@ from .drive import (
     list_team_drives,
     move_file,
     remove_permission,
-    archive_team_drive,
+    restrict_team_drive,
 )
 from .task import list_tasks
 
@@ -124,6 +125,12 @@ class GoogleDriveStoragePlugin(StoragePlugin):
         """Lists all files in team drive."""
         client = get_service("drive", "v3", self.scopes)
         return list_files(client, team_drive_id, q)
+
+    def restrict(self, team_drive_id: str):
+        """Applies a set of restrictions and capabilities to the team drive."""
+        client = get_service("drive", "v3", self.scopes)
+        response = restrict_team_drive(client, team_drive_id)
+        return response
 
 
 class GoogleDriveTaskPlugin(TaskPlugin):


### PR DESCRIPTION
* This PR introduces a new configuration variable called `INCIDENT_STORAGE_RESTRICTED`, which controls whether a set of restrictions and capabilities to prevent content sharing need to be applied on the incident storage.
* This variable is set to `True` by default. You can disable it by setting `INCIDENT_STORAGE_RESTRICTED` to `False` in your `.env` file.

<img width="639" alt="Screen Shot 2020-03-25 at 2 13 05 PM" src="https://user-images.githubusercontent.com/39573146/77587154-9911e480-6ea4-11ea-8bd7-abaa463b34b3.png">
