### PR TITLE
Feature/incident table filter

### DIFF
--- a/src/dispatch/static/dispatch/src/incident/IncidentStatusMultiSelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/IncidentStatusMultiSelect.vue
@@ -1,0 +1,49 @@
+<template>
+  <v-select
+    v-model="incidentStatuses"
+    :items="items"
+    :menu-props="{ maxHeight: '400' }"
+    :label="label"
+    multiple
+    clearable
+    chips
+  />
+</template>
+
+<script>
+import _ from "lodash"
+export default {
+  name: "IncidentStatusMultiSelect",
+  props: {
+    value: {
+      priority: Array,
+      default: function() {
+        return []
+      }
+    },
+    label: {
+      priority: String,
+      default: function() {
+        return "Statuses"
+      }
+    }
+  },
+
+  data() {
+    return {
+      items: ["Active", "Stable", "Closed"]
+    }
+  },
+
+  computed: {
+    incidentStatuses: {
+      get() {
+        return _.cloneDeep(this.value)
+      },
+      set(value) {
+        this.$emit("input", value)
+      }
+    }
+  }
+}
+</script>

--- a/src/dispatch/static/dispatch/src/incident/Table.vue
+++ b/src/dispatch/static/dispatch/src/incident/Table.vue
@@ -4,7 +4,47 @@
     <!--<delete-dialog />-->
     <div class="headline">Incidents</div>
     <v-spacer />
-    <v-btn color="primary" dark class="mb-2" @click="createEditShow()">New</v-btn>
+    <v-btn color="primary" dark @click="createEditShow()">New</v-btn>
+    <v-menu v-model="filterMenu" :close-on-content-click="false" :nudge-width="300" offset-y>
+      <template v-slot:activator="{ on }">
+        <v-btn class="ml-2" color="secondary" dark v-on="on">Filters</v-btn>
+      </template>
+
+      <v-card>
+        <v-list>
+          <v-list-item>
+            <v-list-item-content>
+              <individual-combobox v-model="filters.commanders" label="Commanders"></individual-combobox>
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-content>
+              <individual-combobox v-model="filters.reporters" label="Reporters"></individual-combobox>
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-content>
+              <incident-type-combobox v-model="filters.incidentTypes"></incident-type-combobox>
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-content>
+              <v-list-item-title class="font-weight-bold">Status</v-list-item-title>
+              <div class="aligh-center">
+                <v-checkbox v-model="filters.status" label="Active" value="Active"></v-checkbox>
+                <v-checkbox v-model="filters.status" label="Stable" value="Stable"></v-checkbox>
+                <v-checkbox v-model="filters.status" label="Closed" value="Closed"></v-checkbox>
+              </div>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn text @click="filterMenu = false">Cancel</v-btn>
+          <v-btn color="primary" text @click="menu = false">Save</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-menu>
     <v-flex xs12>
       <v-layout column>
         <v-flex>
@@ -62,15 +102,20 @@ import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 // import DeleteDialog from "@/incident/DeleteDialog.vue"
 import NewEditSheet from "@/incident/NewEditSheet.vue"
+import IndividualCombobox from "@/individual/IndividualCombobox.vue"
+import IncidentTypeCombobox from "@/incident_type/IncidentTypeCombobox.vue"
 export default {
   name: "IncidentTable",
 
   components: {
     // DeleteDialog
-    NewEditSheet
+    NewEditSheet,
+    IndividualCombobox,
+    IncidentTypeCombobox
   },
   data() {
     return {
+      filterMenu: false,
       headers: [
         { text: "Id", value: "name", align: "left", width: "10%" },
         { text: "Title", value: "title", sortable: false },
@@ -93,6 +138,7 @@ export default {
       "table.options.page",
       "table.options.itemsPerPage",
       "table.options.sortBy",
+      "table.options.filters",
       "table.options.descending",
       "table.loading",
       "table.rows.items",

--- a/src/dispatch/static/dispatch/src/incident/Table.vue
+++ b/src/dispatch/static/dispatch/src/incident/Table.vue
@@ -7,42 +7,39 @@
     <v-btn color="primary" dark @click="createEditShow()">New</v-btn>
     <v-menu v-model="filterMenu" :close-on-content-click="false" :nudge-width="300" offset-y>
       <template v-slot:activator="{ on }">
-        <v-btn class="ml-2" color="secondary" dark v-on="on">Filters</v-btn>
+        <v-badge :value="numFilters" bordered overlap :content="numFilters">
+          <v-btn class="ml-2" color="secondary" dark v-on="on">Filters</v-btn>
+        </v-badge>
       </template>
 
       <v-card>
         <v-list>
           <v-list-item>
             <v-list-item-content>
-              <individual-combobox v-model="filters.commanders" label="Commanders"></individual-combobox>
+              <individual-combobox v-model="commanders" label="Commanders"></individual-combobox>
             </v-list-item-content>
           </v-list-item>
           <v-list-item>
             <v-list-item-content>
-              <individual-combobox v-model="filters.reporters" label="Reporters"></individual-combobox>
+              <individual-combobox v-model="reporters" label="Reporters"></individual-combobox>
             </v-list-item-content>
           </v-list-item>
           <v-list-item>
             <v-list-item-content>
-              <incident-type-combobox v-model="filters.incidentTypes"></incident-type-combobox>
+              <incident-type-combobox v-model="incidentTypes" />
             </v-list-item-content>
           </v-list-item>
           <v-list-item>
             <v-list-item-content>
-              <v-list-item-title class="font-weight-bold">Status</v-list-item-title>
-              <div class="aligh-center">
-                <v-checkbox v-model="filters.status" label="Active" value="Active"></v-checkbox>
-                <v-checkbox v-model="filters.status" label="Stable" value="Stable"></v-checkbox>
-                <v-checkbox v-model="filters.status" label="Closed" value="Closed"></v-checkbox>
-              </div>
+              <incident-priority-combobox v-model="incidentPriorities" />
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item>
+            <v-list-item-content>
+              <incident-status-multi-select v-model="incidentStatuses" />
             </v-list-item-content>
           </v-list-item>
         </v-list>
-        <v-card-actions>
-          <v-spacer></v-spacer>
-          <v-btn text @click="filterMenu = false">Cancel</v-btn>
-          <v-btn color="primary" text @click="menu = false">Save</v-btn>
-        </v-card-actions>
       </v-card>
     </v-menu>
     <v-flex xs12>
@@ -98,12 +95,16 @@
 </template>
 
 <script>
+import _ from "lodash"
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 // import DeleteDialog from "@/incident/DeleteDialog.vue"
 import NewEditSheet from "@/incident/NewEditSheet.vue"
+import IncidentStatusMultiSelect from "@/incident/IncidentStatusMultiSelect.vue"
 import IndividualCombobox from "@/individual/IndividualCombobox.vue"
 import IncidentTypeCombobox from "@/incident_type/IncidentTypeCombobox.vue"
+import IncidentPriorityCombobox from "@/incident_priority/IncidentPriorityCombobox.vue"
+
 export default {
   name: "IncidentTable",
 
@@ -111,7 +112,9 @@ export default {
     // DeleteDialog
     NewEditSheet,
     IndividualCombobox,
-    IncidentTypeCombobox
+    IncidentTypeCombobox,
+    IncidentPriorityCombobox,
+    IncidentStatusMultiSelect
   },
   data() {
     return {
@@ -138,12 +141,25 @@ export default {
       "table.options.page",
       "table.options.itemsPerPage",
       "table.options.sortBy",
-      "table.options.filters",
+      "table.options.filters.commanders",
+      "table.options.filters.reporters",
+      "table.options.filters.incidentTypes",
+      "table.options.filters.incidentPriorities",
+      "table.options.filters.incidentStatuses",
       "table.options.descending",
       "table.loading",
       "table.rows.items",
       "table.rows.total"
-    ])
+    ]),
+    numFilters: function() {
+      return _.sum([
+        this.reporters.length,
+        this.commanders.length,
+        this.incidentTypes.length,
+        this.incidentPriorities.length,
+        this.incidentStatuses.length
+      ])
+    }
   },
 
   mounted() {

--- a/src/dispatch/static/dispatch/src/incident/Table.vue
+++ b/src/dispatch/static/dispatch/src/incident/Table.vue
@@ -4,44 +4,48 @@
     <!--<delete-dialog />-->
     <div class="headline">Incidents</div>
     <v-spacer />
-    <v-btn color="primary" dark @click="createEditShow()">New</v-btn>
-    <v-menu v-model="filterMenu" :close-on-content-click="false" :nudge-width="300" offset-y>
+    <v-dialog v-model="filterDialog" max-width="600px">
       <template v-slot:activator="{ on }">
         <v-badge :value="numFilters" bordered overlap :content="numFilters">
-          <v-btn class="ml-2" color="secondary" dark v-on="on">Filters</v-btn>
+          <v-btn color="secondary" dark v-on="on">Filter Columns</v-btn>
         </v-badge>
       </template>
-
       <v-card>
-        <v-list>
+        <v-card-title>
+          <span class="headline">Column Filters</span>
+        </v-card-title>
+        <v-list dense>
+          <!--
           <v-list-item>
             <v-list-item-content>
-              <individual-combobox v-model="commanders" label="Commanders"></individual-combobox>
+              <individual-combobox v-model="commander" label="Commanders"></individual-combobox>
             </v-list-item-content>
           </v-list-item>
           <v-list-item>
             <v-list-item-content>
-              <individual-combobox v-model="reporters" label="Reporters"></individual-combobox>
+              <individual-combobox v-model="reporter" label="Reporters"></individual-combobox>
+            </v-list-item-content>
+          </v-list-item>
+          -->
+          <v-list-item>
+            <v-list-item-content>
+              <incident-type-combobox v-model="incident_type" />
             </v-list-item-content>
           </v-list-item>
           <v-list-item>
             <v-list-item-content>
-              <incident-type-combobox v-model="incidentTypes" />
+              <incident-priority-combobox v-model="incident_priority" />
             </v-list-item-content>
           </v-list-item>
           <v-list-item>
             <v-list-item-content>
-              <incident-priority-combobox v-model="incidentPriorities" />
-            </v-list-item-content>
-          </v-list-item>
-          <v-list-item>
-            <v-list-item-content>
-              <incident-status-multi-select v-model="incidentStatuses" />
+              <incident-status-multi-select v-model="status" />
             </v-list-item-content>
           </v-list-item>
         </v-list>
       </v-card>
-    </v-menu>
+    </v-dialog>
+    <v-btn color="primary" class="ml-2" dark @click="createEditShow()">New</v-btn>
     <v-flex xs12>
       <v-layout column>
         <v-flex>
@@ -101,7 +105,7 @@ import { mapActions } from "vuex"
 // import DeleteDialog from "@/incident/DeleteDialog.vue"
 import NewEditSheet from "@/incident/NewEditSheet.vue"
 import IncidentStatusMultiSelect from "@/incident/IncidentStatusMultiSelect.vue"
-import IndividualCombobox from "@/individual/IndividualCombobox.vue"
+// import IndividualCombobox from "@/individual/IndividualCombobox.vue"
 import IncidentTypeCombobox from "@/incident_type/IncidentTypeCombobox.vue"
 import IncidentPriorityCombobox from "@/incident_priority/IncidentPriorityCombobox.vue"
 
@@ -111,14 +115,14 @@ export default {
   components: {
     // DeleteDialog
     NewEditSheet,
-    IndividualCombobox,
+    // IndividualCombobox,
     IncidentTypeCombobox,
     IncidentPriorityCombobox,
     IncidentStatusMultiSelect
   },
   data() {
     return {
-      filterMenu: false,
+      filterDialog: false,
       headers: [
         { text: "Id", value: "name", align: "left", width: "10%" },
         { text: "Title", value: "title", sortable: false },
@@ -141,11 +145,11 @@ export default {
       "table.options.page",
       "table.options.itemsPerPage",
       "table.options.sortBy",
-      "table.options.filters.commanders",
-      "table.options.filters.reporters",
-      "table.options.filters.incidentTypes",
-      "table.options.filters.incidentPriorities",
-      "table.options.filters.incidentStatuses",
+      "table.options.filters.commander",
+      "table.options.filters.reporter",
+      "table.options.filters.incident_type",
+      "table.options.filters.incident_priority",
+      "table.options.filters.status",
       "table.options.descending",
       "table.loading",
       "table.rows.items",
@@ -153,11 +157,11 @@ export default {
     ]),
     numFilters: function() {
       return _.sum([
-        this.reporters.length,
-        this.commanders.length,
-        this.incidentTypes.length,
-        this.incidentPriorities.length,
-        this.incidentStatuses.length
+        this.reporter.length,
+        this.commander.length,
+        this.incident_type.length,
+        this.incident_priority.length,
+        this.status.length
       ])
     }
   },
@@ -166,7 +170,18 @@ export default {
     this.getAll({})
 
     this.$watch(
-      vm => [vm.q, vm.page, vm.itemsPerPage, vm.sortBy, vm.descending],
+      vm => [
+        vm.q,
+        vm.page,
+        vm.itemsPerPage,
+        vm.sortBy,
+        vm.descending,
+        vm.commander,
+        vm.reporter,
+        vm.incident_type,
+        vm.incident_priority,
+        vm.status
+      ],
       () => {
         this.getAll()
       }

--- a/src/dispatch/static/dispatch/src/incident/store.js
+++ b/src/dispatch/static/dispatch/src/incident/store.js
@@ -47,7 +47,8 @@ const state = {
         reporters: [],
         commanders: [],
         incidentTypes: [],
-        status: []
+        incidentPriorities: [],
+        incidentStatuses: []
       },
       q: "",
       page: 1,

--- a/src/dispatch/static/dispatch/src/incident/store.js
+++ b/src/dispatch/static/dispatch/src/incident/store.js
@@ -92,7 +92,6 @@ const actions = {
         tableOptions.ops.push("==")
       })
     })
-    console.log(tableOptions)
     return IncidentApi.getAll(tableOptions).then(response => {
       commit("SET_TABLE_LOADING", false)
       commit("SET_TABLE_ROWS", response.data)

--- a/src/dispatch/static/dispatch/src/incident/store.js
+++ b/src/dispatch/static/dispatch/src/incident/store.js
@@ -43,6 +43,12 @@ const state = {
       total: null
     },
     options: {
+      filters: {
+        reporters: [],
+        commanders: [],
+        incidentTypes: [],
+        status: []
+      },
       q: "",
       page: 1,
       itemsPerPage: 10,

--- a/src/dispatch/static/dispatch/src/incident_type/IncidentTypeCombobox.vue
+++ b/src/dispatch/static/dispatch/src/incident_type/IncidentTypeCombobox.vue
@@ -10,6 +10,7 @@
     multiple
     chips
     close
+    clearable
     :loading="loading"
     @update:search-input="fetchData({ q: $event })"
   >
@@ -18,7 +19,8 @@
         <v-list-item-content>
           <v-list-item-title>
             No Incident Types matching "
-            <strong>{{ search }}</strong>".
+            <strong>{{ search }}</strong
+            >".
           </v-list-item-title>
         </v-list-item-content>
       </v-list-item>

--- a/src/dispatch/static/dispatch/src/incident_type/IncidentTypeCombobox.vue
+++ b/src/dispatch/static/dispatch/src/incident_type/IncidentTypeCombobox.vue
@@ -1,0 +1,95 @@
+<template>
+  <v-combobox
+    v-model="incidentType"
+    :items="items"
+    item-text="name"
+    :search-input.sync="search"
+    :menu-props="{ maxHeight: '400' }"
+    hide-selected
+    :label="label"
+    multiple
+    chips
+    close
+    :loading="loading"
+    @update:search-input="fetchData({ q: $event })"
+  >
+    <template v-slot:no-data>
+      <v-list-item>
+        <v-list-item-content>
+          <v-list-item-title>
+            No Incident Types matching "
+            <strong>{{ search }}</strong>".
+          </v-list-item-title>
+        </v-list-item-content>
+      </v-list-item>
+    </template>
+  </v-combobox>
+</template>
+
+<script>
+import IncidentTypeApi from "@/incident_type/api"
+import _ from "lodash"
+export default {
+  name: "IncidentTypeComboBox",
+  props: {
+    value: {
+      type: Array,
+      default: function() {
+        return []
+      }
+    },
+    label: {
+      type: String,
+      default: function() {
+        return "Incident Types"
+      }
+    }
+  },
+
+  data() {
+    return {
+      loading: false,
+      items: [],
+      search: null
+    }
+  },
+
+  computed: {
+    incidentType: {
+      get() {
+        return _.cloneDeep(this.value)
+      },
+      set(value) {
+        this._incidentTypes = value.map(v => {
+          if (typeof v === "string") {
+            v = {
+              name: v
+            }
+            this.items.push(v)
+          }
+          return v
+        })
+        this.$emit("input", this._incidentTypes)
+      }
+    }
+  },
+
+  created() {
+    this.fetchData({})
+  },
+
+  methods: {
+    fetchData(filterOptions) {
+      this.error = null
+      this.loading = true
+      IncidentTypeApi.getAll(filterOptions).then(response => {
+        this.items = response.data.items
+        this.loading = false
+      })
+    },
+    getFilteredData: _.debounce(function(options) {
+      this.fetchData(options)
+    }, 500)
+  }
+}
+</script>

--- a/src/dispatch/static/dispatch/src/individual/IndividualCombobox.vue
+++ b/src/dispatch/static/dispatch/src/individual/IndividualCombobox.vue
@@ -1,0 +1,95 @@
+<template>
+  <v-combobox
+    v-model="individual"
+    :items="items"
+    item-text="name"
+    :search-input.sync="search"
+    :menu-props="{ maxHeight: '400' }"
+    hide-selected
+    :label="label"
+    multiple
+    close
+    chips
+    :loading="loading"
+    @update:search-input="fetchData({ q: $event })"
+  >
+    <template v-slot:no-data>
+      <v-list-item>
+        <v-list-item-content>
+          <v-list-item-title>
+            No Indivduals matching "
+            <strong>{{ search }}</strong>".
+          </v-list-item-title>
+        </v-list-item-content>
+      </v-list-item>
+    </template>
+  </v-combobox>
+</template>
+
+<script>
+import IndividualApi from "@/individual/api"
+import _ from "lodash"
+export default {
+  name: "IndividualComboBox",
+  props: {
+    value: {
+      type: Array,
+      default: function() {
+        return []
+      }
+    },
+    label: {
+      type: String,
+      default: function() {
+        return "Individual"
+      }
+    }
+  },
+
+  data() {
+    return {
+      loading: false,
+      items: [],
+      search: null
+    }
+  },
+
+  computed: {
+    individual: {
+      get() {
+        return _.cloneDeep(this.value)
+      },
+      set(value) {
+        this._individuals = value.map(v => {
+          if (typeof v === "string") {
+            v = {
+              name: v
+            }
+            this.items.push(v)
+          }
+          return v
+        })
+        this.$emit("input", this._individuals)
+      }
+    }
+  },
+
+  created() {
+    this.fetchData({})
+  },
+
+  methods: {
+    fetchData(filterOptions) {
+      this.error = null
+      this.loading = true
+      IndividualApi.getAll(filterOptions).then(response => {
+        this.items = response.data.items
+        this.loading = false
+      })
+    },
+    getFilteredData: _.debounce(function(options) {
+      this.fetchData(options)
+    }, 500)
+  }
+}
+</script>

--- a/src/dispatch/static/dispatch/src/individual/IndividualCombobox.vue
+++ b/src/dispatch/static/dispatch/src/individual/IndividualCombobox.vue
@@ -10,6 +10,7 @@
     multiple
     close
     chips
+    clearable
     :loading="loading"
     @update:search-input="fetchData({ q: $event })"
   >
@@ -18,7 +19,8 @@
         <v-list-item-content>
           <v-list-item-title>
             No Indivduals matching "
-            <strong>{{ search }}</strong>".
+            <strong>{{ search }}</strong
+            >".
           </v-list-item-title>
         </v-list-item-content>
       </v-list-item>


### PR DESCRIPTION
Adds basic filtering for the incident table. If this approach works well, we can likely expand to the other tables and add filtering there as well. 

This approach should work with filtering the `command` and `reporter` fields as well as soon as an underlying library supports hybrid properties. See: juliotrigo/sqlalchemy-filters#32

For other filters (e.g. visibility, cost, reported, etc.) these can be incrementally added as needed.

![2020-04-08_14-52_1](https://user-images.githubusercontent.com/2262214/78837487-0a738c00-79a9-11ea-8e58-2907324fbb0f.png)
![2020-04-08_14-52](https://user-images.githubusercontent.com/2262214/78837490-0b0c2280-79a9-11ea-85f3-67d450295a1b.png)
