### PR TITLE
Improves formatting of some Slack messages

### DIFF
--- a/src/dispatch/incident/scheduled.py
+++ b/src/dispatch/incident/scheduled.py
@@ -5,6 +5,7 @@ from schedule import every
 from sqlalchemy import func
 
 from dispatch.config import (
+    DISPATCH_UI_URL,
     INCIDENT_ONCALL_SERVICE_ID,
     INCIDENT_NOTIFICATION_CONVERSATIONS,
 )
@@ -93,8 +94,11 @@ def daily_summary(db_session=None):
     blocks = []
     blocks.append(
         {
-            "type": "section",
-            "text": {"type": "mrkdwn", "text": f"*{INCIDENT_DAILY_SUMMARY_DESCRIPTION}*"},
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": f":rotating_light: {INCIDENT_DAILY_SUMMARY_DESCRIPTION} :rotating_light:",
+            },
         }
     )
 
@@ -136,6 +140,18 @@ def daily_summary(db_session=None):
                     )
                 except Exception as e:
                     log.exception(e)
+
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"For more information about active incidents, please visit the active incidents status <{DISPATCH_UI_URL}/incidents/status|page>.",
+                    }
+                ],
+            }
+        )
     else:
         blocks.append(
             {

--- a/src/dispatch/incident/scheduled.py
+++ b/src/dispatch/incident/scheduled.py
@@ -97,7 +97,7 @@ def daily_summary(db_session=None):
             "type": "header",
             "text": {
                 "type": "plain_text",
-                "text": f":rotating_light: {INCIDENT_DAILY_SUMMARY_DESCRIPTION} :rotating_light:",
+                "text": f"{INCIDENT_DAILY_SUMMARY_DESCRIPTION}",
             },
         }
     )

--- a/src/dispatch/messaging.py
+++ b/src/dispatch/messaging.py
@@ -9,7 +9,6 @@ from dispatch.conversation.enums import ConversationButtonActions
 from dispatch.incident.enums import IncidentStatus
 
 from .config import (
-    DISPATCH_UI_URL,
     INCIDENT_RESOURCE_CONVERSATION_REFERENCE_DOCUMENT,
     INCIDENT_RESOURCE_EXECUTIVE_REPORT_DOCUMENT,
     INCIDENT_RESOURCE_INCIDENT_FAQ_DOCUMENT,
@@ -53,8 +52,8 @@ Daily Incidents Summary""".replace(
     "\n", " "
 ).strip()
 
-INCIDENT_DAILY_SUMMARY_ACTIVE_INCIDENTS_DESCRIPTION = f"""
-Active Incidents (<{DISPATCH_UI_URL}/incidents/status|Details>)""".replace(
+INCIDENT_DAILY_SUMMARY_ACTIVE_INCIDENTS_DESCRIPTION = """
+Active Incidents""".replace(
     "\n", " "
 ).strip()
 

--- a/src/dispatch/plugins/dispatch_slack/commands.py
+++ b/src/dispatch/plugins/dispatch_slack/commands.py
@@ -313,7 +313,7 @@ def list_incidents(incident_id: int, command: dict = None, db_session=None):
     )
 
     blocks = []
-    blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "*List of Incidents*"}})
+    blocks.append({"type": "header", "text": {"type": "plain_text", "text": "List of Incidents"}})
 
     if incidents:
         for incident in incidents:

--- a/src/dispatch/plugins/dispatch_slack/messaging.py
+++ b/src/dispatch/plugins/dispatch_slack/messaging.py
@@ -145,10 +145,17 @@ def create_command_run_in_conversation_where_bot_not_present_message(
 
 
 def create_incident_reported_confirmation_message(
-    title: str, incident_type: str, incident_priority: str
+    title: str, description: str, incident_type: str, incident_priority: str
 ):
     """Creates an incident reported confirmation message."""
     return [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "Security Incident Reported",
+            },
+        },
         {
             "type": "section",
             "text": {
@@ -157,6 +164,10 @@ def create_incident_reported_confirmation_message(
             },
         },
         {"type": "section", "text": {"type": "mrkdwn", "text": f"*Incident Title*: {title}"}},
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*Incident Description*: {description}"},
+        },
         {
             "type": "section",
             "text": {"type": "mrkdwn", "text": f"*Incident Type*: {incident_type}"},
@@ -204,7 +215,7 @@ def format_default_text(item: dict):
     if item.get("title_link"):
         return f"*<{item['title_link']}|{item['title']}>*\n{item['text']}"
     if item.get("datetime"):
-        return f"*{item['title']}* \n <!date^{int(item['datetime'].timestamp())}^ {{date}} | {item['datetime']}"
+        return f"*{item['title']}*\n <!date^{int(item['datetime'].timestamp())}^ {{date}} | {item['datetime']}"
     return f"*{item['title']}*\n{item['text']}"
 
 
@@ -219,7 +230,10 @@ def default_notification(items: list):
         if item.get("title_link") == "None":  # avoid adding blocks with no data
             continue
 
-        block = {"type": "section", "text": {"type": "mrkdwn", "text": format_default_text(item)}}
+        block = {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": format_default_text(item)},
+        }
 
         if item.get("button_text") and item.get("button_value"):
             block.update(

--- a/src/dispatch/plugins/dispatch_slack/modals.py
+++ b/src/dispatch/plugins/dispatch_slack/modals.py
@@ -146,6 +146,7 @@ def report_incident_from_submitted_form(action: dict, db_session: Session = None
     # Send a confirmation to the user
     blocks = create_incident_reported_confirmation_message(
         title=requested_form_title,
+        description=requested_form_description,
         incident_type=requested_form_incident_type.get("value"),
         incident_priority=requested_form_incident_priority.get("value"),
     )


### PR DESCRIPTION
Leverages the new `header` block type to improve some of the Slack messages.
<img width="612" alt="Screen Shot 2020-10-16 at 2 28 09 PM" src="https://user-images.githubusercontent.com/39573146/96310701-b9c69680-0fbc-11eb-918b-0c5fe1772d13.png">
<img width="294" alt="Screen Shot 2020-10-16 at 2 28 33 PM" src="https://user-images.githubusercontent.com/39573146/96310702-baf7c380-0fbc-11eb-9cc6-262ba75a4ff7.png">
<img width="638" alt="Screen Shot 2020-10-16 at 2 29 38 PM" src="https://user-images.githubusercontent.com/39573146/96310705-bc28f080-0fbc-11eb-8768-54812fcaddda.png">
