### PR TITLE
Fix Doc Typos

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -19,5 +19,5 @@
   * [Installation](docs/installation.md)
   * [License](docs/license.md)
   * [Plugins](docs/plugins.md)
-  * [Contributing](docs/development.md)
+  * [Contributing](docs/contributing/)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ Dispatch relies on multiple services to work, which are all orchestrated by `Doc
 
 ## Installing Dispatch Server
 
-We strongly recommend using Docker, for installing Dispatch and all it's services. If you need to to something custom, you can use this repository as the basis of your setup. If you do not wish to use the Docker images we provide, you can still find Dispatch on PyPI. However, we don't recommend that method. You'll need to work your way back from the main Dispatch image. It is not too hard, but you are likely to spend a lot more time and hit some bumps.
+We strongly recommend using Docker, for installing Dispatch and all its services. If you need to do something custom, you can use this repository as the basis of your setup. If you do not wish to use the Docker images we provide, you can still find Dispatch on PyPI; however, we don't recommend that method. You'll need to work your way back from the main Dispatch image. It is not too hard, but you are likely to spend a lot more time and hit some bumps.
 
 To install Dispatch from the repository, clone the repository locally:
 


### PR DESCRIPTION
While reading docs, fixed a few typos/syntax and a bad link.

Not worth a new release.  I'm sorry if I come off as a "Linter" (no impact beyond spellcheck) but it stands out to me and this may be what little I can contribute :)