### PR TITLE
Allows incident details to be more flexible

### DIFF
--- a/src/dispatch/database.py
+++ b/src/dispatch/database.py
@@ -134,7 +134,7 @@ def create_filter_spec(model, fields, ops, values, user_role):
         if model.lower() in ["incident", "task"]:
             filter_spec.append(
                 {
-                    "model": model,
+                    "model": "Incident",
                     "field": "visibility",
                     "op": "!=",
                     "value": Visibility.restricted,

--- a/src/dispatch/static/dispatch/src/components/AppDrawer.vue
+++ b/src/dispatch/static/dispatch/src/components/AppDrawer.vue
@@ -59,9 +59,9 @@ export default {
       {
         action: "error_outline",
         items: [
-          { title: "List", route: "/incidents/list" },
-          { title: "Tasks", route: "/incidents/tasks" },
-          { title: "Feedback", route: "/incidents/feedback" }
+          { title: "Incidents", route: "/incidents" },
+          { title: "Tasks", route: "/tasks" },
+          { title: "Feedback", route: "/feedback" }
         ],
         title: "Incident"
       },

--- a/src/dispatch/static/dispatch/src/incident/EditSheet.vue
+++ b/src/dispatch/static/dispatch/src/incident/EditSheet.vue
@@ -1,6 +1,6 @@
 <template>
   <ValidationObserver v-slot="{ invalid, validated }">
-    <v-navigation-drawer v-model="showEditSheet" app clipped right width="800">
+    <v-navigation-drawer app clipped right width="800">
       <template v-slot:prepend>
         <v-list-item two-line>
           <v-list-item-content>
@@ -78,6 +78,8 @@ export default {
     }
   },
 
+  props: ["incidentName"],
+
   computed: {
     ...mapFields("incident", [
       "selected.id",
@@ -88,8 +90,21 @@ export default {
     ])
   },
 
+  created() {
+    this.fetchDetails()
+  },
+
+  watch: {
+    $route() {
+      this.fetchDetails()
+    }
+  },
+
   methods: {
-    ...mapActions("incident", ["save", "closeEditSheet"])
+    fetchDetails() {
+      this.getDetails({ name: this.$route.params.name })
+    },
+    ...mapActions("incident", ["save", "getDetails", "closeEditSheet"])
   }
 }
 </script>

--- a/src/dispatch/static/dispatch/src/incident/Table.vue
+++ b/src/dispatch/static/dispatch/src/incident/Table.vue
@@ -1,6 +1,8 @@
 <template>
   <v-layout wrap>
-    <edit-sheet />
+    <div v-if="showEditSheet">
+      <router-view></router-view>
+    </div>
     <new-sheet />
     <delete-dialog />
     <div class="headline">Incidents</div>
@@ -59,7 +61,7 @@
                     </v-btn>
                   </template>
                   <v-list>
-                    <v-list-item @click="showEditSheet(item)">
+                    <v-list-item :to="`/incidents/${item.name}`">
                       <v-list-item-title>View / Edit</v-list-item-title>
                     </v-list-item>
                     <v-list-item @click="showDeleteDialog(item)">
@@ -82,7 +84,6 @@ import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import BulkEditSheet from "@/incident/BulkEditSheet.vue"
 import DeleteDialog from "@/incident/DeleteDialog.vue"
-import EditSheet from "@/incident/EditSheet.vue"
 import IncidentParticipant from "@/incident/Participant.vue"
 import IncidentPriority from "@/incident/IncidentPriority.vue"
 import IncidentStatus from "@/incident/IncidentStatus.vue"
@@ -96,7 +97,6 @@ export default {
   components: {
     BulkEditSheet,
     DeleteDialog,
-    EditSheet,
     IncidentParticipant,
     IncidentPriority,
     IncidentStatus,
@@ -119,7 +119,8 @@ export default {
         { text: "Commander", value: "commander", sortable: false },
         { text: "Reported At", value: "reported_at" },
         { text: "", value: "data-table-actions", sortable: false, align: "end" }
-      ]
+      ],
+      showEditSheet: false
     }
   },
 
@@ -143,11 +144,16 @@ export default {
     ])
   },
 
-  mounted() {
-    // process our props
-    if (this.name) {
-      this.q = this.name
+  watch: {
+    $route: {
+      immediate: true,
+      handler: function(newVal) {
+        this.showEditSheet = newVal.meta && newVal.meta.showEditSheet
+      }
     }
+  },
+
+  mounted() {
     this.getAll()
 
     this.$watch(
@@ -178,7 +184,7 @@ export default {
   },
 
   methods: {
-    ...mapActions("incident", ["getAll", "showNewSheet", "showEditSheet", "showDeleteDialog"])
+    ...mapActions("incident", ["getAll", "showNewSheet", "showDeleteDialog"])
   }
 }
 </script>

--- a/src/dispatch/static/dispatch/src/router/config.js
+++ b/src/dispatch/static/dispatch/src/router/config.js
@@ -58,35 +58,50 @@ export const protectedRoute = [
   {
     path: "/incidents",
     component: DefaultLayout,
-    redirect: "/incidents/list",
     meta: { title: "Incidents", icon: "view_compact", group: "incidents", requiresAuth: true },
     children: [
       {
-        path: "list",
+        path: "",
         name: "IncidentTable",
         meta: { title: "List" },
+        component: () => import(/* webpackChunkName: "incident-table" */ "@/incident/Table.vue"),
         children: [
           {
             path: ":name",
-            name: "IncidentTable",
             component: () =>
-              import(/* webpackChunkName: "incident-table" */ "@/incident/Table.vue"),
-            props: true
+              import(/* webpackChunkName: "incident-table" */ "@/incident/EditSheet.vue"),
+            props: true,
+            meta: {
+              showEditSheet: true
+            }
           }
-        ],
-        component: () => import(/* webpackChunkName: "incident-table" */ "@/incident/Table.vue")
-      },
+        ]
+      }
+    ]
+  },
+  {
+    path: "/tasks",
+    component: DefaultLayout,
+    meta: { title: "Tasks", icon: "view_compact", group: "tasks", requiresAuth: true },
+    children: [
       {
-        path: "tasks",
+        path: "",
         name: "TaskTable",
-        meta: { title: "Tasks" },
-        component: () => import(/* webpackChunkName: "knowledge-table" */ "@/task/Table.vue")
-      },
+        meta: { title: "List" },
+        component: () => import(/* webpackChunkName: "task-table" */ "@/task/Table.vue")
+      }
+    ]
+  },
+  {
+    path: "/feedback",
+    component: DefaultLayout,
+    meta: { title: "Feedback", icon: "view_compact", group: "feedback", requiresAuth: true },
+    children: [
       {
-        path: "feedback",
+        path: "",
         name: "FeedbackTable",
         meta: { title: "Feedback" },
-        component: () => import(/* webpackChunkName: "knowledge-table" */ "@/feedback/Table.vue")
+        component: () => import(/* webpackChunkName: "feedback-table" */ "@/feedback/Table.vue")
       }
     ]
   },
@@ -132,7 +147,8 @@ export const protectedRoute = [
         path: "/configuration/incidentTypes",
         name: "IncidentTypeTable",
         meta: { title: "Incident Types" },
-        component: () => import(/* webpackChunkName: "routing-table" */ "@/incident_type/Table.vue")
+        component: () =>
+          import(/* webpackChunkName: "incident-type-table" */ "@/incident_type/Table.vue")
       },
       {
         path: "/configuration/incidentPriorities",
@@ -145,31 +161,32 @@ export const protectedRoute = [
         path: "/configuration/notifications",
         name: "NotificationTable",
         meta: { title: "Notifications" },
-        component: () => import(/* webpackChunkName: "routing-table" */ "@/notification/Table.vue")
+        component: () =>
+          import(/* webpackChunkName: "notification-table" */ "@/notification/Table.vue")
       },
       {
         path: "/configuration/plugins",
         name: "PluginTable",
         meta: { title: "Plugins" },
-        component: () => import(/* webpackChunkName: "routing-table" */ "@/plugin/Table.vue")
+        component: () => import(/* webpackChunkName: "plugin-table" */ "@/plugin/Table.vue")
       },
       {
         path: "/configuration/tagTypes",
         name: "TagTypeTable",
         meta: { title: "Tag Types" },
-        component: () => import(/* webpackChunkName: "routing-table" */ "@/tag_type/Table.vue")
+        component: () => import(/* webpackChunkName: "tag-type-table" */ "@/tag_type/Table.vue")
       },
       {
         path: "/configuration/users",
         name: "UserTable",
         meta: { title: "Users" },
-        component: () => import(/* webpackChunkName: "routing-table" */ "@/auth/Table.vue")
+        component: () => import(/* webpackChunkName: "users-table" */ "@/auth/Table.vue")
       },
       {
         path: "/configuration/workflows",
         name: "WorkflowTable",
         meta: { title: "Workflows" },
-        component: () => import(/* webpackChunkName: "routing-table" */ "@/workflow/Table.vue")
+        component: () => import(/* webpackChunkName: "workflows-table" */ "@/workflow/Table.vue")
       }
     ]
   },
@@ -194,7 +211,7 @@ export const protectedRoute = [
         path: "teams",
         name: "TaamTable",
         meta: { title: "Teams" },
-        component: () => import(/* webpackChunkName: "individual-table" */ "@/team/Table.vue")
+        component: () => import(/* webpackChunkName: "team-table" */ "@/team/Table.vue")
       }
     ]
   },
@@ -213,7 +230,7 @@ export const protectedRoute = [
         path: "documents",
         name: "DocumentTable",
         meta: { title: "Documents" },
-        component: () => import(/* webpackChunkName: "definition-table" */ "@/document/Table.vue")
+        component: () => import(/* webpackChunkName: "document-table" */ "@/document/Table.vue")
       },
       {
         path: "definitions",
@@ -225,7 +242,7 @@ export const protectedRoute = [
         path: "terms",
         name: "TermTable",
         meta: { title: "Terms" },
-        component: () => import(/* webpackChunkName: "knowledge-table" */ "@/term/Table.vue")
+        component: () => import(/* webpackChunkName: "term-table" */ "@/term/Table.vue")
       }
     ]
   },

--- a/src/dispatch/tag/models.py
+++ b/src/dispatch/tag/models.py
@@ -45,7 +45,7 @@ class TagUpdate(TagBase):
 
 class TagRead(TagBase):
     id: int
-    tag_type: TagTypeRead
+    tag_type: Optional[TagTypeRead]
 
 
 class TagPagination(DispatchBase):


### PR DESCRIPTION
Allows for true incident details to be displayed. i.e. when a user enters `/incidents/fooBar` the details sheet is displayed with data about fooBar.

Additionally, we now reload an incident data when that details sheet is displayed. This will allow us to limit the number of fields we need to return when listing incidents which should speed up the table as the number of incidents grows.

We may also want to transition other modals where we want the URL to reflect some sort of page state, e.g. /tasks/:id

Addresses #797 