### PR TITLE
Adds a tracking only checkbox and fixes commander rendering

### DIFF
--- a/src/dispatch/static/dispatch/src/incident/ReportReceiptCard.vue
+++ b/src/dispatch/static/dispatch/src/incident/ReportReceiptCard.vue
@@ -3,9 +3,9 @@
     <v-card-text>
       <p class="display-2 text--primary">Security Incident Report</p>
       <p>
-        This page will be populated with incident resources as they are created. If you have any
-        questions, please feel free to review the Frequently Asked Questions (FAQ) document linked
-        below, and/or reach out to the listed Incident Commander.
+        This page will be populated with incident resources as they are created (if available). If
+        you have any questions, please feel free to review the Frequently Asked Questions (FAQ)
+        document linked below, and/or reach out to the listed Incident Commander.
       </p>
       <v-list three-line>
         <v-list-group :value="true">
@@ -14,13 +14,13 @@
           </template>
           <v-list-item-group>
             <v-list-item
-              :href="commander.weblink"
+              :href="commander.individual.weblink"
               target="_blank"
               title="The Incident Commander maintains all necessary context, and drives the incident to resolution."
             >
               <v-list-item-content>
                 <v-list-item-title>Commander</v-list-item-title>
-                <v-list-item-subtitle>{{ commander.name }}</v-list-item-subtitle>
+                <v-list-item-subtitle>{{ commander.individual.name }}</v-list-item-subtitle>
               </v-list-item-content>
               <v-list-item-action>
                 <v-list-item-icon>
@@ -66,7 +66,7 @@
           </v-list-item-group>
         </v-list-group>
       </v-list>
-      <v-list three-line>
+      <v-list three-line v-if="!trackingOnly">
         <v-list-group :value="true">
           <template v-slot:activator>
             <v-list-item-title class="title">Incident Resources</v-list-item-title>
@@ -260,6 +260,7 @@ export default {
       "selected.visibility",
       "selected.storage",
       "selected.documents",
+      "selected.trackingOnly",
       "selected.loading",
       "selected.ticket",
       "selected.id"

--- a/src/dispatch/static/dispatch/src/incident/ReportSubmissionCard.vue
+++ b/src/dispatch/static/dispatch/src/incident/ReportSubmissionCard.vue
@@ -51,6 +51,24 @@
               <v-flex xs12>
                 <tag-filter-combobox v-model="tags" label="Tags"></tag-filter-combobox>
               </v-flex>
+              <v-flex xs12>
+                <v-checkbox v-model="trackingOnly" label="Tracking Only">
+                  <template v-slot:label>
+                    <div>
+                      Tracking Only
+                      <v-tooltip bottom>
+                        <template v-slot:activator="{ on, attrs }">
+                          <v-icon v-bind="attrs" v-on="on">
+                            help_outline
+                          </v-icon>
+                        </template>
+                        This incident does not require additional action. No incident resources will
+                        be created for this incident.
+                      </v-tooltip>
+                    </div>
+                  </template>
+                </v-checkbox>
+              </v-flex>
             </v-layout>
             <template>
               <v-btn
@@ -102,7 +120,6 @@ export default {
       isSubmitted: false
     }
   },
-  mounted() {},
   computed: {
     ...mapFields("incident", [
       "selected.incident_priority",
@@ -118,6 +135,7 @@ export default {
       "selected.documents",
       "selected.loading",
       "selected.ticket",
+      "selected.trackingOnly",
       "selected.id"
     ])
   },

--- a/src/dispatch/static/dispatch/src/incident/store.js
+++ b/src/dispatch/static/dispatch/src/incident/store.js
@@ -29,6 +29,7 @@ const getDefaultSelectedState = () => {
     workflow_instances: null,
     title: null,
     visibility: null,
+    trackingOnly: null,
     loading: false
   }
 }
@@ -150,6 +151,9 @@ const actions = {
   },
   report({ commit, dispatch }) {
     commit("SET_SELECTED_LOADING", true)
+    if (state.selected.trackingOnly === true) {
+      state.selected.status = "Closed"
+    }
     return IncidentApi.create(state.selected)
       .then(response => {
         commit("SET_SELECTED", response.data)


### PR DESCRIPTION
Adds a tracking only checkbox, that creates a new incident in the "closed" state. Meaning no incident resources will be created for it. 

![Screenshot from 2021-01-07 13-44-48](https://user-images.githubusercontent.com/2262214/103948369-880e2900-50ee-11eb-8f1a-3eea189c3bf7.png)
