### PR TITLE
Fixed two typos in docs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -194,7 +194,7 @@ The `revision` command is an `alembic` command that creates a new database schem
 It's most often used with the `--autogenerate` flag:
 
 ```bash
-> dispatch database revision --autoge
+> dispatch database revision --autogenerate
 ```
 
 ### Upgrade/Downgrade

--- a/docs/contributing/environment.md
+++ b/docs/contributing/environment.md
@@ -105,6 +105,6 @@ Install required node modules with `npm` :
 Test the development server:
 
 ```bash
-> npm run server
+> npm run serve
 ```
 


### PR DESCRIPTION
During local deploy of dispatch I found some typos in the commands in the documentation.