### PR TITLE
fix typo in setup.py option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -399,7 +399,7 @@ setup(
     install_requires=install_requires,
     extras_require={"dev": dev_requires, "metrics": metrics_requires},
     cmdclass=cmdclass,
-    zip_save=False,
+    zip_safe=False,
     include_package_data=True,
     entry_points={
         "console_scripts": ["dispatch = dispatch.cli:entrypoint"],


### PR DESCRIPTION
This was causing errors for setup tools, looks like it was a missed typo since the option is `zip_safe`.

`/usr/local/lib/python3.8/distutils/dist.py:274: UserWarning: Unknown distribution option: 'zip_save'
  warnings.warn(msg)
`