### PR TITLE
Fixing Slack properties

### DIFF
--- a/docs/configuration/plugins/configuring-slack.md
+++ b/docs/configuration/plugins/configuring-slack.md
@@ -148,7 +148,6 @@ remote_files:read
 team:read
 users:read
 users:read.email
-users.profile:read
 users:write
 ```
 
@@ -158,5 +157,6 @@ users:write
 channels:read
 groups:history
 groups:read
+users.profile:read
 ```
 


### PR DESCRIPTION
There is not 'users.profile:read' in the Bot Token Scopes.