### PR TITLE
Protects the incident notifications from failures in participant mess…

### DIFF
--- a/src/dispatch/incident/messaging.py
+++ b/src/dispatch/incident/messaging.py
@@ -242,9 +242,9 @@ def send_incident_status_notifications(incident: Incident, db_session: SessionLo
         )
 
     # we send status notifications to distribution lists
-    # email_plugin = plugins.get(INCIDENT_PLUGIN_EMAIL_SLUG)
-    # for distro in INCIDENT_NOTIFICATION_DISTRIBUTION_LISTS:
-    #   email_plugin.send(distro, message_template, notification_type, **message_kwargs)
+    email_plugin = plugins.get(INCIDENT_PLUGIN_EMAIL_SLUG)
+    for distro in INCIDENT_NOTIFICATION_DISTRIBUTION_LISTS:
+        email_plugin.send(distro, message_template, notification_type, **message_kwargs)
 
     log.debug("Incident status notifications sent.")
 

--- a/src/dispatch/incident/messaging.py
+++ b/src/dispatch/incident/messaging.py
@@ -242,9 +242,9 @@ def send_incident_status_notifications(incident: Incident, db_session: SessionLo
         )
 
     # we send status notifications to distribution lists
-    email_plugin = plugins.get(INCIDENT_PLUGIN_EMAIL_SLUG)
-    for distro in INCIDENT_NOTIFICATION_DISTRIBUTION_LISTS:
-        email_plugin.send(distro, message_template, notification_type, **message_kwargs)
+    # email_plugin = plugins.get(INCIDENT_PLUGIN_EMAIL_SLUG)
+    # for distro in INCIDENT_NOTIFICATION_DISTRIBUTION_LISTS:
+    #   email_plugin.send(distro, message_template, notification_type, **message_kwargs)
 
     log.debug("Incident status notifications sent.")
 


### PR DESCRIPTION
…ages.

I believe we are getting errors from `send_incident_suggested_reading_messages` for _some_ incidents, this protects us from those failures (and gives us better logging to work on a fix). It also moves the general notifications higher in the flow. 