### PR TITLE
Asks the commander to review the incident's information on incident close

### DIFF
--- a/src/dispatch/incident/flows.py
+++ b/src/dispatch/incident/flows.py
@@ -53,16 +53,17 @@ from dispatch.ticket import service as ticket_service
 from dispatch.ticket.models import TicketCreate
 
 from .messaging import (
-    send_incident_update_notifications,
+    get_suggested_document_items,
+    send_incident_closed_information_review_reminder,
     send_incident_commander_readded_notification,
     send_incident_new_role_assigned_notification,
     send_incident_notifications,
     send_incident_participant_announcement_message,
     send_incident_resources_ephemeral_message_to_participant,
     send_incident_review_document_notification,
-    send_incident_welcome_participant_messages,
     send_incident_suggested_reading_messages,
-    get_suggested_document_items,
+    send_incident_update_notifications,
+    send_incident_welcome_participant_messages,
 )
 from .models import Incident, IncidentStatus
 
@@ -771,6 +772,10 @@ def incident_closed_flow(incident_id: int, command: Optional[dict] = None, db_se
             storage_plugin = plugin_service.get_active(db_session=db_session, plugin_type="storage")
             if storage_plugin:
                 storage_plugin.instance.open(incident.storage.resource_id)
+
+    # we send a direct message to the incident commander asking to review
+    # the incident's information and to tag the incident if appropiate
+    send_incident_closed_information_review_reminder(incident, db_session)
 
     # we delete the tactical and notification groups
     delete_participant_groups(incident, db_session)

--- a/src/dispatch/incident/messaging.py
+++ b/src/dispatch/incident/messaging.py
@@ -739,7 +739,6 @@ def send_incident_closed_information_review_reminder(incident: Incident, db_sess
             "description": incident.description,
             "type": incident.incident_type.name,
             "priority": incident.incident_priority.name,
-            "ticket_weblink": incident.ticket.weblink,
             "dispatch_ui_url": DISPATCH_UI_URL,
         }
     ]

--- a/src/dispatch/incident/messaging.py
+++ b/src/dispatch/incident/messaging.py
@@ -18,6 +18,7 @@ from dispatch.incident import service as incident_service
 from dispatch.incident.enums import IncidentStatus
 from dispatch.incident.models import Incident, IncidentRead
 from dispatch.messaging import (
+    INCIDENT_CLOSED_INFORMATION_REVIEW_REMINDER_NOTIFICATION,
     INCIDENT_COMMANDER,
     INCIDENT_COMMANDER_READDED_NOTIFICATION,
     INCIDENT_NAME,
@@ -31,8 +32,8 @@ from dispatch.messaging import (
     INCIDENT_RESOURCES_MESSAGE,
     INCIDENT_REVIEW_DOCUMENT,
     INCIDENT_STATUS_CHANGE,
-    INCIDENT_TYPE_CHANGE,
     INCIDENT_STATUS_REMINDER,
+    INCIDENT_TYPE_CHANGE,
     MessageType,
 )
 from dispatch.document import service as document_service
@@ -689,7 +690,7 @@ def send_incident_close_reminder(incident: Incident, db_session: SessionLocal):
 
     plugin = plugin_service.get_active(db_session=db_session, plugin_type="conversation")
     if not plugin:
-        log.warning("Incident close reminder message not set, no conversation plugin enabled.")
+        log.warning("Incident close reminder message not sent, no conversation plugin enabled.")
         return
 
     update_command = plugin.instance.get_command_name(ConversationCommands.update_incident)
@@ -713,3 +714,42 @@ def send_incident_close_reminder(incident: Incident, db_session: SessionLocal):
     )
 
     log.debug(f"Incident close reminder sent to {incident.commander.email}.")
+
+
+def send_incident_closed_information_review_reminder(incident: Incident, db_session: SessionLocal):
+    """
+    Sends a direct message to the incident commander
+    asking them to review the incident's information
+    and to tag the incident if appropriate.
+    """
+    message_text = "Incident Closed Information Review Reminder"
+    message_template = INCIDENT_CLOSED_INFORMATION_REVIEW_REMINDER_NOTIFICATION
+
+    plugin = plugin_service.get_active(db_session=db_session, plugin_type="conversation")
+    if not plugin:
+        log.warning(
+            "Incident closed information review reminder message not sent, no conversation plugin enabled."
+        )
+        return
+
+    items = [
+        {
+            "name": incident.name,
+            "title": incident.title,
+            "description": incident.description,
+            "type": incident.incident_type.name,
+            "priority": incident.incident_priority.name,
+            "ticket_weblink": incident.ticket.weblink,
+            "dispatch_ui_url": DISPATCH_UI_URL,
+        }
+    ]
+
+    plugin.instance.send_direct(
+        incident.commander.email,
+        message_text,
+        message_template,
+        MessageType.incident_closed_information_review_reminder,
+        items=items,
+    )
+
+    log.debug(f"Incident closed information review reminder sent to {incident.commander.email}.")

--- a/src/dispatch/messaging.py
+++ b/src/dispatch/messaging.py
@@ -503,7 +503,7 @@ INCIDENT_COMMANDER_READDED_NOTIFICATION = [
 INCIDENT_CLOSED_INFORMATION_REVIEW_REMINDER_NOTIFICATION = [
     {
         "title": "{{name}} Incident - Information Review Reminder",
-        "title_link": "{{ticket_weblink}}",
+        "title_link": "{{dispatch_ui_url}}",
         "text": INCIDENT_CLOSED_INFORMATION_REVIEW_REMINDER_DESCRIPTION,
     }
 ]

--- a/src/dispatch/messaging.py
+++ b/src/dispatch/messaging.py
@@ -20,17 +20,18 @@ from .config import (
 
 
 class MessageType(str, Enum):
+    incident_closed_information_review_reminder = "incident-closed-information-review-reminder"
     incident_daily_summary = "incident-daily-summary"
     incident_daily_summary_no_incidents = "incident-daily-summary-no-incidents"
     incident_executive_report = "incident-executive-report"
     incident_notification = "incident-notification"
+    incident_participant_suggested_reading = "incident-participant-suggested-reading"
     incident_participant_welcome = "incident-participant-welcome"
     incident_resources_message = "incident-resources-message"
+    incident_status_reminder = "incident-status-reminder"
     incident_tactical_report = "incident-tactical-report"
     incident_task_list = "incident-task-list"
     incident_task_reminder = "incident-task-reminder"
-    incident_status_reminder = "incident-status-reminder"
-    incident_participant_suggested_reading = "incident-participant-suggested-reading"
 
 
 INCIDENT_STATUS_DESCRIPTIONS = {
@@ -251,6 +252,9 @@ This workflow's status has changed from *{{ instance_status_old }}* to *{{ insta
 \n\n {% for a in instance_artifacts %}- <{{a.weblink}}|{{a.name}}> \n\n{% endfor %}
 {% endif %}
 """
+
+INCIDENT_CLOSED_INFORMATION_REVIEW_REMINDER_DESCRIPTION = """
+Thanks for closing incident {{name}}. Is the following incident information up to date? If not, please edit the incident in the <{{dispatch_ui_url}}|Dispatch Web UI>. Also, consider tagging the incident using the Web UI if appropiate.\n\n*Title:* {{title}}\n*Description:* {{description}}\n*Incident Type:* {{type}}\n*Incident Priority:* {{priority}}"""
 
 INCIDENT_TYPE_CHANGE_DESCRIPTION = """
 The incident type has been changed from *{{ incident_type_old }}* to *{{ incident_type_new }}*."""
@@ -494,6 +498,14 @@ INCIDENT_WORKFLOW_COMPLETE_NOTIFICATION = [
 
 INCIDENT_COMMANDER_READDED_NOTIFICATION = [
     {"title": "Incident Commander Re-Added", "text": INCIDENT_COMMANDER_READDED_DESCRIPTION}
+]
+
+INCIDENT_CLOSED_INFORMATION_REVIEW_REMINDER_NOTIFICATION = [
+    {
+        "title": "{{name}} Incident - Information Review Reminder",
+        "title_link": "{{ticket_weblink}}",
+        "text": INCIDENT_CLOSED_INFORMATION_REVIEW_REMINDER_DESCRIPTION,
+    }
 ]
 
 

--- a/src/dispatch/messaging.py
+++ b/src/dispatch/messaging.py
@@ -254,7 +254,7 @@ This workflow's status has changed from *{{ instance_status_old }}* to *{{ insta
 """
 
 INCIDENT_CLOSED_INFORMATION_REVIEW_REMINDER_DESCRIPTION = """
-Thanks for closing incident {{name}}. Is the following incident information up to date? If not, please edit the incident in the <{{dispatch_ui_url}}|Dispatch Web UI>. Also, consider tagging the incident using the Web UI if appropiate.\n\n*Title:* {{title}}\n*Description:* {{description}}\n*Incident Type:* {{type}}\n*Incident Priority:* {{priority}}"""
+Thanks for closing incident {{name}}. Is the following incident information up to date? If not, please edit the incident in the <{{dispatch_ui_url}}|Dispatch Web UI>. If it's appropriate, consider adding relevant tags to the incident using the Web UI. This will help us solve similar incidents faster.\n\n*Title:* {{title}}\n*Description:* {{description}}\n*Incident Type:* {{type}}\n*Incident Priority:* {{priority}}"""
 
 INCIDENT_TYPE_CHANGE_DESCRIPTION = """
 The incident type has been changed from *{{ incident_type_old }}* to *{{ incident_type_new }}*."""

--- a/src/dispatch/messaging.py
+++ b/src/dispatch/messaging.py
@@ -254,7 +254,7 @@ This workflow's status has changed from *{{ instance_status_old }}* to *{{ insta
 """
 
 INCIDENT_CLOSED_INFORMATION_REVIEW_REMINDER_DESCRIPTION = """
-Thanks for closing incident {{name}}. Is the following incident information up to date? If not, please edit the incident in the <{{dispatch_ui_url}}|Dispatch Web UI>. If it's appropriate, consider adding relevant tags to the incident using the Web UI. This will help us solve similar incidents faster.\n\n*Title:* {{title}}\n*Description:* {{description}}\n*Incident Type:* {{type}}\n*Incident Priority:* {{priority}}"""
+Thanks for closing incident {{name}}. Is the following incident information up to date? If not, please edit the incident in the <{{dispatch_ui_url}}|Dispatch Web UI>. If it's appropriate, consider adding relevant tags to the incident using the Web UI. This will help us correlate incidents and generate metrics.\n\n*Title:* {{title}}\n*Description:* {{description}}\n*Incident Type:* {{type}}\n*Incident Priority:* {{priority}}"""
 
 INCIDENT_TYPE_CHANGE_DESCRIPTION = """
 The incident type has been changed from *{{ incident_type_old }}* to *{{ incident_type_new }}*."""

--- a/src/dispatch/plugins/dispatch_slack/messaging.py
+++ b/src/dispatch/plugins/dispatch_slack/messaging.py
@@ -189,6 +189,10 @@ def get_template(message_type: MessageType):
             None,
         ),
         MessageType.incident_task_list: (default_notification, INCIDENT_TASK_LIST_DESCRIPTION),
+        MessageType.incident_closed_information_review_reminder: (
+            default_notification,
+            None,
+        ),
     }
 
     template_func, description = template_map.get(message_type, (None, None))

--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -48,11 +48,11 @@ from .service import (
     list_conversations,
     message_filter,
     open_dialog_with_user,
+    open_modal_with_user,
     resolve_user,
     send_ephemeral_message,
     send_message,
     set_conversation_topic,
-    open_modal_with_user,
 )
 
 


### PR DESCRIPTION
This PR adds a reminder for the incident commander to review the incident's information and to tag the incident when the incident is closed.

<img width="634" alt="Screen Shot 2020-10-16 at 1 24 59 PM" src="https://user-images.githubusercontent.com/39573146/96305778-4a987480-0fb3-11eb-80b2-be3bea4ea9a4.png">
