### PR TITLE
[Hotfix] Fetches Slack conversation ignoring channel type (#560)

### DIFF
--- a/src/dispatch/conversation/service.py
+++ b/src/dispatch/conversation/service.py
@@ -2,19 +2,48 @@ from typing import Optional
 
 from fastapi.encoders import jsonable_encoder
 
+from dispatch.event import service as event_service
+
 from .models import Conversation, ConversationCreate, ConversationUpdate
 
 
 def get(*, db_session, conversation_id: int) -> Optional[Conversation]:
-    """Returns a conversation based on the given conversation id."""
+    """Fetch a conversation by its `conversation_id`."""
     return db_session.query(Conversation).filter(Conversation.id == conversation_id).one_or_none()
 
 
 def get_by_channel_id(db_session, channel_id: str) -> Optional[Conversation]:
-    """Returns a conversation based on the given channel id."""
+    """Fetch a conversation by its `channel_id`."""
     return (
         db_session.query(Conversation).filter(Conversation.channel_id == channel_id).one_or_none()
     )
+
+
+def get_by_channel_id_ignoring_channel_type(db_session, channel_id: str) -> Optional[Conversation]:
+    """Fetch a conversation by its `channel_id` ignoring the channel type
+    and update the channel id in the database if the channel type has changed."""
+    conversation = (
+        db_session.query(Conversation)
+        .filter(Conversation.channel_id.contains(channel_id[1:]))
+        .one_or_none()
+    )
+
+    if conversation:
+        if channel_id[0] != conversation.channel_id[0]:
+            # The channel type has changed. We update the channel id in the database
+            conversation_in = ConversationUpdate(channel_id=channel_id)
+            update(
+                db_session=db_session, conversation=conversation, conversation_in=conversation_in,
+            )
+
+            event_service.log(
+                db_session=db_session,
+                source="Dispatch Core App",
+                description=f"Slack conversation type has changed ({channel_id[0]} -> {conversation.channel_id[0]})",
+                incident_id=conversation.incident_id,
+            )
+
+    return conversation
 
 
 def get_all(*, db_session):

--- a/src/dispatch/plugins/dispatch_slack/actions.py
+++ b/src/dispatch/plugins/dispatch_slack/actions.py
@@ -1,20 +1,20 @@
 from fastapi import BackgroundTasks
 
 from dispatch.config import INCIDENT_PLUGIN_TASK_SLUG
-
+from dispatch.conversation import service as conversation_service
 from dispatch.conversation.enums import ConversationButtonActions
-from dispatch.conversation.service import get_by_channel_id
 from dispatch.database import SessionLocal
 from dispatch.decorators import background_task
 from dispatch.incident import flows as incident_flows
 from dispatch.incident import service as incident_service
-from dispatch.task import service as task_service
 from dispatch.incident.enums import IncidentStatus
 from dispatch.incident.models import IncidentUpdate, IncidentRead
-from dispatch.task.models import TaskStatus
-from dispatch.plugins.dispatch_slack import service as dispatch_slack_service
+from dispatch.plugin import service as plugin_service
 from dispatch.plugins.base import plugins
+from dispatch.plugins.dispatch_slack import service as dispatch_slack_service
 from dispatch.report import flows as report_flows
+from dispatch.task import service as task_service
+from dispatch.task.models import TaskStatus
 
 from .config import (
     SLACK_COMMAND_ASSIGN_ROLE_SLUG,
@@ -162,7 +162,9 @@ def block_action_functions(action: str):
 def handle_dialog_action(action: dict, background_tasks: BackgroundTasks, db_session: SessionLocal):
     """Handles all dialog actions."""
     channel_id = action["channel"]["id"]
-    conversation = get_by_channel_id(db_session=db_session, channel_id=channel_id)
+    conversation = conversation_service.get_by_channel_id_ignoring_channel_type(
+        db_session=db_session, channel_id=channel_id
+    )
     incident_id = conversation.incident_id
 
     user_id = action["user"]["id"]

--- a/src/dispatch/plugins/dispatch_slack/events.py
+++ b/src/dispatch/plugins/dispatch_slack/events.py
@@ -85,16 +85,12 @@ def get_channel_id_from_event(event_body: dict):
 def event_functions(event: EventEnvelope):
     """Interprets the events and routes it the appropriate function."""
     event_mappings = {
-        "file_created": [add_evidence_to_storage],
-        "file_shared": [add_evidence_to_storage],
-        "link_shared": [],
         "member_joined_channel": [member_joined_channel],
-        "message": [ban_threads_warning],
         "member_left_channel": [incident_flows.incident_remove_participant_flow],
+        "message": [after_hours, ban_threads_warning],
         "message.groups": [],
         "message.im": [],
         "reaction_added": [handle_reaction_added_event],
-        "reaction_removed": [handle_reaction_removed_event],
     }
 
     return event_mappings.get(event.event.type, [])
@@ -134,20 +130,6 @@ def handle_reaction_added_event(
             individual_id=individual.id,
             started_at=message_ts_utc,
         )
-
-
-@background_task
-def handle_reaction_removed_event(
-    user_email: str, incident_id: int, event: dict = None, db_session=None
-):
-    """Handles an event where a reaction is removed from a message."""
-    pass
-
-
-@background_task
-def add_evidence_to_storage(user_email: str, incident_id: int, event: dict = None, db_session=None):
-    """Adds evidence (e.g. files) added/shared in the conversation to storage."""
-    pass
 
 
 def is_business_hours(commander_tz: str):

--- a/src/dispatch/plugins/dispatch_slack/views.py
+++ b/src/dispatch/plugins/dispatch_slack/views.py
@@ -14,8 +14,8 @@ from sqlalchemy.orm import Session
 from starlette.requests import Request
 from starlette.responses import Response
 
+from dispatch.conversation import service as conversation_service
 from dispatch.database import get_db
-from dispatch.conversation.service import get_by_channel_id
 from dispatch.plugins.dispatch_slack import service as dispatch_slack_service
 
 from . import __version__
@@ -102,7 +102,9 @@ async def handle_event(
     channel_id = get_channel_id_from_event(event_body)
 
     if user_id and channel_id:
-        conversation = get_by_channel_id(db_session=db_session, channel_id=channel_id)
+        conversation = conversation_service.get_by_channel_id_ignoring_channel_type(
+            db_session=db_session, channel_id=channel_id
+        )
 
         if conversation and dispatch_slack_service.is_user(user_id):
             # We create an async Slack client
@@ -147,7 +149,9 @@ async def handle_command(
 
     # Fetch conversation by channel id
     channel_id = command.get("channel_id")
-    conversation = get_by_channel_id(db_session=db_session, channel_id=channel_id)
+    conversation = conversation_service.get_by_channel_id_ignoring_channel_type(
+        db_session=db_session, channel_id=channel_id
+    )
 
     incident_id = 0
     if conversation:


### PR DESCRIPTION
* Removes unused or unimplemented code

* Adds after hours

* Fetches conversation by channel id ignoring channel type

* Adds event to timeline