### PR TITLE
Dockerfile bugfix: Add backslash on line 52

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN for key in \
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.12
 RUN set -x \
-    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"
+    && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
     && gpg2 --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \


### PR DESCRIPTION
newline wasn't escaped on line 52, causing parse error for line 53