### PR TITLE
Slack Commands: Handles channel not found error

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -242,9 +242,15 @@ def get_conversation_by_name(client: Any, name: str):
 
 async def get_conversation_name_by_id_async(client: Any, conversation_id: str):
     """Fetches a conversation by id and returns its name."""
-    return (await make_call_async(client, "conversations.info", channel=conversation_id))[
-        "channel"
-    ]["name"]
+    try:
+        return (await make_call_async(client, "conversations.info", channel=conversation_id))[
+            "channel"
+        ]["name"]
+    except slack.errors.SlackApiError as e:
+        if e.response["error"] == "channel_not_found":
+            return None
+        else:
+            raise e
 
 
 def set_conversation_topic(client: Any, conversation_id: str, topic: str):

--- a/src/dispatch/plugins/dispatch_slack/views.py
+++ b/src/dispatch/plugins/dispatch_slack/views.py
@@ -188,7 +188,10 @@ async def handle_command(
             slack_async_client, conversation_id
         )
 
-        if conversation_name not in public_conversations + private_conversations:
+        if (
+            not conversation_name
+            or conversation_name not in public_conversations + private_conversations
+        ):
             # We let the user know in which public conversations they can run the command
             return create_command_run_in_conversation_where_bot_not_present_message(
                 command, public_conversations


### PR DESCRIPTION
Handles a situation where a user tries to run a non incident specific command such as `/dispatch-list-incidents` in a private channel where Dispatch bot is not a member of.