### PR TITLE
Handles commands run in non-incident channels

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/commands.py
+++ b/src/dispatch/plugins/dispatch_slack/commands.py
@@ -154,7 +154,7 @@ def list_tasks(
         slack_client,
         command["channel_id"],
         command["user_id"],
-        "Incident List Tasks",
+        "Incident Task List",
         blocks=blocks,
     )
 
@@ -232,6 +232,6 @@ def list_participants(incident_id: int, command: dict = None, db_session=None):
         slack_client,
         command["channel_id"],
         command["user_id"],
-        "Incident List Participants",
+        "Incident Participant List",
         blocks=blocks,
     )

--- a/src/dispatch/plugins/dispatch_slack/messaging.py
+++ b/src/dispatch/plugins/dispatch_slack/messaging.py
@@ -101,7 +101,7 @@ Incident-specifc commands can only be run in incident conversations.""".replace(
 
 INCIDENT_CONVERSATION_COMMAND_RUN_IN_CONVERSATION_WHERE_BOT_NOT_PRESENT = """
 Looks like you tried to run `{{command}}` in a conversation where the Dispatch bot is not present.
-Try again in one of the following conversations: {{conversations}}""".replace(
+Add the bot to your conversation or run the command in one of the following conversations: {{conversations}}""".replace(
     "\n", " "
 ).strip()
 

--- a/src/dispatch/plugins/dispatch_slack/messaging.py
+++ b/src/dispatch/plugins/dispatch_slack/messaging.py
@@ -93,20 +93,64 @@ INCIDENT_CONVERSATION_COMMAND_MESSAGE = {
     },
 }
 
-INCIDENT_CONVERSATION_NON_INCIDENT_CONVERSATION_COMMAND_ERROR = """
-Looks like you tried to run `{{command}}` in an non-incident conversation. You can only run Dispatch commands in incident conversations.""".replace(
+INCIDENT_CONVERSATION_COMMAND_RUN_IN_NONINCIDENT_CONVERSATION = """
+Looks like you tried to run `{{command}}` in an nonincident conversation.
+Incident-specifc commands can only be run in incident conversations.""".replace(
+    "\n", " "
+).strip()
+
+INCIDENT_CONVERSATION_COMMAND_RUN_IN_CONVERSATION_WHERE_BOT_NOT_PRESENT = """
+Looks like you tried to run `{{command}}` in a conversation where the Dispatch bot is not present.
+Try again in one of the following conversations: {{conversations}}""".replace(
     "\n", " "
 ).strip()
 
 
-def render_non_incident_conversation_command_error_message(command: str):
-    """Renders a non-incident conversation command error ephemeral message."""
+def create_command_run_in_nonincident_conversation_message(command: str):
+    """Creates a message for when an incident specific command is run in an nonincident conversation."""
     return {
         "response_type": "ephemeral",
-        "text": Template(INCIDENT_CONVERSATION_NON_INCIDENT_CONVERSATION_COMMAND_ERROR).render(
+        "text": Template(INCIDENT_CONVERSATION_COMMAND_RUN_IN_NONINCIDENT_CONVERSATION).render(
             command=command
         ),
     }
+
+
+def create_command_run_in_conversation_where_bot_not_present_message(
+    command: str, conversations: []
+):
+    """Creates a message for when a nonincident specific command is run in a conversation where the Dispatch bot is not present."""
+    conversations = (", ").join([f"#{conversation}" for conversation in conversations])
+    return {
+        "response_type": "ephemeral",
+        "text": Template(
+            INCIDENT_CONVERSATION_COMMAND_RUN_IN_CONVERSATION_WHERE_BOT_NOT_PRESENT
+        ).render(command=command, conversations=conversations),
+    }
+
+
+def create_incident_reported_confirmation_message(
+    title: str, incident_type: str, incident_priority: str
+):
+    """Creates an incident reported confirmation message."""
+    return [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "This is a confirmation that you have reported a security incident with the following information. You'll get invited to a Slack conversation soon.",
+            },
+        },
+        {"type": "section", "text": {"type": "mrkdwn", "text": f"*Incident Title*: {title}"}},
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*Incident Type*: {incident_type}"},
+        },
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*Incident Priority*: {incident_priority}"},
+        },
+    ]
 
 
 def get_template(message_type: MessageType):
@@ -125,10 +169,7 @@ def get_template(message_type: MessageType):
             default_notification,
             INCIDENT_TASK_REMINDER_DESCRIPTION,
         ),
-        MessageType.incident_status_reminder: (
-            default_notification,
-            None,
-        ),
+        MessageType.incident_status_reminder: (default_notification, None,),
         MessageType.incident_task_list: (default_notification, INCIDENT_TASK_LIST_DESCRIPTION),
     }
 
@@ -211,26 +252,3 @@ def slack_preview(message, block=None):
         print(f"https://api.slack.com/tools/block-kit-builder?blocks={message}")
     else:
         print(f"https://api.slack.com/docs/messages/builder?msg={message}")
-
-
-def create_incident_reported_confirmation_msg(
-    title: str, incident_type: str, incident_priority: str
-):
-    return [
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": "This is a confirmation that you have reported a security incident with the following information. You'll get invited to a Slack conversation soon.",
-            },
-        },
-        {"type": "section", "text": {"type": "mrkdwn", "text": f"*Incident Title*: {title}"}},
-        {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": f"*Incident Type*: {incident_type}"},
-        },
-        {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": f"*Incident Priority*: {incident_priority}"},
-        },
-    ]

--- a/src/dispatch/plugins/dispatch_slack/modals.py
+++ b/src/dispatch/plugins/dispatch_slack/modals.py
@@ -21,7 +21,7 @@ from dispatch.participant.models import Participant, ParticipantUpdate
 from dispatch.plugin import service as plugin_service
 from dispatch.plugins.dispatch_slack import service as dispatch_slack_service
 
-from .messaging import create_incident_reported_confirmation_msg
+from .messaging import create_incident_reported_confirmation_message
 from .service import get_user_profile_by_email
 
 
@@ -126,7 +126,7 @@ def report_incident_from_submitted_form(action: dict, db_session: Session = None
     requested_form_incident_priority = parsed_form_data.get(IncidentSlackViewBlockId.priority)
 
     # Send a confirmation to the user
-    msg_template = create_incident_reported_confirmation_msg(
+    blocks = create_incident_reported_confirmation_message(
         title=requested_form_title,
         incident_type=requested_form_incident_type.get("value"),
         incident_priority=requested_form_incident_priority.get("value"),
@@ -135,11 +135,7 @@ def report_incident_from_submitted_form(action: dict, db_session: Session = None
     user_id = action["user"]["id"]
     channel_id = submitted_form.get("private_metadata")["channel_id"]
     dispatch_slack_service.send_ephemeral_message(
-        client=slack_client,
-        conversation_id=channel_id,
-        user_id=user_id,
-        text="",
-        blocks=msg_template,
+        client=slack_client, conversation_id=channel_id, user_id=user_id, text="", blocks=blocks,
     )
 
     # Create the incident

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -29,10 +29,6 @@ def create_slack_client(run_async: bool = False):
     return slack.WebClient(token=str(SLACK_API_BOT_TOKEN), run_async=run_async)
 
 
-def contains_numbers(string):
-    return any(char.isdigit() for char in string)
-
-
 def resolve_user(client: Any, user_id: str):
     """Attempts to resolve a user object regardless if email, id, or prefix."""
     if SLACK_USER_ID_OVERRIDE:
@@ -218,9 +214,14 @@ def get_user_avatar_url(client: Any, email: str):
     return get_user_info_by_email(client, email)["profile"]["image_512"]
 
 
-def get_escaped_user_from_command(command_text: str):
-    """Gets escaped user sent to Slack command."""
-    return re.match(r"<@(?P<user_id>\w+)\|(?P<user_name>\w+)>", command_text).group("user_id")
+@functools.lru_cache()
+async def get_conversations_by_user_id_async(client: Any, user_id: str):
+    """Gets the list of conversations a user is a member of."""
+    result = await make_call_async(
+        client, "users.conversations", user=user_id, types="public_channel", exclude_archived=True
+    )
+    conversations = [c["name"] for c in result["channels"]]
+    return conversations
 
 
 # note this will get slower over time, we might exclude archived to make it sane
@@ -229,24 +230,6 @@ def get_conversation_by_name(client: Any, name: str):
     for c in list_conversations(client):
         if c["name"] == name:
             return c
-
-
-def get_conversation_messages_by_reaction(client: Any, conversation_id: str, reaction: str):
-    """Fetches messages from a conversation by reaction type."""
-    messages = []
-    for m in list_conversation_messages(client, conversation_id):
-        if "reactions" in m and m["reactions"][0]["name"] == reaction and m["text"].strip():
-            messages.insert(
-                0,
-                {
-                    "datetime": datetime.fromtimestamp(float(m["ts"]))
-                    .astimezone(timezone("America/Los_Angeles"))
-                    .strftime("%Y-%m-%d %H:%M:%S"),
-                    "message": m["text"],
-                    "user": get_user_info_by_id(client, m["user"])["user"]["real_name"],
-                },
-            )
-    return messages
 
 
 def set_conversation_topic(client: Any, conversation_id: str, topic: str):
@@ -295,25 +278,6 @@ def add_users_to_conversation(client: Any, conversation_id: str, user_ids: List[
     # NOTE this will trigger a member_joined_channel event, which we will capture and run the incident.incident_add_or_reactivate_participant_flow() as a result
     for c in chunks(user_ids, 30):  # NOTE api only allows 30 at a time.
         make_call(client, "conversations.invite", users=c, channel=conversation_id)
-
-
-@paginated("members")
-def get_conversation_members(
-    client: Any, conversation_id: str, include_bots: bool = False, **kwargs
-):
-    response = make_call(client, "conversations.members", channel=conversation_id, **kwargs)
-
-    details = []
-    for m in response["members"]:
-        details.append(make_call(client, "users.info", user=m)["user"])
-
-    response["members"] = details
-    return response
-
-
-def get_conversation_details(client: Any, conversation_id):
-    """Get conversation details."""
-    return make_call(client, "conversations.info", channel=conversation_id)
 
 
 def send_message(

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -1,16 +1,8 @@
-"""
-.. module: dispatch.plugins.dispatch_slack.service
-    :platform: Unix
-    :copyright: (c) 2019 by Netflix Inc., see AUTHORS for more
-    :license: Apache, see LICENSE for more details.
-.. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
-"""
 from datetime import datetime, timezone
 from tenacity import TryAgain, retry, retry_if_exception_type, stop_after_attempt
 from typing import Any, Dict, List, Optional
 import functools
 import logging
-import re
 import slack
 import time
 


### PR DESCRIPTION
This PR adds logic to handle commands when they're run from non-incident channels or channels where Dispatch bot is not present.
<img width="629" alt="Screen Shot 2020-09-21 at 1 50 26 PM" src="https://user-images.githubusercontent.com/39573146/93820052-707b6500-fc11-11ea-8a41-c4b2f24f7696.png">
