### PR TITLE
Update URL for example env

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ git clone https://github.com/Netflix/dispatch-docker.git
 Before starting the installation, we strongly recommend you check out [how to configure your Dispatch instance](configuration/) as you'd need to rebuild your images \(`docker-compose build`\) if you want to change your configuration settings. You may copy and edit the example configs provided in the repository. If none exists, the install script will use these examples as actual configurations.
 
 {% hint style="info" %}
-Note: Dispatch will not start without at least a few required configuration variables. See the example [env](https://github.com/Netflix/dispatch/blob/master/docker/.env.example).
+Note: Dispatch will not start without at least a few required configuration variables. See the example [env](https://github.com/Netflix/dispatch/blob/latest/docker/.env.example).
 {% endhint %}
 
 {% hint style="info" %}


### PR DESCRIPTION
Looks like the `develop` branch is no more, and so this link is dead. Update to be `master` (will need to be changed again in the future if/when this project moves to `main`)