### PR TITLE
switch gpg keyserver due to missing keys, fix syntax error in dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,18 +36,17 @@ RUN for key in \
     A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
     B9E2F5981AA6E0CD28160D9FF13993A75599653C \
     ; do \
-    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key"; \
+    gpg --batch --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys "$key"; \
     done
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.12
 RUN set -x \
-    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"
+    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
-    && export GNUPGHOME="$(mktemp -d)" \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 
 # grab tini for signal processing and zombie killing


### PR DESCRIPTION
Fix a syntax issue in the Dockerfile, switch to sks-pools for the keyserver as several keys were missing from keys.openpgp.org (including the one for `gosu`)

Removed the bits messing with `$GPUGPHOME` since it didn't seem necessary and none of the other steps did anything similar.

Closes #340 