### PR TITLE
Allowing some heavy weight metric libraries to be opt-in.

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -7,7 +7,6 @@ click
 email-validator
 emails
 fastapi
-# fbprophet
 google-api-python-client
 google-auth-oauthlib
 httpx
@@ -18,7 +17,6 @@ oauth2client
 psycopg2-binary
 pyparsing
 pypd  # pagerduty plugin
-# pystan==2.18  # NOTE newer versions require C++14
 python-dateutil
 python-jose
 python-multipart

--- a/requirements-metrics.txt
+++ b/requirements-metrics.txt
@@ -1,0 +1,3 @@
+numpy
+pystan
+fbprophet

--- a/setup.py
+++ b/setup.py
@@ -345,6 +345,7 @@ def get_requirements(env):
 
 install_requires = get_requirements("base")
 dev_requires = get_requirements("dev")
+metrics_requires = get_requirements("metrics")
 
 
 class DispatchSDistCommand(SDistCommand):
@@ -396,7 +397,7 @@ setup(
     packages=find_packages("src"),
     python_requires=">=3.7",
     install_requires=install_requires,
-    extras_require={"dev": dev_requires},
+    extras_require={"dev": dev_requires, "metrics": metrics_requires},
     cmdclass=cmdclass,
     zip_save=False,
     include_package_data=True,


### PR DESCRIPTION
This allows our heavy weight metric dependencies to be optionally installed via `pip install -e .[metrics]`