### PR TITLE
Bugfix. Variables w/multiple definitions.

### DIFF
--- a/src/dispatch/common/utils/cli.py
+++ b/src/dispatch/common/utils/cli.py
@@ -41,8 +41,6 @@ def install_plugins():
         except KeyError as e:
             logger.warning(f"Failed to load plugin {ep.name}. Reason: {e}")
         except Exception:
-            import traceback
-
             logger.error(f"Failed to load plugin {ep.name}:{traceback.format_exc()}")
         else:
             register(plugin)

--- a/src/dispatch/messaging.py
+++ b/src/dispatch/messaging.py
@@ -50,12 +50,6 @@ INCIDENT_STATUS_DESCRIPTIONS = {
     IncidentStatus.closed: "This no longer requires additional involvement, long term incident action items have been assigned to their respective owners.",
 }
 
-INCIDENT_STATUS_REPORT_DESCRIPTION = """
-This is an incident status update.
-""".replace(
-    "\n", " "
-).strip()
-
 INCIDENT_TASK_REMINDER_DESCRIPTION = """
 You are assigned to the following incident tasks.
 This is a reminder that these tasks have *passed* their due date.

--- a/src/dispatch/plugins/dispatch_pagerduty/service.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/service.py
@@ -46,7 +46,7 @@ def get_oncall(service_id: str = None, service_name: str = None):
 
         return get_oncall_email(service[0])
 
-    DispatchPluginException(f"Cannot fetch oncall. Must specify service_id or service_name.")
+    raise DispatchPluginException(f"Cannot fetch oncall. Must specify service_id or service_name.")
 
 
 def page_oncall(

--- a/src/dispatch/service/models.py
+++ b/src/dispatch/service/models.py
@@ -53,7 +53,6 @@ class Service(TimeStampMixin, Base):
     type = Column(String, default="pagerduty-oncall")
     external_id = Column(String)
     incidents = relationship("Incident", secondary=assoc_service_incidents, backref="services")
-    incident_types = relationship("IncidentType")
     incident_priorities = relationship(
         "IncidentPriority", secondary=assoc_service_incident_priorities, backref="services"
     )


### PR DESCRIPTION
Found some minor bugs with LGTM.

Fixed 2 of the three `multiple variable definition`:
https://lgtm.com/projects/g/Netflix/dispatch/alerts/?mode=tree&ruleFocus=1800095&id=py%2Fmultiple-definition

Removed a redundant import:
https://lgtm.com/projects/g/Netflix/dispatch/alerts/?mode=tree&id=py%2Frepeated-import&ruleFocus=7890086

`dispatch_pagerduty/service.py` forgot the `raise` keyword before instantiating a `DispatchPluginException` object:
https://lgtm.com/projects/g/Netflix/dispatch/alerts/?mode=tree&id=py%2Funused-exception-object&ruleFocus=1505923886371