### PR TITLE
Migrates to the pdpyras client library

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -20,7 +20,7 @@ oauth2client
 pandas
 psycopg2-binary
 pyparsing
-pypd  # pagerduty plugin
+pdpyras
 python-dateutil
 python-jose
 python-multipart

--- a/src/dispatch/plugins/bases/oncall.py
+++ b/src/dispatch/plugins/bases/oncall.py
@@ -13,5 +13,15 @@ class OncallPlugin(Plugin):
     type = "oncall"
     _schema = PluginOptionModel
 
-    def get(self, **kwargs):
+    def get(self, service_id: str, **kwargs):
+        raise NotImplementedError
+
+    def page(
+        self,
+        service_id: str,
+        incident_name: str,
+        incident_title: str,
+        incident_description: str,
+        **kwargs,
+    ):
         raise NotImplementedError

--- a/src/dispatch/plugins/dispatch_opsgenie/plugin.py
+++ b/src/dispatch/plugins/dispatch_opsgenie/plugin.py
@@ -27,5 +27,12 @@ class OpsGenieOncallPlugin(OncallPlugin):
     def get(self, service_id: str, **kwargs):
         return get_oncall()
 
-    def page(self, incident_name: str, incident_title: str, incident_description: str, **kwargs):
+    def page(
+        self,
+        service_id: str,
+        incident_name: str,
+        incident_title: str,
+        incident_description: str,
+        **kwargs,
+    ):
         return page_oncall(incident_name, incident_title, incident_description)

--- a/src/dispatch/plugins/dispatch_opsgenie/plugin.py
+++ b/src/dispatch/plugins/dispatch_opsgenie/plugin.py
@@ -24,8 +24,8 @@ class OpsGenieOncallPlugin(OncallPlugin):
     description = "Uses Opsgenie to resolve and page oncall teams."
     version = __version__
 
-    def get(self, *args, **kwargs):
+    def get(self, service_id: str, **kwargs):
         return get_oncall()
 
-    def page(self, incident_name: str, incident_title: str, incident_description: str):
+    def page(self, incident_name: str, incident_title: str, incident_description: str, **kwargs):
         return page_oncall(incident_name, incident_title, incident_description)

--- a/src/dispatch/plugins/dispatch_pagerduty/config.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/config.py
@@ -1,5 +1,4 @@
 from dispatch.config import config, Secret
 
 PAGERDUTY_API_KEY = config("PAGERDUTY_API_KEY", cast=Secret)
-print(PAGERDUTY_API_KEY)
 PAGERDUTY_API_FROM_EMAIL = config("PAGERDUTY_API_FROM_EMAIL")

--- a/src/dispatch/plugins/dispatch_pagerduty/config.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/config.py
@@ -1,4 +1,5 @@
 from dispatch.config import config, Secret
 
 PAGERDUTY_API_KEY = config("PAGERDUTY_API_KEY", cast=Secret)
+print(PAGERDUTY_API_KEY)
 PAGERDUTY_API_FROM_EMAIL = config("PAGERDUTY_API_FROM_EMAIL")

--- a/src/dispatch/plugins/dispatch_pagerduty/plugin.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/plugin.py
@@ -5,12 +5,13 @@
     :license: Apache, see LICENSE for more details.
 """
 import logging
-
+from pdpyras import APISession
 from dispatch.decorators import apply, counter, timer
 from dispatch.plugins import dispatch_pagerduty as pagerduty_oncall_plugin
 from dispatch.plugins.bases import OncallPlugin
 
 from .service import get_oncall, page_oncall
+from .config import PAGERDUTY_API_KEY
 
 
 log = logging.getLogger(__name__)
@@ -28,10 +29,18 @@ class PagerDutyOncallPlugin(OncallPlugin):
 
     def get(self, service_id: str = None, service_name: str = None):
         """Gets the oncall person."""
-        return get_oncall(service_id=service_id, service_name=service_name)
+        client = APISession(PAGERDUTY_API_KEY)
+        return get_oncall(client=client, service_id=service_id, service_name=service_name)
 
     def page(
         self, service_id: str, incident_name: str, incident_title: str, incident_description: str
     ):
         """Pages the oncall person."""
-        return page_oncall(service_id, incident_name, incident_title, incident_description)
+        client = APISession(PAGERDUTY_API_KEY)
+        return page_oncall(
+            client=client,
+            service_id=service_id,
+            incident_name=incident_name,
+            incident_title=incident_title,
+            incident_description=incident_description,
+        )

--- a/src/dispatch/plugins/dispatch_pagerduty/plugin.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/plugin.py
@@ -27,13 +27,18 @@ class PagerDutyOncallPlugin(OncallPlugin):
     description = "Uses PagerDuty to resolve and page oncall teams."
     version = pagerduty_oncall_plugin.__version__
 
-    def get(self, service_id: str = None, service_name: str = None):
+    def get(self, service_id: str = None, **kwargs):
         """Gets the oncall person."""
         client = APISession(PAGERDUTY_API_KEY)
-        return get_oncall(client=client, service_id=service_id, service_name=service_name)
+        return get_oncall(client=client, service_id=service_id)
 
     def page(
-        self, service_id: str, incident_name: str, incident_title: str, incident_description: str
+        self,
+        service_id: str,
+        incident_name: str,
+        incident_title: str,
+        incident_description: str,
+        **kwargs,
     ):
         """Pages the oncall person."""
         client = APISession(PAGERDUTY_API_KEY)

--- a/src/dispatch/plugins/dispatch_pagerduty/service.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/service.py
@@ -1,60 +1,40 @@
-import pypd
-from pypd.models.service import Service
-
-from dispatch.exceptions import DispatchPluginException
-
-from .config import PAGERDUTY_API_KEY, PAGERDUTY_API_FROM_EMAIL
+from .config import PAGERDUTY_API_FROM_EMAIL
 
 
-pypd.api_key = PAGERDUTY_API_KEY
-
-
-def get_oncall_email(service: Service):
+def get_oncall_email(client, service: dict) -> str:
     """Fetches the oncall's email for a given service."""
-    escalation_policy_id = service.json["escalation_policy"]["id"]
-    escalation_policy = pypd.EscalationPolicy.fetch(escalation_policy_id)
+    escalation_policy_id = service["escalation_policy"]["id"]
+    escalation_policy = client.rget(f"/escalation_policies/{escalation_policy_id}")
+    schedule_id = escalation_policy["escalation_rules"][0]["targets"][0]["id"]
 
-    schedule_id = escalation_policy.json["escalation_rules"][0]["targets"][0]["id"]
-
-    oncall = pypd.OnCall.find_one(
-        escalation_policy_ids=[escalation_policy_id], schedule_ids=[schedule_id]
+    oncalls = client.iter_all(
+        "oncalls",  # method
+        {
+            # "include[]": "users", # including users doesn't give us the contact details
+            "schedule_ids[]": [schedule_id],
+            "escalation_policy_ids[]": [escalation_policy_id],
+        },  # params
     )
 
-    user_id = oncall.json["user"]["id"]
-    user = pypd.User.fetch(user_id)
+    user_id = list(oncalls)[0]["user"]["id"]
+    user = client.rget(f"/users/{user_id}")
 
-    return user.json["email"]
+    return user["email"]
 
 
-def get_oncall(service_id: str = None, service_name: str = None):
+def get_oncall(client, service_id: str):
     """Gets the oncall for a given service id or name."""
-    if service_id:
-        service = pypd.Service.fetch(service_id)
-        return get_oncall_email(service)
-    elif service_name:
-        service = pypd.Service.find(query=service_name)
-
-        if len(service) > 1:
-            raise DispatchPluginException(
-                f"More than one PagerDuty service found with service name: {service_name}"
-            )
-
-        if not service:
-            raise DispatchPluginException(
-                f"No on-call service found with service name: {service_name}"
-            )
-
-        return get_oncall_email(service[0])
-
-    raise DispatchPluginException("Cannot fetch oncall. Must specify service_id or service_name.")
+    service = client.rget(f"/services/{service_id}")
+    return get_oncall_email(client, service)
 
 
 def page_oncall(
-    service_id: str, incident_name: str, incident_title: str, incident_description: str
+    client, service_id: str, incident_name: str, incident_title: str, incident_description: str
 ):
     """Pages the oncall for a given service id."""
-    service = pypd.Service.fetch(service_id)
-    escalation_policy_id = service.json["escalation_policy"]["id"]
+    service = client.rget(f"/services/{service_id}")
+
+    escalation_policy_id = service["escalation_policy"]["id"]
 
     data = {
         "type": "incident",
@@ -64,7 +44,7 @@ def page_oncall(
         "body": {"type": "incident_body", "details": incident_description},
         "escalation_policy": {"id": escalation_policy_id, "type": "escalation_policy_reference"},
     }
-
-    incident = pypd.Incident.create(data=data, add_headers={"from": PAGERDUTY_API_FROM_EMAIL})
+    headers = {"from": PAGERDUTY_API_FROM_EMAIL}
+    incident = client.rpost("/incidents", json=data, headers=headers)
 
     return incident

--- a/src/dispatch/plugins/dispatch_test/oncall.py
+++ b/src/dispatch/plugins/dispatch_test/oncall.py
@@ -12,8 +12,15 @@ class TestOncallPlugin(OncallPlugin):
     slug = "test-oncall"
     description = "Oncall plugin for testing purposes"
 
-    def get(self, **kwargs):
+    def get(self, service_id: str, **kwargs):
         return "johnsmith@example.com"
 
-    def page(self, **kwargs):
+    def page(
+        self,
+        service_id: str,
+        incident_name: str,
+        incident_title: str,
+        incident_description: str,
+        **kwargs,
+    ):
         return


### PR DESCRIPTION
I've removed resolution by `service_name` because dispatch never passes such a value. If we want to support service name in the future it would be by detecting a name via the `service_id` value.