### PR TITLE
Initial work on allowing tasks to be resolve by dispatch.

### DIFF
--- a/src/dispatch/conversation/enums.py
+++ b/src/dispatch/conversation/enums.py
@@ -15,3 +15,4 @@ class ConversationCommands(str, Enum):
 
 class ConversationButtonActions(str, Enum):
     invite_user = "invite-user"
+    update_task_status = "update-task-status"

--- a/src/dispatch/plugins/dispatch_google/drive/drive.py
+++ b/src/dispatch/plugins/dispatch_google/drive/drive.py
@@ -228,6 +228,21 @@ def list_comments(client: Any, file_id: str, **kwargs):
     return make_call(client.comments(), "list", fileId=file_id, fields="*", **kwargs)
 
 
+def add_reply(
+    client: Any, file_id: str, comment_id: str, content: str, resolved: bool = False, **kwargs
+):
+    """Adds a reply to a comment."""
+    if resolved:
+        verb = "resolve"
+        content = content if content else "Resolved by Dispatch"
+    else:
+        verb = "reopen"
+        content = content if content else "Reopened by Dispatch"
+
+    body = {"content": content, "verb": verb}
+    return make_call(client.replies(), "insert", fieldId=file_id, commentId=comment_id, body=body)
+
+
 def copy_file(client: Any, folder_id: str, file_id: str, new_file_name: str):
     """Copies a given file."""
     return make_call(

--- a/src/dispatch/plugins/dispatch_google/drive/drive.py
+++ b/src/dispatch/plugins/dispatch_google/drive/drive.py
@@ -233,14 +233,16 @@ def add_reply(
 ):
     """Adds a reply to a comment."""
     if resolved:
-        verb = "resolve"
+        action = "resolve"
         content = content if content else "Resolved by Dispatch"
     else:
-        verb = "reopen"
+        action = "reopen"
         content = content if content else "Reopened by Dispatch"
 
-    body = {"content": content, "verb": verb}
-    return make_call(client.replies(), "insert", fieldId=file_id, commentId=comment_id, body=body)
+    body = {"content": content, "action": action}
+    return make_call(
+        client.replies(), "create", fileId=file_id, commentId=comment_id, fields="id", body=body
+    )
 
 
 def copy_file(client: Any, folder_id: str, file_id: str, new_file_name: str):

--- a/src/dispatch/plugins/dispatch_google/drive/plugin.py
+++ b/src/dispatch/plugins/dispatch_google/drive/plugin.py
@@ -17,6 +17,7 @@ from .drive import (
     move_file,
     remove_permission,
     add_domain_permission,
+    add_reply,
 )
 from .task import list_tasks
 
@@ -124,9 +125,10 @@ class GoogleDriveTaskPlugin(TaskPlugin):
         """Creates a new task."""
         pass
 
-    def update(self, file_id: str, task_id):
+    def update(self, file_id: str, task_id: str, content: str, resolved: bool = False):
         """Updates an existing task."""
-        pass
+        client = get_service("drive", "v3", self.scopes)
+        return add_reply(client, file_id, task_id, content, resolved)
 
     def list(self, file_id: str, **kwargs):
         """Lists all available tasks."""

--- a/src/dispatch/plugins/dispatch_google/drive/plugin.py
+++ b/src/dispatch/plugins/dispatch_google/drive/plugin.py
@@ -125,7 +125,7 @@ class GoogleDriveTaskPlugin(TaskPlugin):
         """Creates a new task."""
         pass
 
-    def update(self, file_id: str, task_id: str, content: str, resolved: bool = False):
+    def update(self, file_id: str, task_id: str, content: str = None, resolved: bool = False):
         """Updates an existing task."""
         client = get_service("drive", "v3", self.scopes)
         return add_reply(client, file_id, task_id, content, resolved)

--- a/src/dispatch/plugins/dispatch_slack/actions.py
+++ b/src/dispatch/plugins/dispatch_slack/actions.py
@@ -68,14 +68,14 @@ def update_task_status(
 
     # avoid external calls if we are already in the desired state
     if resolve and task.status == TaskStatus.resolved:
-        message = f"Task is already resolved."
+        message = "Task is already resolved."
         dispatch_slack_service.send_ephemeral_message(
             slack_client, action["container"]["channel_id"], user_id, message
         )
         return
 
     if not resolve and task.status == TaskStatus.open:
-        message = f"Task is already open."
+        message = "Task is already open."
         dispatch_slack_service.send_ephemeral_message(
             slack_client, action["container"]["channel_id"], user_id, message
         )

--- a/src/dispatch/plugins/dispatch_slack/actions.py
+++ b/src/dispatch/plugins/dispatch_slack/actions.py
@@ -1,15 +1,19 @@
 from fastapi import BackgroundTasks
 
+from dispatch.config import INCIDENT_PLUGIN_TASK_SLUG
+
 from dispatch.conversation.enums import ConversationButtonActions
 from dispatch.conversation.service import get_by_channel_id
 from dispatch.database import SessionLocal
 from dispatch.decorators import background_task
 from dispatch.incident import flows as incident_flows
 from dispatch.incident import service as incident_service
+from dispatch.task import service as task_service
 from dispatch.incident.enums import IncidentStatus
 from dispatch.incident.models import IncidentUpdate, IncidentRead
 from dispatch.task.models import TaskStatus
 from dispatch.plugins.dispatch_slack import service as dispatch_slack_service
+from dispatch.plugins.base import plugins
 from dispatch.report import flows as report_flows
 
 from .config import (
@@ -53,9 +57,43 @@ def update_task_status(
     user_id: str, user_email: str, incident_id: int, action: dict, db_session=None
 ):
     """Updates a task based on user input."""
-    task = ""
+    action_type, external_task_id = action["actions"][0]["value"].split("-")
+
+    resolve = True
+    if action_type == "reopen":
+        resolve = False
+
+    # we only update the external task allowing syncing to care of propagation to dispatch
+    task = task_service.get_by_resource_id(db_session=db_session, resource_id=external_task_id)
+
+    # avoid external calls if we are already in the desired state
+    if resolve and task.status == TaskStatus.resolved:
+        message = f"Task is already resolved."
+        dispatch_slack_service.send_ephemeral_message(
+            slack_client, action["container"]["channel_id"], user_id, message
+        )
+        return
+
+    if not resolve and task.status == TaskStatus.open:
+        message = f"Task is already open."
+        dispatch_slack_service.send_ephemeral_message(
+            slack_client, action["container"]["channel_id"], user_id, message
+        )
+        return
+
+    # we don't currently have a good way to get the correct file_id (we don't store a task <-> relationship)
+    # lets try in both the incident doc and PIR doc
+    drive_task_plugin = plugins.get(INCIDENT_PLUGIN_TASK_SLUG)
+
+    # try:
+    file_id = task.incident.incident_document.resource_id
+    drive_task_plugin.update(file_id, external_task_id, resolved=resolve)
+    # except Exception as e:
+    #    file_id = task.incident.incident_review_document.resource_id
+    #    drive_task_plugin.update(file_id, external_task_id, resolved=resolve)
+
     status = "resolved" if task.status == TaskStatus.open else "re-opened"
-    message = f"Task has been successfully {status}."
+    message = f"Task successfully {status}."
     dispatch_slack_service.send_ephemeral_message(
         slack_client, action["container"]["channel_id"], user_id, message
     )

--- a/src/dispatch/plugins/dispatch_slack/actions.py
+++ b/src/dispatch/plugins/dispatch_slack/actions.py
@@ -85,12 +85,12 @@ def update_task_status(
     # lets try in both the incident doc and PIR doc
     drive_task_plugin = plugins.get(INCIDENT_PLUGIN_TASK_SLUG)
 
-    # try:
-    file_id = task.incident.incident_document.resource_id
-    drive_task_plugin.update(file_id, external_task_id, resolved=resolve)
-    # except Exception as e:
-    #    file_id = task.incident.incident_review_document.resource_id
-    #    drive_task_plugin.update(file_id, external_task_id, resolved=resolve)
+    try:
+        file_id = task.incident.incident_document.resource_id
+        drive_task_plugin.update(file_id, external_task_id, resolved=resolve)
+    except Exception:
+        file_id = task.incident.incident_review_document.resource_id
+        drive_task_plugin.update(file_id, external_task_id, resolved=resolve)
 
     status = "resolved" if task.status == TaskStatus.open else "re-opened"
     message = f"Task successfully {status}."


### PR DESCRIPTION
This adds `resolve` and `reopen` buttons to the output of `list-my-tasks` and `list-tasks` commands and allows a user to set the status of a task from the incident channel itself.

We do not add these buttons to the "New Task" or "Resolved Task" notifications at this time.

![2020-07-08_15-10](https://user-images.githubusercontent.com/2262214/86975747-d5084700-c12d-11ea-9ec0-a4748ec8a69c.png)
