### PR TITLE
Restricts certain configuration aspects to admins only

### DIFF
--- a/src/dispatch/auth/views.py
+++ b/src/dispatch/auth/views.py
@@ -1,6 +1,8 @@
 from typing import List
+
 from fastapi import APIRouter, Depends, Request, HTTPException, Query
 from sqlalchemy.orm import Session
+
 from dispatch.database import get_db, search_filter_sort_paginate
 from dispatch.enums import UserRoles
 
@@ -21,6 +23,7 @@ from .service import (
     create,
     get_current_user,
 )
+
 
 auth_router = APIRouter()
 user_router = APIRouter()
@@ -86,7 +89,7 @@ def update_user(
 
         return user
 
-    raise HTTPException(status_code=401, detail="You do no have permission to modify users.")
+    raise HTTPException(status_code=403, detail="You do no have permission to modify users.")
 
 
 @auth_router.post("/login", response_model=UserLoginResponse)

--- a/src/dispatch/incident/views.py
+++ b/src/dispatch/incident/views.py
@@ -119,7 +119,7 @@ def get_incident(
             return incident
 
         raise HTTPException(
-            status_code=401, detail="You do not have permission to view this incident."
+            status_code=403, detail="You do not have permission to view this incident."
         )
 
     return incident
@@ -174,7 +174,7 @@ def update_incident(
             or current_user.role != UserRoles.admin
         ):
             raise HTTPException(
-                status_code=401, detail="You do not have permission to update this incident."
+                status_code=403, detail="You do not have permission to update this incident."
             )
 
     previous_incident = IncidentRead.from_orm(incident)
@@ -230,7 +230,7 @@ def join_incident(
         # reject if the user isn't an admin
         if current_user.role != UserRoles.admin.value:
             raise HTTPException(
-                status_code=401, detail="You do not have permission to join this incident."
+                status_code=403, detail="You do not have permission to join this incident."
             )
 
     background_tasks.add_task(
@@ -250,7 +250,7 @@ def delete_incident(
     """
     if current_user.role != UserRoles.admin:
         raise HTTPException(
-            status_code=401, detail="You do not have permission to delete incidents."
+            status_code=403, detail="You do not have permission to delete incidents."
         )
 
     incident = get(db_session=db_session, incident_id=incident_id)

--- a/src/dispatch/incident_priority/views.py
+++ b/src/dispatch/incident_priority/views.py
@@ -85,7 +85,7 @@ def update_incident_priority(
             status_code=404, detail="The incident priority with this id does not exist."
         )
 
-    # We restrict updating incident types to admins only
+    # We restrict updating incident priorities to admins only
     if current_user.role != UserRoles.admin:
         raise HTTPException(
             status_code=403, detail="You do not have permission to update incident priorities."

--- a/src/dispatch/incident_type/views.py
+++ b/src/dispatch/incident_type/views.py
@@ -57,7 +57,7 @@ def create_incident_type(
     # We restrict the creation of incident types to admins only
     if current_user.role != UserRoles.admin:
         raise HTTPException(
-            status_code=401, detail="You do not have permission to create incident types."
+            status_code=403, detail="You do not have permission to create incident types."
         )
     incident_type = create(db_session=db_session, incident_type_in=incident_type_in)
     return incident_type
@@ -83,7 +83,7 @@ def update_incident_type(
     # We restrict updating incident types to admins only
     if current_user.role != UserRoles.admin:
         raise HTTPException(
-            status_code=401, detail="You do not have permission to update incident types."
+            status_code=403, detail="You do not have permission to update incident types."
         )
 
     incident_type = update(

--- a/src/dispatch/incident_type/views.py
+++ b/src/dispatch/incident_type/views.py
@@ -3,10 +3,14 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
+from dispatch.auth.models import DispatchUser
+from dispatch.auth.service import get_current_user
 from dispatch.database import get_db, search_filter_sort_paginate
+from dispatch.enums import UserRoles
 
 from .models import IncidentTypeCreate, IncidentTypePagination, IncidentTypeRead, IncidentTypeUpdate
 from .service import create, get, update
+
 
 router = APIRouter()
 
@@ -42,11 +46,19 @@ def get_incident_types(
 
 @router.post("/", response_model=IncidentTypeRead)
 def create_incident_type(
-    *, db_session: Session = Depends(get_db), incident_type_in: IncidentTypeCreate
+    *,
+    db_session: Session = Depends(get_db),
+    incident_type_in: IncidentTypeCreate,
+    current_user: DispatchUser = Depends(get_current_user),
 ):
     """
-    Create a new incident_type.
+    Create a new incident type.
     """
+    # We restrict the creation of incident types to admins only
+    if current_user.role != UserRoles.admin:
+        raise HTTPException(
+            status_code=401, detail="You do not have permission to create incident types."
+        )
     incident_type = create(db_session=db_session, incident_type_in=incident_type_in)
     return incident_type
 
@@ -57,6 +69,7 @@ def update_incident_type(
     db_session: Session = Depends(get_db),
     incident_type_id: int,
     incident_type_in: IncidentTypeUpdate,
+    current_user: DispatchUser = Depends(get_current_user),
 ):
     """
     Update an existing incident_type.
@@ -66,6 +79,13 @@ def update_incident_type(
         raise HTTPException(
             status_code=404, detail="The incident_type with this id does not exist."
         )
+
+    # We restrict updating incident types to admins only
+    if current_user.role != UserRoles.admin:
+        raise HTTPException(
+            status_code=401, detail="You do not have permission to update incident types."
+        )
+
     incident_type = update(
         db_session=db_session, incident_type=incident_type, incident_type_in=incident_type_in
     )

--- a/src/dispatch/incident_type/views.py
+++ b/src/dispatch/incident_type/views.py
@@ -72,12 +72,12 @@ def update_incident_type(
     current_user: DispatchUser = Depends(get_current_user),
 ):
     """
-    Update an existing incident_type.
+    Update an existing incident type.
     """
     incident_type = get(db_session=db_session, incident_type_id=incident_type_id)
     if not incident_type:
         raise HTTPException(
-            status_code=404, detail="The incident_type with this id does not exist."
+            status_code=404, detail="The incident type with this id does not exist."
         )
 
     # We restrict updating incident types to admins only
@@ -95,11 +95,11 @@ def update_incident_type(
 @router.get("/{incident_type_id}", response_model=IncidentTypeRead)
 def get_incident_type(*, db_session: Session = Depends(get_db), incident_type_id: int):
     """
-    Get a single incident_type.
+    Get an incident type.
     """
     incident_type = get(db_session=db_session, incident_type_id=incident_type_id)
     if not incident_type:
         raise HTTPException(
-            status_code=404, detail="The incident_type with this id does not exist."
+            status_code=404, detail="The incident type with this id does not exist."
         )
     return incident_type


### PR DESCRIPTION
This PR adds logic to restrict the creation and editing of incident types, priorities, and plugins to admins only.