### PR TITLE
Add PKCE overrides and support the key rotation

### DIFF
--- a/docs/configuration/app.md
+++ b/docs/configuration/app.md
@@ -83,6 +83,14 @@ Today, basic authentication allows self registration without approval.
 
 > Used by the basic auth provider to mint JWT tokens and set their expiration.
 
+#### `DISPATCH_JWT_AUDIENCE`
+
+> Override what the `Audience` is expected to be in the PKCE JWT decode
+
+#### `DISPATCH_JWT_EMAIL_OVERRIDE`
+
+> Override where Dispatch should find the user email in the idtoken.
+
 #### `DISPATCH_AUTHENTICATION_DEFAULT_USER` \['default': dispatch@example.com\]
 
 > Used as the default anonymous user when authentication is disabled.

--- a/src/dispatch/plugins/dispatch_core/config.py
+++ b/src/dispatch/plugins/dispatch_core/config.py
@@ -1,6 +1,20 @@
+import logging
+
 from starlette.config import Config
+
+
+log = logging.getLogger(__name__)
+
 
 config = Config(".env")
 
-DISPATCH_JWT_AUDIENCE = config("DISPATCH_JWT_AUDIENCE")
-DISPATCH_JWT_EMAIL_OVERRIDE = config("DISPATCH_JWT_EMAIL_OVERRIDE")
+
+DISPATCH_JWT_AUDIENCE = config("DISPATCH_JWT_AUDIENCE", default=None)
+DISPATCH_JWT_EMAIL_OVERRIDE = config("DISPATCH_JWT_EMAIL_OVERRIDE", default=None)
+
+
+if config.get("DISPATCH_AUTHENTICATION_PROVIDER_SLUG") == "dispatch-auth-provider-pkce":
+    if not DISPATCH_JWT_AUDIENCE:
+        log.warn("No JWT Audience specified. This is required for IdPs like Okta")
+    if not DISPATCH_JWT_EMAIL_OVERRIDE:
+        log.warn("No JWT Email Override specified. 'email' is expected in the idtoken.")

--- a/src/dispatch/plugins/dispatch_core/config.py
+++ b/src/dispatch/plugins/dispatch_core/config.py
@@ -1,3 +1,6 @@
 from starlette.config import Config
 
 config = Config(".env")
+
+DISPATCH_JWT_AUDIENCE = config("DISPATCH_JWT_AUDIENCE")
+DISPATCH_JWT_EMAIL_OVERRIDE = config("DISPATCH_JWT_EMAIL_OVERRIDE")


### PR DESCRIPTION
Adds the ability to include an audience in `jwt.decode` as well as not rely on email address to be in `email` key of the JWT.  This also adds the support for key rotation when the IDP sends back more than one key in the key fetch.