### PR TITLE
Create services and documents from incident type

### DIFF
--- a/src/dispatch/static/dispatch/src/document/DocumentSelect.vue
+++ b/src/dispatch/static/dispatch/src/document/DocumentSelect.vue
@@ -14,14 +14,25 @@
       return-object
       :loading="loading"
       no-filter
-    />
+    >
+      <template slot="append-outer">
+        <v-btn icon @click="createEditShow({})">
+          <v-icon>add</v-icon>
+        </v-btn>
+        <new-edit-sheet @new-document-created="addItem($event)" />
+      </template>
+    </v-autocomplete>
   </ValidationProvider>
 </template>
 
 <script>
-import DocumentApi from "@/document/api"
+import { mapActions } from "vuex"
 import { cloneDeep } from "lodash"
 import { ValidationProvider } from "vee-validate"
+
+import DocumentApi from "@/document/api"
+import NewEditSheet from "@/document/NewEditSheet.vue"
+
 export default {
   name: "DocumentSelect",
 
@@ -35,7 +46,8 @@ export default {
   },
 
   components: {
-    ValidationProvider
+    ValidationProvider,
+    NewEditSheet
   },
 
   data() {
@@ -69,6 +81,11 @@ export default {
   },
 
   methods: {
+    ...mapActions("document", ["createEditShow"]),
+    addItem(value) {
+      this.document = value
+      this.items.push(value)
+    },
     querySelections(v) {
       this.loading = "error"
       // Simulated ajax query

--- a/src/dispatch/static/dispatch/src/document/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/document/NewEditSheet.vue
@@ -201,7 +201,13 @@ export default {
   },
 
   methods: {
-    ...mapActions("document", ["save", "closeCreateEdit"])
+    ...mapActions("document", ["closeCreateEdit"]),
+    save() {
+      const self = this
+      this.$store.dispatch("document/save").then(function(data) {
+        self.$emit("new-document-created", data)
+      })
+    }
   }
 }
 </script>

--- a/src/dispatch/static/dispatch/src/document/store.js
+++ b/src/dispatch/static/dispatch/src/document/store.js
@@ -84,7 +84,7 @@ const actions = {
   save({ commit, dispatch }) {
     if (!state.selected.id) {
       return DocumentApi.create(state.selected)
-        .then(() => {
+        .then(function(resp) {
           dispatch("closeCreateEdit")
           dispatch("getAll")
           commit(
@@ -92,6 +92,7 @@ const actions = {
             { text: "Document created successfully.", type: "success" },
             { root: true }
           )
+          return resp.data
         })
         .catch(err => {
           commit(

--- a/src/dispatch/static/dispatch/src/incident_type/Table.vue
+++ b/src/dispatch/static/dispatch/src/incident_type/Table.vue
@@ -58,6 +58,7 @@
 import { mapFields } from "vuex-map-fields"
 import { mapActions } from "vuex"
 import NewEditSheet from "@/incident_type/NewEditSheet.vue"
+
 export default {
   name: "IncidentTypeTable",
 

--- a/src/dispatch/static/dispatch/src/service/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/service/NewEditSheet.vue
@@ -145,7 +145,13 @@ export default {
   },
 
   methods: {
-    ...mapActions("service", ["save", "closeCreateEdit"])
+    ...mapActions("service", ["closeCreateEdit"]),
+    save() {
+      const self = this
+      this.$store.dispatch("service/save").then(function(data) {
+        self.$emit("new-service-created", data)
+      })
+    }
   },
 
   data() {

--- a/src/dispatch/static/dispatch/src/service/ServiceSelect.vue
+++ b/src/dispatch/static/dispatch/src/service/ServiceSelect.vue
@@ -1,23 +1,34 @@
 <template>
-  <v-autocomplete
-    v-model="service"
-    :items="items"
-    :search-input.sync="search"
-    :menu-props="{ maxHeight: '400' }"
-    item-text="name"
-    :label="label"
-    placeholder="Start typing to Search"
-    return-object
-    :hint="hint"
-    :loading="loading"
-    no-filter
-  >
-  </v-autocomplete>
+  <ValidationProvider name="service" immediate>
+    <v-autocomplete
+      v-model="service"
+      :items="items"
+      :search-input.sync="search"
+      :menu-props="{ maxHeight: '400' }"
+      item-text="name"
+      :label="label"
+      placeholder="Start typing to Search"
+      return-object
+      :hint="hint"
+      :loading="loading"
+      no-filter
+    >
+      <template slot="append-outer">
+        <v-btn icon @click="createEditShow({})"><v-icon>add</v-icon></v-btn>
+        <new-edit-sheet @new-service-created="addItem($event)" />
+      </template>
+    </v-autocomplete>
+  </ValidationProvider>
 </template>
 
 <script>
-import ServiceApi from "@/service/api"
+import { mapActions } from "vuex"
 import { cloneDeep } from "lodash"
+import { ValidationProvider } from "vee-validate"
+
+import ServiceApi from "@/service/api"
+import NewEditSheet from "@/service/NewEditSheet.vue"
+
 export default {
   name: "ServiceSelect",
 
@@ -40,6 +51,11 @@ export default {
         return "Service to associate"
       }
     }
+  },
+
+  components: {
+    ValidationProvider,
+    NewEditSheet
   },
 
   data() {
@@ -73,6 +89,11 @@ export default {
   },
 
   methods: {
+    ...mapActions("service", ["createEditShow"]),
+    addItem(v) {
+      this.service = v
+      this.items.push(v)
+    },
     querySelections(v) {
       this.loading = "error"
       // Simulated ajax query

--- a/src/dispatch/static/dispatch/src/service/ServiceSelect.vue
+++ b/src/dispatch/static/dispatch/src/service/ServiceSelect.vue
@@ -7,7 +7,7 @@
       :menu-props="{ maxHeight: '400' }"
       item-text="name"
       :label="label"
-      placeholder="Start typing to Search"
+      placeholder="Start typing to search"
       return-object
       :hint="hint"
       :loading="loading"

--- a/src/dispatch/static/dispatch/src/service/store.js
+++ b/src/dispatch/static/dispatch/src/service/store.js
@@ -80,7 +80,7 @@ const actions = {
   save({ commit, dispatch }) {
     if (!state.selected.id) {
       return ServiceApi.create(state.selected)
-        .then(() => {
+        .then(function(resp) {
           dispatch("closeCreateEdit")
           dispatch("getAll")
           commit(
@@ -88,6 +88,7 @@ const actions = {
             { text: "Service created successfully.", type: "success" },
             { root: true }
           )
+          return resp.data
         })
         .catch(err => {
           commit(


### PR DESCRIPTION
Adding the ability to create services and documents when creating/editing incident types.
![2021-02-23_10-05](https://user-images.githubusercontent.com/2262214/108887232-d0aa7480-75be-11eb-80f7-1a6669404d14.png)
