### PR TITLE
Feature/sentry tags

### DIFF
--- a/docs/configuration/app.md
+++ b/docs/configuration/app.md
@@ -37,7 +37,7 @@ In general, do not include any quotation marks when adding configuration values.
 
 #### `ENV_TAGS` \[defaut: ""\]
 
-> A comma seperated list of tags that Dispatch will attempt to pull from the environment. As an example the string `foo:bar,baz:blah` will create two tags, `foo` with the environment value for `bar` and `baz with the environments values for `blah`.
+> A comma separated list of tags that Dispatch will attempt to pull from the environment. As an example the string `foo:bar,baz:blah` will create two tags: `foo` with the environment value for `bar` and `baz` with the environment value for `blah`.
 
 #### `SENTRY_DSN` \[default: none\]
 

--- a/docs/configuration/app.md
+++ b/docs/configuration/app.md
@@ -35,7 +35,11 @@ In general, do not include any quotation marks when adding configuration values.
 
 > A comma separated list of metric providers Dispatch will send key system metrics to.
 
-#### `SENTRY_DSN` \[default: none\] \[secret: True\]
+#### `ENV_TAGS` \[defaut: ""\]
+
+> A comma seperated list of tags that Dispatch will attempt to pull from the environment. As an example the string `foo:bar,baz:blah` will create two tags, `foo` with the environment value for `bar` and `baz with the environments values for `blah`.
+
+#### `SENTRY_DSN` \[default: none\]
 
 > Optional configuration for using Sentry to report Dispatch errors.
 

--- a/src/dispatch/config.py
+++ b/src/dispatch/config.py
@@ -136,7 +136,7 @@ STATIC_DIR = config("STATIC_DIR", default=DEFAULT_STATIC_DIR)
 METRIC_PROVIDERS = config("METRIC_PROVIDERS", cast=CommaSeparatedStrings, default="")
 
 # sentry middleware
-SENTRY_DSN = config("SENTRY_DSN", cast=Secret, default=None)
+SENTRY_DSN = config("SENTRY_DSN", default=None)
 
 # database
 DATABASE_HOSTNAME = config("DATABASE_HOSTNAME")

--- a/src/dispatch/config.py
+++ b/src/dispatch/config.py
@@ -1,11 +1,27 @@
 import logging
 import os
 import base64
+from typing import List
 
 from starlette.config import Config
 from starlette.datastructures import CommaSeparatedStrings
 
 log = logging.getLogger(__name__)
+
+
+def get_env_tags(tag_list: List[str]) -> dict:
+    """Create dictionary of available env tags."""
+    tags = {}
+    for t in tag_list:
+        tag_key, env_key = t.split(":")
+
+        env_value = os.environ.get(env_key)
+
+        if env_value:
+            tags.update({tag_key: env_value})
+
+    return tags
+
 
 # if we have metatron available to us, lets use it to decrypt our secrets in memory
 try:
@@ -67,6 +83,9 @@ config = Config(".env")
 
 LOG_LEVEL = config("LOG_LEVEL", default=logging.WARNING)
 ENV = config("ENV", default="local")
+
+ENV_TAG_LIST = config("ENV_TAGS", cast=CommaSeparatedStrings, default="")
+ENV_TAGS = get_env_tags(ENV_TAG_LIST)
 
 DISPATCH_UI_URL = config("DISPATCH_UI_URL")
 DISPATCH_HELP_EMAIL = config("DISPATCH_HELP_EMAIL")

--- a/src/dispatch/extensions.py
+++ b/src/dispatch/extensions.py
@@ -40,5 +40,6 @@ def configure_extensions():
             environment=ENV,
         )
         with configure_scope() as scope:
+            log.debug(f"Using the following tags... ENV_TAGS: {ENV_TAGS}")
             for k, v in ENV_TAGS.items():
                 scope.set_tag(k, v)

--- a/src/dispatch/extensions.py
+++ b/src/dispatch/extensions.py
@@ -4,6 +4,11 @@ import sentry_sdk
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.stdlib import StdlibIntegration
+from sentry_sdk.integrations.excepthook import ExcepthookIntegration
+from sentry_sdk.integrations.dedupe import DedupeIntegration
+from sentry_sdk.integrations.atexit import AtexitIntegration
+from sentry_sdk.integrations.modules import ModulesIntegration
 
 from .config import SENTRY_DSN, ENV
 
@@ -21,6 +26,15 @@ def configure_extensions():
     if SENTRY_DSN:
         sentry_sdk.init(
             dsn=str(SENTRY_DSN),
-            integrations=[sentry_logging, AioHttpIntegration(), SqlalchemyIntegration()],
+            integrations=[
+                sentry_logging,
+                AioHttpIntegration(),
+                SqlalchemyIntegration(),
+                StdlibIntegration(),
+                ExcepthookIntegration(),
+                DedupeIntegration(),
+                AtexitIntegration(),
+                ModulesIntegration(),
+            ],
             environment=ENV,
         )

--- a/src/dispatch/extensions.py
+++ b/src/dispatch/extensions.py
@@ -1,6 +1,7 @@
 import logging
 
 import sentry_sdk
+from sentry_sdk import configure_scope
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -10,7 +11,7 @@ from sentry_sdk.integrations.dedupe import DedupeIntegration
 from sentry_sdk.integrations.atexit import AtexitIntegration
 from sentry_sdk.integrations.modules import ModulesIntegration
 
-from .config import SENTRY_DSN, ENV
+from .config import ENV_TAGS, SENTRY_DSN, ENV
 
 
 log = logging.getLogger(__file__)
@@ -38,3 +39,6 @@ def configure_extensions():
             ],
             environment=ENV,
         )
+        with configure_scope() as scope:
+            for k, v in ENV_TAGS.items():
+                scope.set_tag(k, v)


### PR DESCRIPTION
Allows you to specify env tags that will be gathered and sent to sentry. An example:

`ENV_TAGS="foo:bar"`

Will attempt to pull `bar` from the current ENV and set it's value to the tag `foo`
