### PR TITLE
Unused db connection fix

### DIFF
--- a/src/dispatch/auth/views.py
+++ b/src/dispatch/auth/views.py
@@ -108,4 +108,4 @@ def get_me(
     req: Request,
     db_session: Session = Depends(get_db),
 ):
-    return get_current_user(request=req)
+    return get_current_user(db_session=db_session, request=req)


### PR DESCRIPTION
Both get_me (/auth/views.py) and get_current_user() (/auth/service.py) depend on db_session, but auth/me doesn't pass it when calling get_current_user(), hence creating two db_session for handeling one request. Sorry for not bumping dispatch/__about__.py, this is my first open source commit and I'm unable to locate that file. 