### PR TITLE
Bugfix router login redirect

### DIFF
--- a/src/dispatch/plugins/base/manager.py
+++ b/src/dispatch/plugins/base/manager.py
@@ -76,7 +76,7 @@ class PluginManager(InstanceManager):
                 required=cls.required,
                 multiple=cls.multiple,
                 description=cls.description,
-                enabled=getattr(cls, "enabled", False)
+                enabled=cls.enabled
             )
             db_session.add(plugin)
         else:

--- a/src/dispatch/plugins/base/manager.py
+++ b/src/dispatch/plugins/base/manager.py
@@ -76,6 +76,7 @@ class PluginManager(InstanceManager):
                 required=cls.required,
                 multiple=cls.multiple,
                 description=cls.description,
+                enabled=getattr(cls, "enabled", False)
             )
             db_session.add(plugin)
         else:

--- a/src/dispatch/static/dispatch/src/router/index.js
+++ b/src/dispatch/static/dispatch/src/router/index.js
@@ -141,7 +141,10 @@ function loginBasic(to, from, next) {
     // prevent redirect loop
     if (to.path !== "/login") {
       next("/login")
+      return
     }
+    // if no criteria is matched the user should continue on
+    next()
   }
 }
 


### PR DESCRIPTION
Currently if auth provider is set to dispatch-auth-provider-basic if the requestor is not authenticated, the requestor will remain hanging trying to access /login page.

e.g 
User is unauthorized gets redirect to "/login" from L143 after this the hook on routerBefore will be called again but this time the path.to is "/login" thus the router will actually have no resolve at all, and next() is never called. 