### PR TITLE
Ensuring we are enforcing require fields.

### DIFF
--- a/src/dispatch/static/dispatch/src/definition/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/definition/NewEditSheet.vue
@@ -3,12 +3,8 @@
     <template v-slot:prepend>
       <v-list-item two-line>
         <v-list-item-content>
-          <v-list-item-title v-if="id" class="title">
-            Edit
-          </v-list-item-title>
-          <v-list-item-title v-else class="title">
-            New
-          </v-list-item-title>
+          <v-list-item-title v-if="id" class="title">Edit</v-list-item-title>
+          <v-list-item-title v-else class="title">New</v-list-item-title>
           <v-list-item-subtitle>Definition</v-list-item-subtitle>
         </v-list-item-content>
       </v-list-item>
@@ -41,17 +37,13 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn color="secondary" @click="closeCreateEdit()">
-            Cancel
-          </v-btn>
+          <v-btn color="secondary" @click="closeCreateEdit()">Cancel</v-btn>
           <v-btn
             color="primary"
             :loading="loading"
             :disabled="invalid || !validated"
             @click="save()"
-          >
-            Save
-          </v-btn>
+          >Save</v-btn>
         </v-card-actions>
       </v-card>
     </ValidationObserver>
@@ -62,7 +54,14 @@
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import { ValidationObserver, ValidationProvider } from "vee-validate"
+import { required } from "vee-validate/dist/rules"
 import TermCombobox from "@/term/TermCombobox.vue"
+
+extend("required", {
+  ...required,
+  message: "This field is required"
+})
+
 export default {
   name: "DefinitionNewEditSheet",
 

--- a/src/dispatch/static/dispatch/src/document/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/document/NewEditSheet.vue
@@ -109,8 +109,7 @@
             :loading="loading"
             :disabled="invalid || !validated"
             @click="save()"
-            >Save</v-btn
-          >
+          >Save</v-btn>
         </v-card-actions>
       </v-card>
     </ValidationObserver>
@@ -121,9 +120,16 @@
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import { ValidationObserver, ValidationProvider } from "vee-validate"
+import { required } from "vee-validate/dist/rules"
 import IncidentPriorityMultiSelect from "@/incident_priority/IncidentPriorityMultiSelect.vue"
 import IncidentTypeMultiSelect from "@/incident_type/IncidentTypeMultiSelect.vue"
 import TermCombobox from "@/term/TermCombobox.vue"
+
+extend("required", {
+  ...required,
+  message: "This field is required"
+})
+
 export default {
   name: "DocumentNewEditSheet",
 

--- a/src/dispatch/static/dispatch/src/incident/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/incident/NewEditSheet.vue
@@ -144,8 +144,7 @@
             :loading="loading"
             :disabled="invalid || !validated"
             @click="save()"
-            >Save</v-btn
-          >
+          >Save</v-btn>
         </v-card-actions>
       </v-card>
     </ValidationObserver>
@@ -156,6 +155,7 @@
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import { ValidationObserver, ValidationProvider } from "vee-validate"
+import { required } from "vee-validate/dist/rules"
 import IncidentPrioritySelect from "@/incident_priority/IncidentPrioritySelect.vue"
 import IncidentTypeSelect from "@/incident_type/IncidentTypeSelect.vue"
 import IndividualSelect from "@/individual/IndividualSelect.vue"
@@ -163,6 +163,11 @@ import DatePickerMenu from "@/components/DatePickerMenu.vue"
 import TimePickerMenu from "@/components/TimePickerMenu.vue"
 import TermCombobox from "@/term/TermCombobox.vue"
 import TagCombobox from "@/tag/TagCombobox.vue"
+
+extend("required", {
+  ...required,
+  message: "This field is required"
+})
 
 export default {
   name: "IncidentNewEditSheet",

--- a/src/dispatch/static/dispatch/src/incident/ReportForm.vue
+++ b/src/dispatch/static/dispatch/src/incident/ReportForm.vue
@@ -181,9 +181,7 @@
             </v-list>
             <v-container grid-list-md>
               <v-flex xs12>
-                <v-btn color="primary" depressed @click="resetSelected()">
-                  Report another incident
-                </v-btn>
+                <v-btn color="primary" depressed @click="resetSelected()">Report another incident</v-btn>
               </v-flex>
             </v-container>
           </v-card-text>
@@ -243,8 +241,7 @@
                     :loading="loading"
                     :disabled="invalid || !validated"
                     @click="save()"
-                    >Submit</v-btn
-                  >
+                  >Submit</v-btn>
                 </v-container>
               </v-form>
             </v-card-text>
@@ -266,8 +263,14 @@
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import { ValidationObserver, ValidationProvider } from "vee-validate"
+import { required } from "vee-validate/dist/rules"
 import IncidentTypeSelect from "@/incident_type/IncidentTypeSelect.vue"
 import IncidentPrioritySelect from "@/incident_priority/IncidentPrioritySelect.vue"
+
+extend("required", {
+  ...required,
+  message: "This field is required"
+})
 
 // import IncidentMembersCombobox from "@/incident/IncidentMembersCombobox.vue"
 export default {

--- a/src/dispatch/static/dispatch/src/incident_priority/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/incident_priority/NewEditSheet.vue
@@ -94,8 +94,7 @@
             :loading="loading"
             :disabled="invalid || !validated"
             @click="save()"
-            >Save</v-btn
-          >
+          >Save</v-btn>
         </v-card-actions>
       </v-card>
     </ValidationObserver>
@@ -106,6 +105,12 @@
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import { ValidationObserver, ValidationProvider } from "vee-validate"
+import { required } from "vee-validate/dist/rules"
+
+extend("required", {
+  ...required,
+  message: "This field is required"
+})
 
 export default {
   name: "IncidentPriorityNewEditSheet",

--- a/src/dispatch/static/dispatch/src/incident_type/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/incident_type/NewEditSheet.vue
@@ -72,8 +72,7 @@
             :loading="loading"
             :disabled="invalid || !validated"
             @click="save()"
-            >Save</v-btn
-          >
+          >Save</v-btn>
         </v-card-actions>
       </v-card>
     </ValidationObserver>
@@ -84,8 +83,14 @@
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import { ValidationObserver, ValidationProvider } from "vee-validate"
+import { required } from "vee-validate/dist/rules"
 import ServiceSelect from "@/service/ServiceSelect.vue"
 import DocumentSelect from "@/document/DocumentSelect.vue"
+
+extend("required", {
+  ...required,
+  message: "This field is required"
+})
 
 export default {
   name: "IncidentTypeNewEditSheet",

--- a/src/dispatch/static/dispatch/src/individual/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/individual/NewEditSheet.vue
@@ -3,12 +3,8 @@
     <template v-slot:prepend>
       <v-list-item two-line>
         <v-list-item-content>
-          <v-list-item-title v-if="id" class="title">
-            Edit
-          </v-list-item-title>
-          <v-list-item-title v-else class="title">
-            New
-          </v-list-item-title>
+          <v-list-item-title v-if="id" class="title">Edit</v-list-item-title>
+          <v-list-item-title v-else class="title">New</v-list-item-title>
           <v-list-item-subtitle>Individual</v-list-item-subtitle>
         </v-list-item-content>
       </v-list-item>
@@ -81,17 +77,13 @@
 
         <v-card-actions>
           <v-spacer />
-          <v-btn color="secondary" @click="closeCreateEdit()">
-            Cancel
-          </v-btn>
+          <v-btn color="secondary" @click="closeCreateEdit()">Cancel</v-btn>
           <v-btn
             color="primary"
             :loading="loading"
             :disabled="invalid || !validated"
             @click="save()"
-          >
-            Save
-          </v-btn>
+          >Save</v-btn>
         </v-card-actions>
       </v-card>
     </ValidationObserver>
@@ -102,9 +94,16 @@
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import { ValidationObserver, ValidationProvider } from "vee-validate"
+import { required } from "vee-validate/dist/rules"
 import IncidentPriorityMultiSelect from "@/incident_priority/IncidentPriorityMultiSelect.vue"
 import IncidentTypeMultiSelect from "@/incident_type/IncidentTypeMultiSelect.vue"
 import TermCombobox from "@/term/TermCombobox.vue"
+
+extend("required", {
+  ...required,
+  message: "This field is required"
+})
+
 export default {
   name: "IndividualNewEditSheet",
 

--- a/src/dispatch/static/dispatch/src/service/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/service/NewEditSheet.vue
@@ -88,8 +88,7 @@ rules="required" immediate>
             :loading="loading"
             :disabled="invalid || !validated"
             @click="save()"
-            >Save</v-btn
-          >
+          >Save</v-btn>
         </v-card-actions>
       </v-card>
     </ValidationObserver>
@@ -100,9 +99,16 @@ rules="required" immediate>
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import { ValidationObserver, ValidationProvider } from "vee-validate"
+import { required } from "vee-validate/dist/rules"
 import IncidentPriorityMultiSelect from "@/incident_priority/IncidentPriorityMultiSelect.vue"
 import IncidentTypeMultiSelect from "@/incident_type/IncidentTypeMultiSelect.vue"
 import TermCombobox from "@/term/TermCombobox.vue"
+
+extend("required", {
+  ...required,
+  message: "This field is required"
+})
+
 export default {
   name: "ServiceNewEditSheet",
 

--- a/src/dispatch/static/dispatch/src/tag/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/tag/NewEditSheet.vue
@@ -98,8 +98,7 @@
             :loading="loading"
             :disabled="invalid || !validated"
             @click="save()"
-            >Save</v-btn
-          >
+          >Save</v-btn>
         </v-card-actions>
       </v-card>
     </ValidationObserver>
@@ -110,6 +109,13 @@
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import { ValidationObserver, ValidationProvider } from "vee-validate"
+import { required } from "vee-validate/dist/rules"
+
+extend("required", {
+  ...required,
+  message: "This field is required"
+})
+
 export default {
   name: "TagNewEditSheet",
 

--- a/src/dispatch/static/dispatch/src/task/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/task/NewEditSheet.vue
@@ -43,8 +43,7 @@
             :disabled="invalid || !validated"
             :loading="loading"
             @click="save()"
-            >Save</v-btn
-          >
+          >Save</v-btn>
         </v-card-actions>
       </v-card>
     </ValidationObserver>
@@ -55,7 +54,14 @@
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import { ValidationObserver, ValidationProvider } from "vee-validate"
+import { required } from "vee-validate/dist/rules"
 import DefinitionCombobox from "@/definition/DefinitionCombobox.vue"
+
+extend("required", {
+  ...required,
+  message: "This field is required"
+})
+
 export default {
   name: "TaskNewEditSheet",
 

--- a/src/dispatch/static/dispatch/src/team/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/team/NewEditSheet.vue
@@ -3,12 +3,8 @@
     <template v-slot:prepend>
       <v-list-item two-line>
         <v-list-item-content>
-          <v-list-item-title v-if="id" class="title">
-            Edit
-          </v-list-item-title>
-          <v-list-item-title v-else class="title">
-            New
-          </v-list-item-title>
+          <v-list-item-title v-if="id" class="title">Edit</v-list-item-title>
+          <v-list-item-title v-else class="title">New</v-list-item-title>
           <v-list-item-subtitle>Service</v-list-item-subtitle>
         </v-list-item-content>
       </v-list-item>
@@ -81,17 +77,13 @@
 
         <v-card-actions>
           <v-spacer />
-          <v-btn color="secondary" @click="closeCreateEdit()">
-            Cancel
-          </v-btn>
+          <v-btn color="secondary" @click="closeCreateEdit()">Cancel</v-btn>
           <v-btn
             color="primary"
             :loading="loading"
             :disabled="invalid || !validated"
             @click="save()"
-          >
-            Save
-          </v-btn>
+          >Save</v-btn>
         </v-card-actions>
       </v-card>
     </ValidationObserver>
@@ -102,9 +94,16 @@
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import { ValidationObserver, ValidationProvider } from "vee-validate"
+import { required } from "vee-validate/dist/rules"
 import IncidentPriorityMultiSelect from "@/incident_priority/IncidentPriorityMultiSelect.vue"
 import IncidentTypeMultiSelect from "@/incident_type/IncidentTypeMultiSelect.vue"
 import TermCombobox from "@/term/TermCombobox.vue"
+
+extend("required", {
+  ...required,
+  message: "This field is required"
+})
+
 export default {
   name: "ServiceNewEditSheet",
 

--- a/src/dispatch/static/dispatch/src/term/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/term/NewEditSheet.vue
@@ -3,12 +3,8 @@
     <template v-slot:prepend>
       <v-list-item two-line>
         <v-list-item-content>
-          <v-list-item-title v-if="id" class="title">
-            Edit
-          </v-list-item-title>
-          <v-list-item-title v-else class="title">
-            New
-          </v-list-item-title>
+          <v-list-item-title v-if="id" class="title">Edit</v-list-item-title>
+          <v-list-item-title v-else class="title">New</v-list-item-title>
           <v-list-item-subtitle>Term</v-list-item-subtitle>
         </v-list-item-content>
       </v-list-item>
@@ -41,17 +37,13 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer />
-          <v-btn color="secondary" @click="closeCreateEdit()">
-            Cancel
-          </v-btn>
+          <v-btn color="secondary" @click="closeCreateEdit()">Cancel</v-btn>
           <v-btn
             color="primary"
             :disabled="invalid || !validated"
             :loading="loading"
             @click="save()"
-          >
-            Save
-          </v-btn>
+          >Save</v-btn>
         </v-card-actions>
       </v-card>
     </ValidationObserver>
@@ -62,7 +54,14 @@
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import { ValidationObserver, ValidationProvider } from "vee-validate"
+import { required } from "vee-validate/dist/rules"
 import DefinitionCombobox from "@/definition/DefinitionCombobox.vue"
+
+extend("required", {
+  ...required,
+  message: "This field is required"
+})
+
 export default {
   name: "TermNewEditSheet",
 


### PR DESCRIPTION
With the update to veevalidate 3.x we need to explicitly import our validation rules (including `required`).

See: 
https://logaretm.github.io/vee-validate/#usage