### PR TITLE
[WIP] Test incident creation flow.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,5 @@ factory-boy
 faker
 flake8
 pytest
+pytest-mock
 vulture

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -626,6 +626,18 @@ class IncidentFactory(BaseFactory):
     title = FuzzyText()
     description = FuzzyText()
     status = FuzzyChoice(["Active", "Stable", "Closed"])
+    cost = Sequence(lambda n: f"10000{n}")
+
+    incident_type = SubFactory(IncidentTypeFactory)
+    incident_priority = SubFactory(IncidentPriorityFactory)
+    # commander = SubFactory(ContactBaseFactory)
+    # reporter = SubFactory(ContactBaseFactory)
+    conversation = SubFactory(ConversationFactory)
+    # incident_document = SubFactory(DocumentFactory)
+    storage = SubFactory(StorageFactory)
+    # Note circular usage between Conference and Incident. Use an absolute import.
+    # https://factoryboy.readthedocs.io/en/latest/reference.html#circular-imports
+    conference = SubFactory('tests.factories.ConferenceFactory')
 
     class Meta:
         """Factory Configuration."""
@@ -681,4 +693,5 @@ class ConferenceFactory(ResourceBaseFactory):
 
     conference_id = Sequence(lambda n: f"conference{n}")
     conference_challenge = FuzzyText()
-    incident = SubFactory(IncidentFactory)
+    # Setting 'conference' to None handles our circular usage carefully.
+    incident = SubFactory(IncidentFactory, conference=None)

--- a/tests/incident/test_incident_flows.py
+++ b/tests/incident/test_incident_flows.py
@@ -1,8 +1,30 @@
 import pytest
 
 
-def test_update_external_incident_ticket():
-    pass
+def test_update_external_incident_ticket(incident, session, ticket_plugin, incident_type, mocker):
+    from dispatch.incident.flows import update_external_incident_ticket
+    from dispatch.plugin import service as plugin_service
+
+    # from dispatch.incident_type import service as incident_type_service
+
+    mocker.patch.object(ticket_plugin, "update", {})
+    mocker.patch.object(plugin_service, "get_active", ticket_plugin)
+    # mocker.patch.object(incident_type_service, "get_by_name", )
+
+    update_external_incident_ticket(incident=incident, db_session=session)
+
+    ticket_plugin.update.assert_called_once_with(
+        ticket_id=incident.ticket.resource_id,
+        title=incident.title,
+        description=incident.description,
+        status=incident.status,
+        cost=incident.cost,
+        incident_type=incident.incident_type.name,
+        incident_priority=incident.incident_priority.name,
+        conversation=incident.conversation,
+        storage=incident.storage,
+        conference=incident.conference,
+    )
 
 
 def test_set_conversation_topic():

--- a/tests/incident/test_incident_flows.py
+++ b/tests/incident/test_incident_flows.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+def test_update_external_incident_ticket():
+    pass
+
+
+def test_set_conversation_topic():
+    pass
+
+
+def test_update_document():
+    pass

--- a/tests/incident/test_incident_service.py
+++ b/tests/incident/test_incident_service.py
@@ -38,3 +38,15 @@ def test_incident_get(session, incident):
     test_incident = get(db_session=session, incident_id=incident.id)
 
     assert test_incident.id == incident.id
+
+
+def test_update_incident_ticket():
+    pass
+
+
+def test_set_conversation_topic():
+    pass
+
+
+def test_update_document():
+    pass

--- a/tests/incident/test_incident_service.py
+++ b/tests/incident/test_incident_service.py
@@ -38,15 +38,3 @@ def test_incident_get(session, incident):
     test_incident = get(db_session=session, incident_id=incident.id)
 
     assert test_incident.id == incident.id
-
-
-def test_update_incident_ticket():
-    pass
-
-
-def test_set_conversation_topic():
-    pass
-
-
-def test_update_document():
-    pass

--- a/tests/incident/test_incident_service.py
+++ b/tests/incident/test_incident_service.py
@@ -1,0 +1,40 @@
+import pytest
+
+
+@pytest.mark.skip
+def test_incident_create(session):
+    from dispatch.incident.service import create
+    from dispatch.incident.models import IncidentCreate
+
+    incident_type = {}
+    incident_priority = {}
+    incident_priority["name"] = "Low"
+    incident_type["name"] = "Simulation"
+    reporter_email = "fmonsen@netflix.com"
+    title = "Test"
+    status = "Active"
+    description = "Test test"
+    tags = ["test"]
+
+    # incident_in = IncidentCreate(incident_priority=incident_priority, incident_type=incident_type)
+
+    incident = create(
+        db_session=session,
+        incident_priority=incident_priority,
+        incident_type=incident_type,
+        reporter_email=reporter_email,
+        title=title,
+        status=status,
+        description=description,
+        tags=tags,
+    )
+
+    assert incident
+
+
+def test_incident_get(session, incident):
+    from dispatch.incident.service import get
+
+    test_incident = get(db_session=session, incident_id=incident.id)
+
+    assert test_incident.id == incident.id


### PR DESCRIPTION
Re-creating this PR as GitHub wasn't picking up additional commits to the branch, and the build was failing without `pytest-mock`.

What do you think is the best way to handle the assignment of [incident_type_plugin_metadata](https://github.com/Netflix/dispatch/blob/579435f94aac2c1ca60d64514ea189f53e607f33/src/dispatch/incident/flows.py#L109)? I'd rather just have a plain dict assignment. Return a Query object from [incident_type.service.get_by_name()](https://github.com/Netflix/dispatch/blob/9f42c43b63205f4abfde3271b04e85e734f84d09/src/dispatch/incident_type/service.py#L26), then mock get_by_name()? Is there a way to ignore the assignment altogether?