### PR TITLE
Removes visibility open check before sending incident created and updated notifications

### DIFF
--- a/src/dispatch/incident/flows.py
+++ b/src/dispatch/incident/flows.py
@@ -684,14 +684,14 @@ def incident_create_flow(*, incident_id: int, checkpoint: str = None, db_session
                 )
                 log.exception(e)
 
-    if incident.visibility == Visibility.open:
-        send_incident_created_notifications(incident, db_session)
-        event_service.log(
-            db_session=db_session,
-            source="Dispatch Core App",
-            description="Incident notifications sent",
-            incident_id=incident.id,
-        )
+    send_incident_created_notifications(incident, db_session)
+
+    event_service.log(
+        db_session=db_session,
+        source="Dispatch Core App",
+        description="Incident notifications sent",
+        incident_id=incident.id,
+    )
 
     suggested_document_items = get_suggested_document_items(incident.id, db_session)
 

--- a/src/dispatch/incident/messaging.py
+++ b/src/dispatch/incident/messaging.py
@@ -328,42 +328,40 @@ def send_incident_update_notifications(
                 "Incident updated notification not sent to incident conversation. No conversation plugin enabled."
             )
 
-    # we only send notifications about incident updates to fyi conversations
-    # and distribution lists if the incident's visibility is open
-    if incident.visibility == Visibility.open:
-        fyi_notification_template = notification_template.copy()
-        if incident.status != IncidentStatus.closed:
-            fyi_notification_template.insert(0, INCIDENT_NAME_WITH_ENGAGEMENT)
-        else:
-            fyi_notification_template.insert(0, INCIDENT_NAME)
+    # we send a notification to the notification conversations and emails
+    fyi_notification_template = notification_template.copy()
+    if incident.status != IncidentStatus.closed:
+        fyi_notification_template.insert(0, INCIDENT_NAME_WITH_ENGAGEMENT)
+    else:
+        fyi_notification_template.insert(0, INCIDENT_NAME)
 
-        notification_kwargs = {
-            "commander_fullname": incident.commander.individual.name,
-            "commander_weblink": incident.commander.individual.weblink,
-            "contact_fullname": incident.commander.individual.name,
-            "contact_weblink": incident.commander.individual.weblink,
-            "incident_id": incident.id,
-            "incident_priority_new": incident.incident_priority.name,
-            "incident_priority_old": previous_incident.incident_priority.name,
-            "incident_status_new": incident.status,
-            "incident_status_old": previous_incident.status.value,
-            "incident_type_new": incident.incident_type.name,
-            "incident_type_old": previous_incident.incident_type.name,
-            "name": incident.name,
-            "ticket_weblink": resolve_attr(incident, "ticket.weblink"),
-            "title": incident.title,
-        }
+    notification_kwargs = {
+        "commander_fullname": incident.commander.individual.name,
+        "commander_weblink": incident.commander.individual.weblink,
+        "contact_fullname": incident.commander.individual.name,
+        "contact_weblink": incident.commander.individual.weblink,
+        "incident_id": incident.id,
+        "incident_priority_new": incident.incident_priority.name,
+        "incident_priority_old": previous_incident.incident_priority.name,
+        "incident_status_new": incident.status,
+        "incident_status_old": previous_incident.status.value,
+        "incident_type_new": incident.incident_type.name,
+        "incident_type_old": previous_incident.incident_type.name,
+        "name": incident.name,
+        "ticket_weblink": resolve_attr(incident, "ticket.weblink"),
+        "title": incident.title,
+    }
 
-        notification_params = {
-            "text": notification_text,
-            "type": notification_type,
-            "template": fyi_notification_template,
-            "kwargs": notification_kwargs,
-        }
+    notification_params = {
+        "text": notification_text,
+        "type": notification_type,
+        "template": fyi_notification_template,
+        "kwargs": notification_kwargs,
+    }
 
-        notification_service.filter_and_send(
-            db_session=db_session, class_instance=incident, notification_params=notification_params
-        )
+    notification_service.filter_and_send(
+        db_session=db_session, class_instance=incident, notification_params=notification_params
+    )
 
     log.debug("Incident updated notifications sent.")
 

--- a/src/dispatch/incident/messaging.py
+++ b/src/dispatch/incident/messaging.py
@@ -10,7 +10,6 @@ from dispatch.config import DISPATCH_UI_URL
 from dispatch.conversation.enums import ConversationCommands
 from dispatch.database import SessionLocal, resolve_attr
 from dispatch.document import service as document_service
-from dispatch.enums import Visibility
 from dispatch.incident import service as incident_service
 from dispatch.incident.enums import IncidentStatus
 from dispatch.incident.models import Incident, IncidentRead

--- a/src/dispatch/notification/views.py
+++ b/src/dispatch/notification/views.py
@@ -96,7 +96,10 @@ def update_notification(
     return notification
 
 
-@router.delete("/{notification_id}")
+@router.delete(
+    "/{notification_id}",
+    dependencies=[Depends(PermissionsDependency([AdminPermission]))],
+)
 def delete_notification(*, db_session: Session = Depends(get_db), notification_id: int):
     """
     Delete a notification, returning only an HTTP 200 OK if successful.


### PR DESCRIPTION
This PR removes the is the incident's visibility open check before sending incident created and updated notifications. We are going to rely on the search filters in notifications to determine when notifications for incidents with restricted visibility need to be sent. Also, we now require Admin permissions to delete notifications to be consistent with notification creation and update.