### PR TITLE
Fixes VueJS individual api param names

### DIFF
--- a/src/dispatch/static/dispatch/src/individual/api.js
+++ b/src/dispatch/static/dispatch/src/individual/api.js
@@ -7,19 +7,19 @@ export default {
     return API.get(`${resource}/`, { params: { ...options } })
   },
 
-  get(termId) {
-    return API.get(`${resource}/${termId}`)
+  get(individualId) {
+    return API.get(`${resource}/${individualId}`)
   },
 
   create(payload) {
     return API.post(`${resource}/`, payload)
   },
 
-  update(termId, payload) {
-    return API.put(`${resource}/${termId}`, payload)
+  update(individualId, payload) {
+    return API.put(`${resource}/${individualId}`, payload)
   },
 
-  delete(termId) {
-    return API.delete(`${resource}/${termId}`)
+  delete(individualId) {
+    return API.delete(`${resource}/${individualId}`)
   }
 }


### PR DESCRIPTION
Renames API param `termId` to `individualId`.