### PR TITLE
Adds last executive report to active incidents status page

### DIFF
--- a/src/dispatch/static/dispatch/src/incident/Status.vue
+++ b/src/dispatch/static/dispatch/src/incident/Status.vue
@@ -64,6 +64,25 @@
                         </v-card>
                       </v-col>
                     </v-row>
+                    <v-row dense>
+                      <v-col cols="12">
+                        <v-card outlined>
+                          <v-card-text>
+                            <div class="title text--primary">Last Executive Report</div>
+                            <div v-if="item.last_executive_report">
+                              <p>As of {{ item.last_executive_report.created_at | formatDate }}</p>
+                              <p class="subtitle-1 text--primary">Current Status</p>
+                              <div>{{ item.last_executive_report.details.current_status }}</div>
+                              <p class="subtitle-1 text--primary">Overview</p>
+                              <div>{{ item.last_executive_report.details.overview }}</div>
+                              <p class="subtitle-1 text--primary">Next Steps</p>
+                              <div>{{ item.last_executive_report.details.next_steps }}</div>
+                            </div>
+                            <div v-else>No executive report available.</div>
+                          </v-card-text>
+                        </v-card>
+                      </v-col>
+                    </v-row>
                   </v-container>
                 </td>
               </template>


### PR DESCRIPTION
<img width="943" alt="Screen Shot 2020-06-01 at 2 48 20 PM" src="https://user-images.githubusercontent.com/39573146/83458248-0a2ac680-a417-11ea-893b-3b357c42e9b3.png">
