### PR TITLE
Updates list of required Slack bot scopes

### DIFF
--- a/docs/configuration/plugins/configuring-slack.md
+++ b/docs/configuration/plugins/configuring-slack.md
@@ -138,9 +138,10 @@ reactions:write
 reminders:write
 remote_files:read
 team:read
+users.profile.get
+users.profile:read
 users:read
 users:read.email
-users.profile:read
 users:write
 ```
 


### PR DESCRIPTION
Adds `users.profile.get` to the list of required scopes. This scope is required if you're using the Dispatch Slack contact plugin.