### PR TITLE
Disables nested validation observers when creating new or editing existing incident types

### DIFF
--- a/src/dispatch/static/dispatch/src/incident_type/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/incident_type/NewEditSheet.vue
@@ -67,13 +67,19 @@
                 />
               </v-flex>
               <v-flex xs12>
-                <service-select label="Commander Service" v-model="commander_service" />
+                <ValidationObserver disabled>
+                  <service-select label="Commander Service" v-model="commander_service" />
+                </ValidationObserver>
               </v-flex>
               <v-flex xs12>
-                <service-select label="Liaison Service" v-model="liaison_service" />
+                <ValidationObserver disabled>
+                  <service-select label="Liaison Service" v-model="liaison_service" />
+                </ValidationObserver>
               </v-flex>
               <v-flex xs12>
-                <document-select v-model="template_document" />
+                <ValidationObserver disabled>
+                  <document-select v-model="template_document" />
+                </ValidationObserver>
               </v-flex>
               <v-flex xs 12>
                 <v-checkbox


### PR DESCRIPTION
Closes #937 