### PR TITLE
Removes extra blank line between title and description in incident update notifications

### DIFF
--- a/src/dispatch/messaging/strings.py
+++ b/src/dispatch/messaging/strings.py
@@ -285,13 +285,19 @@ INCIDENT_CLOSED_RATING_FEEDBACK_DESCRIPTION = """
 Thanks for participating in the {{name}} ("{{title}}") incident. We would appreciate if you could rate your experience and provide feedback."""
 
 INCIDENT_TYPE_CHANGE_DESCRIPTION = """
-The incident type has been changed from {{ incident_type_old }} to {{ incident_type_new }}."""
+The incident type has been changed from {{ incident_type_old }} to {{ incident_type_new }}.""".replace(
+    "\n", " "
+).strip()
 
 INCIDENT_STATUS_CHANGE_DESCRIPTION = """
-The incident status has been changed from {{ incident_status_old }} to {{ incident_status_new }}."""
+The incident status has been changed from {{ incident_status_old }} to {{ incident_status_new }}.""".replace(
+    "\n", " "
+).strip()
 
 INCIDENT_PRIORITY_CHANGE_DESCRIPTION = """
-The incident priority has been changed from {{ incident_priority_old }} to {{ incident_priority_new }}."""
+The incident priority has been changed from {{ incident_priority_old }} to {{ incident_priority_new }}.""".replace(
+    "\n", " "
+).strip()
 
 INCIDENT_NAME_WITH_ENGAGEMENT = {
     "title": "{{name}} Incident Notification",


### PR DESCRIPTION
<img width="626" alt="Screen Shot 2021-01-29 at 10 29 57 AM" src="https://user-images.githubusercontent.com/39573146/106313611-5552de80-621d-11eb-81e4-a437e2985b89.png">
