### PR TITLE
Checks Slack profile fields for None before accessing them

### DIFF
--- a/src/dispatch/individual/service.py
+++ b/src/dispatch/individual/service.py
@@ -47,8 +47,8 @@ def get_or_create(*, db_session, email: str, **kwargs) -> IndividualContact:
         contact_plugin = plugin_service.get_active(db_session=db_session, plugin_type="contact")
         individual_info = contact_plugin.instance.get(email, db_session=db_session)
         kwargs["email"] = individual_info.get("email", email)
-        kwargs["name"] = individual_info.get("fullname", "unknown")
-        kwargs["weblink"] = individual_info.get("weblink", "unknown")
+        kwargs["name"] = individual_info.get("fullname", "Unknown")
+        kwargs["weblink"] = individual_info.get("weblink", "Unknown")
         individual_contact_in = IndividualContactCreate(**kwargs)
         contact = create(db_session=db_session, individual_contact_in=individual_contact_in)
 

--- a/src/dispatch/participant/service.py
+++ b/src/dispatch/participant/service.py
@@ -99,9 +99,9 @@ def get_or_create(
         individual_info = contact_plugin.instance.get(
             individual_contact.email, db_session=db_session
         )
-        location = individual_info.get("location", "unknown")
-        team = individual_info.get("team", "unknown")
-        department = individual_info.get("department", "unknown")
+        location = individual_info.get("location", "Unknown")
+        team = individual_info.get("team", "Unknown")
+        department = individual_info.get("department", "Unknown")
         participant_in = ParticipantCreate(
             participant_roles=participant_roles, team=team, department=department, location=location
         )

--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -198,14 +198,16 @@ class SlackContactPlugin(ContactPlugin):
 
     def get(self, email: str, **kwargs):
         """Fetch user info by email."""
-        team = department = weblink = ""
+        team = department = weblink = "Unknown"
 
         profile = get_user_profile_by_email(self.client, email)
         profile_fields = profile.get("fields")
         if profile_fields:
-            team = profile_fields.get(SLACK_PROFILE_TEAM_FIELD_ID, {}).get("value", "")
-            department = profile_fields.get(SLACK_PROFILE_DEPARTMENT_FIELD_ID, {}).get("value", "")
-            weblink = profile_fields.get(SLACK_PROFILE_WEBLINK_FIELD_ID, {}).get("value", "")
+            team = profile_fields.get(SLACK_PROFILE_TEAM_FIELD_ID, {}).get("value", "Unknown")
+            department = profile_fields.get(SLACK_PROFILE_DEPARTMENT_FIELD_ID, {}).get(
+                "value", "Unknown"
+            )
+            weblink = profile_fields.get(SLACK_PROFILE_WEBLINK_FIELD_ID, {}).get("value", "Unknown")
 
         return {
             "fullname": profile["real_name"],

--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -198,20 +198,23 @@ class SlackContactPlugin(ContactPlugin):
 
     def get(self, email: str, **kwargs):
         """Fetch user info by email."""
+        team = department = weblink = ""
+
         profile = get_user_profile_by_email(self.client, email)
+        profile_fields = profile.get("fields")
+        if profile_fields:
+            team = profile_fields.get(SLACK_PROFILE_TEAM_FIELD_ID, {}).get("value", "")
+            department = profile_fields.get(SLACK_PROFILE_DEPARTMENT_FIELD_ID, {}).get("value", "")
+            weblink = profile_fields.get(SLACK_PROFILE_WEBLINK_FIELD_ID, {}).get("value", "")
 
         return {
             "fullname": profile["real_name"],
             "email": profile["email"],
             "title": profile["title"],
-            "team": profile.get("fields", {}).get(SLACK_PROFILE_TEAM_FIELD_ID, {}).get("value", ""),
-            "department": profile.get("fields", {})
-            .get(SLACK_PROFILE_DEPARTMENT_FIELD_ID, {})
-            .get("value", ""),
+            "team": team,
+            "department": department,
             "location": profile["tz"],
-            "weblink": profile.get("fields", {})
-            .get(SLACK_PROFILE_WEBLINK_FIELD_ID, {})
-            .get("value", ""),
+            "weblink": weblink,
             "thumbnail": profile["image_512"],
         }
 


### PR DESCRIPTION
This PR fixes a `NoneType` exception when Slack fields are `None`.