### PR TITLE
Remove INCIDENT_PLUGIN_STORAGE_SLUG and fix group plugin typo

### DIFF
--- a/src/dispatch/document/scheduled.py
+++ b/src/dispatch/document/scheduled.py
@@ -3,9 +3,8 @@ import logging
 from schedule import every
 from sqlalchemy import func
 
-from dispatch.config import INCIDENT_PLUGIN_STORAGE_SLUG
 from dispatch.decorators import background_task
-from dispatch.plugins.base import plugins
+from dispatch.plugin import service as plugin_service
 from dispatch.route import service as route_service
 from dispatch.scheduler import scheduler
 from dispatch.extensions import sentry_sdk
@@ -24,9 +23,7 @@ def sync_document_terms(db_session=None):
 
     for doc in documents:
         log.debug(f"Processing document. Name: {doc.name}")
-        p = plugins.get(
-            INCIDENT_PLUGIN_STORAGE_SLUG
-        )  # this may need to be refactored if we support multiple document types
+        p = plugin_service.get_active(db_session=db_session, plugin_type="storage")
 
         try:
             if "sheet" in doc.resource_type:

--- a/src/dispatch/plugins/dispatch_slack/modals.py
+++ b/src/dispatch/plugins/dispatch_slack/modals.py
@@ -436,7 +436,7 @@ def build_update_notifications_group_blocks(incident: Incident, db_session: Sess
         "private_metadata": json.dumps({"incident_id": str(incident.id)}),
     }
 
-    group_plugin = plugin_service.get_active(db_session=db_session, plugin_type="grouop")
+    group_plugin = plugin_service.get_active(db_session=db_session, plugin_type="group")
     members = group_plugin.list(incident.notifications_group.email)
 
     members_block = {


### PR DESCRIPTION
Related to https://github.com/Netflix/dispatch/pull/507, fix a typo for `group` plugin type and remove the `INCIDENT_PLUGIN_STORAGE_SLUG` from document scheduler.