### PR TITLE
Jira plugin now supports cloud and server hosting type

### DIFF
--- a/docs/configuration/plugins/configuring-jira.md
+++ b/docs/configuration/plugins/configuring-jira.md
@@ -31,3 +31,7 @@ Dispatch ships with Jira support. Each Jira installation is unique, so you will 
 ## `JIRA_ISSUE_TYPE_NAME` \[Required\]
 
 > Name of the Jira issue type.
+
+## `JIRA_HOSTING_TYPE` \[Default: 'Cloud'\]
+
+> Type of Jira hosting used (e.g. Cloud, Server).

--- a/src/dispatch/plugins/dispatch_jira/config.py
+++ b/src/dispatch/plugins/dispatch_jira/config.py
@@ -2,10 +2,10 @@ from starlette.datastructures import URL
 
 from dispatch.config import config, Secret
 
-
-JIRA_BROWSER_URL = config("JIRA_BROWSER_URL", cast=URL)
 JIRA_API_URL = config("JIRA_API_URL", cast=URL)
-JIRA_USERNAME = config("JIRA_USERNAME")
+JIRA_BROWSER_URL = config("JIRA_BROWSER_URL", cast=URL)
+JIRA_HOSTING_TYPE = config("JIRA_HOSTING_TYPE", default="Cloud")
+JIRA_ISSUE_TYPE_NAME = config("JIRA_ISSUE_TYPE_NAME")
 JIRA_PASSWORD = config("JIRA_PASSWORD", cast=Secret)
 JIRA_PROJECT_ID = config("JIRA_PROJECT_ID")
-JIRA_ISSUE_TYPE_NAME = config("JIRA_ISSUE_TYPE_NAME")
+JIRA_USERNAME = config("JIRA_USERNAME")

--- a/src/dispatch/plugins/dispatch_jira/plugin.py
+++ b/src/dispatch/plugins/dispatch_jira/plugin.py
@@ -51,7 +51,7 @@ def get_email_username(email: str) -> str:
 
 
 def get_user_field(client: JIRA, user_email) -> dict:
-    """Returns correct Jira user field based on Jira hosting option."""
+    """Returns correct Jira user field based on Jira hosting type."""
     if JIRA_HOSTING_TYPE == "Server":
         user = client.search_users(user_email, maxResults=1)[0]
         return {"name": user.name}


### PR DESCRIPTION
This PR refactors the Jira plugin to add support for cloud and server hosting types and to respect any provided incident type plugin metadata.