### PR TITLE
Makes incident conversation creation more robust

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -86,10 +86,9 @@ class SlackConversationPlugin(ConversationPlugin):
     def __init__(self):
         self.client = slack.WebClient(token=str(SLACK_API_BOT_TOKEN))
 
-    def create(self, name: str, participants: List[dict], is_private: bool = True):
-        """Creates a new slack conversation."""
-        participants = [resolve_user(self.client, p)["id"] for p in participants]
-        return create_conversation(self.client, name, participants, is_private)
+    def create(self, name: str, is_private: bool = True):
+        """Creates a new Slack conversation."""
+        return create_conversation(self.client, name, is_private)
 
     def send(
         self,

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -99,8 +99,7 @@ SLACK_GET_ENDPOINTS = [
 
 @retry(stop=stop_after_attempt(5), retry=retry_if_exception_type(TryAgain))
 def make_call(client: Any, endpoint: str, **kwargs):
-    """Make an slack client api call."""
-
+    """Make an Slack client api call."""
     try:
         if endpoint in SLACK_GET_ENDPOINTS:
             response = client.api_call(endpoint, http_verb="GET", params=kwargs)
@@ -133,7 +132,7 @@ def make_call(client: Any, endpoint: str, **kwargs):
 
 
 async def make_call_async(client: Any, endpoint: str, **kwargs):
-    """Make an slack client api call."""
+    """Make an Slack client api call."""
 
     try:
         if endpoint in SLACK_GET_ENDPOINTS:
@@ -267,19 +266,15 @@ def set_conversation_purpose(client: Any, conversation_id: str, purpose: str):
     return make_call(client, "conversations.setPurpose", channel=conversation_id, purpose=purpose)
 
 
-def create_conversation(client: Any, name: str, participants: List[str], is_private: bool = False):
-    """Make a new slack conversation."""
-    participants = list(set(participants))
+def create_conversation(client: Any, name: str, is_private: bool = False):
+    """Make a new Slack conversation."""
     response = make_call(
         client,
         "conversations.create",
         name=name.lower(),  # slack disallows upperCase
         is_group=is_private,
         is_private=is_private,
-        # user_ids=participants,  # NOTE this allows for 30 folks max
     )["channel"]
-
-    add_users_to_conversation(client, response["id"], participants)
 
     return {
         "id": response["id"],

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -117,6 +117,10 @@ def make_call(client: Any, endpoint: str, **kwargs):
         if e.response["error"] == "user_not_in_channel":
             raise TryAgain
 
+        # NOTE we've experienced a wide range of issues when Slack's performance is degraded
+        if e.response["error"] == "fatal_error":
+            raise TryAgain
+
         if e.response.headers.get("Retry-After"):
             wait = int(e.response.headers["Retry-After"])
             log.info(f"SlackError: Rate limit hit. Waiting {wait} seconds.")

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -118,6 +118,8 @@ def make_call(client: Any, endpoint: str, **kwargs):
 
         # NOTE we've experienced a wide range of issues when Slack's performance is degraded
         if e.response["error"] == "fatal_error":
+            # we wait 5 minutes before trying again, as performance issues take time to troubleshoot and fix
+            time.sleep(300)
             raise TryAgain
 
         if e.response.headers.get("Retry-After"):


### PR DESCRIPTION
This PR decouples incident channel creation from adding participants to it. Now we wait after the incident conversation has been created via the plugin and in the database to add participants to it.

Additionally, we will also retry when Slack API calls return `fatal_error`, which seems to be when Slack's performance is downgraded.