### PR TITLE
Fixes bug when tagging incidents

### DIFF
--- a/src/dispatch/incident/models.py
+++ b/src/dispatch/incident/models.py
@@ -45,6 +45,7 @@ from dispatch.participant_role.models import ParticipantRole, ParticipantRoleTyp
 from dispatch.report.enums import ReportTypes
 from dispatch.report.models import ReportRead
 from dispatch.storage.models import StorageRead
+from dispatch.tag.models import TagRead
 from dispatch.ticket.models import TicketRead
 from dispatch.workflow.models import WorkflowInstanceRead
 
@@ -285,7 +286,7 @@ class IncidentRead(IncidentBase):
     storage: Optional[StorageRead] = None
     ticket: Optional[TicketRead] = None
     documents: Optional[List[DocumentRead]] = []
-    tags: Optional[List[Any]] = []  # any until we figure out circular imports
+    tags: Optional[List[TagRead]] = []
     terms: Optional[List[Any]] = []  # any until we figure out circular imports
     conference: Optional[ConferenceRead] = None
     conversation: Optional[ConversationRead] = None

--- a/src/dispatch/static/dispatch/src/tag/TagFilterCombobox.vue
+++ b/src/dispatch/static/dispatch/src/tag/TagFilterCombobox.vue
@@ -49,7 +49,7 @@ export default {
     },
     label: {
       type: String,
-      defualt: "Add Tags"
+      default: "Add Tags"
     }
   },
   data() {

--- a/src/dispatch/tag/models.py
+++ b/src/dispatch/tag/models.py
@@ -35,7 +35,7 @@ class TagBase(DispatchBase):
 
 
 class TagCreate(TagBase):
-    tag_type: Optional[TagTypeCreate]
+    tag_type: TagTypeCreate
 
 
 class TagUpdate(TagBase):

--- a/src/dispatch/tag/models.py
+++ b/src/dispatch/tag/models.py
@@ -35,7 +35,7 @@ class TagBase(DispatchBase):
 
 
 class TagCreate(TagBase):
-    tag_type: TagTypeCreate
+    tag_type: Optional[TagTypeCreate]
 
 
 class TagUpdate(TagBase):


### PR DESCRIPTION
Replaces `Any` with `TagRead` in the `IncidentRead` Pydantic model to ensure we get the whole `Tag` object and any related objects such as `TagType` in the UI. Also fixes typo in `TagFilterCombobox`.