### PR TITLE
Google now converts + to @

### DIFF
--- a/src/dispatch/plugins/dispatch_google/drive/task.py
+++ b/src/dispatch/plugins/dispatch_google/drive/task.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 def get_assignees(content: str) -> List[str]:
     """Gets assignees from comment."""
-    regex = r"\+([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)"
+    regex = r"\@([a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+)"
     matches = re.findall(regex, content)
     return [m for m in matches]
 


### PR DESCRIPTION
We used to rely on the + char to indicate all assignees to a google comment/task. Recently now relies on @ instead of +.