### PR TITLE
Sets default for Slack socket mode token

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/config.py
+++ b/src/dispatch/plugins/dispatch_slack/config.py
@@ -2,7 +2,7 @@ from dispatch.config import config, Secret
 
 # Configuration
 SLACK_API_BOT_TOKEN = config("SLACK_API_BOT_TOKEN", cast=Secret)
-SLACK_SOCKET_MODE_APP_TOKEN = config("SLACK_SOCKET_MODE_APP_TOKEN", cast=Secret)
+SLACK_SOCKET_MODE_APP_TOKEN = config("SLACK_SOCKET_MODE_APP_TOKEN", cast=Secret, default=None)
 SLACK_APP_USER_SLUG = config("SLACK_APP_USER_SLUG")
 SLACK_BAN_THREADS = config("SLACK_BAN_THREADS", default=True)
 SLACK_PROFILE_DEPARTMENT_FIELD_ID = config("SLACK_PROFILE_DEPARTMENT_FIELD_ID", default="")

--- a/src/dispatch/plugins/dispatch_slack/socket_mode.py
+++ b/src/dispatch/plugins/dispatch_slack/socket_mode.py
@@ -1,19 +1,28 @@
+import logging
+
 import asyncio
 from fastapi import BackgroundTasks
 
 from dispatch.database import SessionLocal
 from slack_sdk.web.async_client import AsyncWebClient
 
-from .config import SLACK_API_BOT_TOKEN, SLACK_SOCKET_MODE_APP_TOKEN
 from .actions import handle_slack_action
-from .events import handle_slack_event
 from .commands import handle_slack_command
+from .config import SLACK_API_BOT_TOKEN, SLACK_SOCKET_MODE_APP_TOKEN
+from .events import handle_slack_event
+
+
+log = logging.getLogger(__name__)
 
 
 async def run_websocket_process():
     from slack_sdk.socket_mode.aiohttp import SocketModeClient
     from slack_sdk.socket_mode.response import SocketModeResponse
     from slack_sdk.socket_mode.request import SocketModeRequest
+
+    if not SLACK_SOCKET_MODE_APP_TOKEN:
+        log.error("SLACK_SOCKET_MODE_APP_TOKEN not defined in .env file.")
+        return
 
     # Initialize SocketModeClient with an app-level token + WebClient
     client = SocketModeClient(


### PR DESCRIPTION
Let's allow the server to start even if `SLACK_SOCKET_MODE_APP_TOKEN` is not defined in the `.env` file. We will throw an error if it's not defined when the user runs `dispatch server slack`.