### PR TITLE
Ensures non-incident commands can be run from all conversations where the bot is present

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -208,12 +208,18 @@ def get_user_avatar_url(client: Any, email: str):
 
 @functools.lru_cache()
 async def get_conversations_by_user_id_async(client: Any, user_id: str):
-    """Gets the list of conversations a user is a member of."""
+    """Gets the list of public and private conversations a user is a member of."""
     result = await make_call_async(
-        client, "users.conversations", user=user_id, types="public_channel", exclude_archived=True
+        client, "users.conversations", user=user_id, types="public_channel", exclude_archived=True,
     )
-    conversations = [c["name"] for c in result["channels"]]
-    return conversations
+    public_conversations = [c["name"] for c in result["channels"]]
+
+    result = await make_call_async(
+        client, "users.conversations", user=user_id, types="private_channel", exclude_archived=True,
+    )
+    private_conversations = [c["name"] for c in result["channels"]]
+
+    return public_conversations, private_conversations
 
 
 # note this will get slower over time, we might exclude archived to make it sane

--- a/src/dispatch/plugins/dispatch_slack/views.py
+++ b/src/dispatch/plugins/dispatch_slack/views.py
@@ -166,27 +166,30 @@ async def handle_command(
     if conversation:
         incident_id = conversation.incident_id
     else:
-        if command in [SLACK_COMMAND_REPORT_INCIDENT_SLUG, SLACK_COMMAND_LIST_INCIDENTS_SLUG]:
-            # We create an async Slack client
-            slack_async_client = dispatch_slack_service.create_slack_client(run_async=True)
-
-            # We get the list of conversations the Slack bot is a member of
-            conversations = await dispatch_slack_service.get_conversations_by_user_id_async(
-                slack_async_client, SLACK_APP_USER_SLUG
-            )
-
-            # We get the name of conversation where the command was run
-            conversation_name = command_details.get("channel_name")
-
-            if conversation_name not in conversations:
-                # We let the user know in which conversations they can run the command
-                return create_command_run_in_conversation_where_bot_not_present_message(
-                    command, conversations
-                )
-        else:
+        if command not in [SLACK_COMMAND_REPORT_INCIDENT_SLUG, SLACK_COMMAND_LIST_INCIDENTS_SLUG]:
             # We let the user know that incident-specific commands
             # can only be run in incident conversations
             return create_command_run_in_nonincident_conversation_message(command)
+
+        # We create an async Slack client
+        slack_async_client = dispatch_slack_service.create_slack_client(run_async=True)
+
+        # We get the list of public and private conversations the Slack bot is a member of
+        (
+            public_conversations,
+            private_conversations,
+        ) = await dispatch_slack_service.get_conversations_by_user_id_async(
+            slack_async_client, SLACK_APP_USER_SLUG
+        )
+
+        # We get the name of conversation where the command was run
+        conversation_name = command_details.get("channel_name")
+
+        if conversation_name not in public_conversations + private_conversations:
+            # We let the user know in which public conversations they can run the command
+            return create_command_run_in_conversation_where_bot_not_present_message(
+                command, public_conversations
+            )
 
     for f in command_functions(command):
         background_tasks.add_task(f, incident_id, command=command_details)


### PR DESCRIPTION
When a non-incident / command is run, we check if it was run in one of the public or private conversations the Dispatch bot is a member of. If it wasn't run from one of those channels, we send the user a list of public conversations they can run the command. We don't include the list of private ones, because we don't want to expose them.