### PR TITLE
Fixed empty enabled column in table 'plugin'

### DIFF
--- a/src/dispatch/plugins/base/manager.py
+++ b/src/dispatch/plugins/base/manager.py
@@ -76,7 +76,7 @@ class PluginManager(InstanceManager):
                 required=cls.required,
                 multiple=cls.multiple,
                 description=cls.description,
-                enabled=getattr(cls, "enabled", False)
+                enabled=cls.enabled
             )
             db_session.add(plugin)
         else:

--- a/src/dispatch/plugins/base/manager.py
+++ b/src/dispatch/plugins/base/manager.py
@@ -76,6 +76,7 @@ class PluginManager(InstanceManager):
                 required=cls.required,
                 multiple=cls.multiple,
                 description=cls.description,
+                enabled=getattr(cls, "enabled", False)
             )
             db_session.add(plugin)
         else:


### PR DESCRIPTION
Encountering pydantic errors when trying access plugin page as enabled column is empty. This PR assures that enabled column will always have a value.