### PR TITLE
Cast Secret to string for Slack bot tokens

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -87,7 +87,7 @@ class SlackConversationPlugin(ConversationPlugin):
     author_url = "https://github.com/netflix/dispatch.git"
 
     def __init__(self):
-        self.client = slack.WebClient(token=SLACK_API_BOT_TOKEN)
+        self.client = slack.WebClient(token=str(SLACK_API_BOT_TOKEN))
 
     def create(self, name: str, participants: List[dict], is_private: bool = True):
         """Creates a new slack conversation."""
@@ -198,7 +198,7 @@ class SlackContactPlugin(ContactPlugin):
     author_url = "https://github.com/netflix/dispatch.git"
 
     def __init__(self):
-        self.client = slack.WebClient(token=SLACK_API_BOT_TOKEN)
+        self.client = slack.WebClient(token=str(SLACK_API_BOT_TOKEN))
 
     def get(self, email: str, **kwargs):
         """Fetch user info by email."""
@@ -231,7 +231,7 @@ class SlackDocumentPlugin(DocumentPlugin):
     def __init__(self):
         self.cachedir = os.path.dirname(os.path.realpath(__file__))
         self.memory = Memory(cachedir=self.cachedir, verbose=0)
-        self.client = slack.WebClient(token=SLACK_API_BOT_TOKEN)
+        self.client = slack.WebClient(token=str(SLACK_API_BOT_TOKEN))
 
     def get(self, **kwargs) -> dict:
         """Queries slack for documents."""

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -26,7 +26,7 @@ class NoConversationFoundException(Exception):
 
 def create_slack_client(run_async: bool = False):
     """Creates a Slack Web API client."""
-    return slack.WebClient(token=SLACK_API_BOT_TOKEN, run_async=run_async)
+    return slack.WebClient(token=str(SLACK_API_BOT_TOKEN), run_async=run_async)
 
 
 def contains_numbers(string):


### PR DESCRIPTION
`slackclient` requires tokens to be strings, but they're currently `Secret`s.  `__str__()` seems to be implemented on `Secret` to return the value itself (or decrypted value if using some sort of KMS), so we should be able to just cast these at usage-time.

Stacktrace that current `develop` emits:
```
ERROR:dispatch.common.utils.cli:Failed to load plugin slack_contact:Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/dispatch/common/utils/cli.py", line 34, in install_plugins
    plugin = ep.load()
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2453, in load
    return self.resolve()
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2459, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.8/site-packages/dispatch/plugins/dispatch_slack/plugin.py", line 37, in <module>
    from .views import router as slack_event_router
  File "/usr/local/lib/python3.8/site-packages/dispatch/plugins/dispatch_slack/views.py", line 74, in <module>
    slack_client = dispatch_slack_service.create_slack_client()
  File "/usr/local/lib/python3.8/site-packages/dispatch/plugins/dispatch_slack/service.py", line 29, in create_slack_client
    return slack.WebClient(token=SLACK_API_BOT_TOKEN, run_async=run_async)
  File "/usr/local/lib/python3.8/site-packages/slack/web/base_client.py", line 50, in __init__
    self.token = None if token is None else token.strip()
AttributeError: 'Secret' object has no attribute 'strip'

ERROR:dispatch.common.utils.cli:Failed to load plugin slack_conversation:Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/dispatch/common/utils/cli.py", line 34, in install_plugins
    plugin = ep.load()
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2453, in load
    return self.resolve()
  File "/usr/local/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2459, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.8/site-packages/dispatch/plugins/dispatch_slack/plugin.py", line 37, in <module>
    from .views import router as slack_event_router
  File "/usr/local/lib/python3.8/site-packages/dispatch/plugins/dispatch_slack/views.py", line 74, in <module>
    slack_client = dispatch_slack_service.create_slack_client()
  File "/usr/local/lib/python3.8/site-packages/dispatch/plugins/dispatch_slack/service.py", line 29, in create_slack_client
    return slack.WebClient(token=SLACK_API_BOT_TOKEN, run_async=run_async)
  File "/usr/local/lib/python3.8/site-packages/slack/web/base_client.py", line 50, in __init__
    self.token = None if token is None else token.strip()
AttributeError: 'Secret' object has no attribute 'strip'
```