### PR TITLE
Checks if inviter exists before updating participant's metadata

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/events.py
+++ b/src/dispatch/plugins/dispatch_slack/events.py
@@ -189,25 +189,26 @@ def member_joined_channel(
         user_email=user_email, incident_id=incident_id, db_session=db_session
     )
 
-    # we update the participant's metadata
-    if not dispatch_slack_service.is_user(event.event.inviter):
-        # we default to the incident commander when we don't know how the user was added
-        participant.added_by = participant_service.get_by_incident_id_and_role(
-            db_session=db_session,
-            incident_id=incident_id,
-            role=ParticipantRoleType.incident_commander,
-        )
-        participant.added_reason = "User was automatically added by Dispatch."
+    if event.event.inviter:
+        # we update the participant's metadata
+        if not dispatch_slack_service.is_user(event.event.inviter):
+            # we default to the incident commander when we don't know how the user was added
+            participant.added_by = participant_service.get_by_incident_id_and_role(
+                db_session=db_session,
+                incident_id=incident_id,
+                role=ParticipantRoleType.incident_commander,
+            )
+            participant.added_reason = "User was automatically added by Dispatch."
 
-    else:
-        inviter_email = get_user_email(client=slack_client, user_id=event.event.inviter)
-        added_by_participant = participant_service.get_by_incident_id_and_email(
-            db_session=db_session, incident_id=incident_id, email=inviter_email
-        )
-        participant.added_by = added_by_participant
-        participant.added_reason = event.event.text
+        else:
+            inviter_email = get_user_email(client=slack_client, user_id=event.event.inviter)
+            added_by_participant = participant_service.get_by_incident_id_and_email(
+                db_session=db_session, incident_id=incident_id, email=inviter_email
+            )
+            participant.added_by = added_by_participant
+            participant.added_reason = event.event.text
 
-    db_session.commit()
+        db_session.commit()
 
 
 @background_task


### PR DESCRIPTION
Slacks sends a `member_joined_channel` event when a channel member clicks on "Share Channel". The inviter key in the event is not set. This PR adds logic to check that inviter has a value before trying to update the participant's metadata.