### PR TITLE
Add author and author URL to zoom plugin to fix plugins page

### DIFF
--- a/src/dispatch/plugins/dispatch_zoom/plugin.py
+++ b/src/dispatch/plugins/dispatch_zoom/plugin.py
@@ -58,6 +58,9 @@ class ZoomConferencePlugin(ConferencePlugin):
     description = "Uses Zoom to manage conference meetings."
     version = zoom_plugin.__version__
 
+    author = "HashiCorp"
+    author_url = "https://github.com/netflix/dispatch.git"
+
     def create(
         self, name: str, description: str = None, title: str = None, participants: List[str] = []
     ):


### PR DESCRIPTION
Add `author` and `author_url` to the zoom plugin to fix the plugins page. Without this it fails with 

```
response -> items -> 0 -> author
  none is not an allowed value (type=type_error.none.not_allowed)
response -> items -> 0 -> author_url
  none is not an allowed value (type=type_error.none.not_allowed)
```