### PR TITLE
Allows for more flexible forecasting

### DIFF
--- a/src/dispatch/incident/metrics.py
+++ b/src/dispatch/incident/metrics.py
@@ -84,7 +84,6 @@ def make_forecast(incidents: List[Incident]):
             dataframe, seasonal_periods=12, trend="add", seasonal="add"
         ).fit()
     except Exception as e:
-        raise e
         log.warning(f"Issue forecasting incidents: {e}")
         return [], []
 

--- a/src/dispatch/incident/metrics.py
+++ b/src/dispatch/incident/metrics.py
@@ -1,15 +1,18 @@
 import math
 import logging
+from typing import List
 from itertools import groupby
 
 from datetime import date
-from dateutil.relativedelta import relativedelta
 
 from calendar import monthrange
 
 import pandas as pd
 from statsmodels.tsa.api import ExponentialSmoothing
 
+from sqlalchemy import and_
+
+from dispatch.database import apply_filters
 from dispatch.incident_type.models import IncidentType
 from .models import Incident
 
@@ -26,62 +29,45 @@ def month_grouper(item):
     return key
 
 
-def get_incident_counts(db_session, months=2):
-    """Counts the number of incident in the last n months."""
-    incidents = (
-        db_session.query(Incident)
-        .join(IncidentType)
-        .filter(IncidentType.exclude_from_metrics.isnot(True))
-        .filter(Incident.reported_at > date.today().replace(day=1) + relativedelta(months=-2))
-        .all()
-    )
-
-    counts = []
-    incidents_sorted = sorted(incidents, key=month_grouper)
-    for (key, items) in groupby(incidents_sorted, month_grouper):
-        items = list(items)
-        counts.append(len(items))
-    return counts
-
-
-def make_forecast(
-    db_session, incident_type: str = None, periods: int = 24, grouping: str = "month"
+def create_incident_metric_query(
+    db_session,
+    end_date: date,
+    start_date: date = None,
+    filter_spec: List[dict] = None,
 ):
-    """Makes an incident forecast."""
+    """Fetches eligible incidents."""
     query = db_session.query(Incident).join(IncidentType)
+    query = apply_filters(query, filter_spec)
+
+    if start_date:
+        query = query.filter(
+            and_(Incident.reported_at <= end_date, Incident.reported_at >= start_date)
+        )
+
+    else:
+        query = query.filter(
+            Incident.reported_at <= end_date
+        )
 
     # exclude incident types
     query = query.filter(IncidentType.exclude_from_metrics.isnot(True))
+    return query.all()
 
-    # exclude last two months
-    query = query.filter(
-        Incident.reported_at < date.today().replace(day=1) + relativedelta(months=-2)
-    )
 
-    if incident_type != "all":
-        if incident_type:
-            query = query.filter(IncidentType.name == incident_type)
-
-    if grouping == "month":
-        grouper = month_grouper
-        query.filter(Incident.reported_at > date.today() + relativedelta(months=-periods))
-
-    incidents = query.all()
-    incidents_sorted = sorted(incidents, key=grouper)
+def make_forecast(incidents: List[Incident]):
+    """Makes an incident forecast."""
+    incidents_sorted = sorted(incidents, key=month_grouper)
 
     dataframe_dict = {"ds": [], "y": []}
 
-    for (last_day, items) in groupby(incidents_sorted, grouper):
+    for (last_day, items) in groupby(incidents_sorted, month_grouper):
         dataframe_dict["ds"].append(str(last_day))
         dataframe_dict["y"].append(len(list(items)))
 
     dataframe = pd.DataFrame.from_dict(dataframe_dict)
 
     if dataframe.empty:
-        return {
-            "categories": [],
-            "series": [{"name": "Predicted", "data": []}],
-        }
+        return [], []
 
     # reset index to by month and drop month column
     dataframe.index = dataframe.ds
@@ -90,19 +76,17 @@ def make_forecast(
 
     # fill periods without incidents with 0
     idx = pd.date_range(dataframe.index[0], dataframe.index[-1], freq="M")
-    dataframe.index = idx
+    dataframe.index = pd.DatetimeIndex(dataframe.index)
     dataframe = dataframe.reindex(idx, fill_value=0)
 
     try:
         forecaster = ExponentialSmoothing(
             dataframe, seasonal_periods=12, trend="add", seasonal="add"
-        ).fit(use_boxcox=True)
+        ).fit()
     except Exception as e:
+        raise e
         log.warning(f"Issue forecasting incidents: {e}")
-        return {
-            "categories": [],
-            "series": [{"name": "Predicted", "data": []}],
-        }
+        return [], []
 
     forecast = forecaster.forecast(12)
     forecast_df = pd.DataFrame({"ds": forecast.index.astype("str"), "yhat": forecast.values})
@@ -111,16 +95,5 @@ def make_forecast(
 
     # drop day data
     categories = [d[:-3] for d in forecast_data["ds"]]
-
-    incident_counts = get_incident_counts(db_session=db_session)
-
-    return {
-        "categories": categories,
-        "series": [
-            {
-                "name": "Predicted",
-                "data": [max(math.ceil(x), 0) for x in list(forecast_data["yhat"])],
-            },
-            {"name": "Actual", "data": incident_counts},
-        ],
-    }
+    predicted_counts = [max(math.ceil(x), 0) for x in list(forecast_data["yhat"])]
+    return categories, predicted_counts

--- a/src/dispatch/static/dispatch/src/dashboard/DialogFilter.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/DialogFilter.vue
@@ -137,6 +137,7 @@ export default {
       })
 
       this.$emit("loading", "error")
+      this.$emit("filterOptions", this.filters)
       IncidentApi.getAll(filterOptions).then(response => {
         this.$emit("update", response.data.items)
         this.$emit("loading", false)

--- a/src/dispatch/static/dispatch/src/dashboard/IncidentOverview.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/IncidentOverview.vue
@@ -5,7 +5,12 @@
         <v-btn color="info" @click="copyView">Share View</v-btn>
       </v-flex>
       <v-flex class="d-flex justify-end" lg6 sm6 xs12>
-        <dialog-filter v-bind="query" @update="update" @loading="setLoading" />
+        <dialog-filter
+          v-bind="query"
+          @update="update"
+          @filterOptions="setFilterOptions"
+          @loading="setLoading"
+        />
       </v-flex>
     </v-layout>
     <v-layout row wrap>
@@ -49,7 +54,7 @@
         ></incident-cost-bar-chart-card>
       </v-flex>
       <v-flex lg12 sm12 xs12>
-        <incident-forecast-card></incident-forecast-card>
+        <incident-forecast-card v-model="filterOptions"></incident-forecast-card>
       </v-flex>
       <v-flex lg6 sm6 xs12>
         <incident-active-time-card
@@ -128,6 +133,7 @@ export default {
     return {
       tab: null,
       loading: "error",
+      filterOptions: {},
       items: []
     }
   },
@@ -137,6 +143,9 @@ export default {
       this.items = filter(data, function(item) {
         return !item.incident_type.exclude_from_metrics && !item.duplicates.length
       })
+    },
+    setFilterOptions(options) {
+      this.filterOptions = options
     },
     setLoading(data) {
       this.loading = data

--- a/src/dispatch/static/dispatch/src/incident/IncidentForecastCard.vue
+++ b/src/dispatch/static/dispatch/src/incident/IncidentForecastCard.vue
@@ -11,13 +11,15 @@
 <script>
 import IncidentApi from "@/incident/api"
 import DashboardCard from "@/dashboard/DashboardCard.vue"
+import SearchUtils from "@/search/utils"
+
 export default {
   name: "IncidentForecastCard",
   props: {
     value: {
-      type: String,
+      type: Object,
       default: function() {
-        return "all"
+        return {}
       }
     }
   },
@@ -78,7 +80,9 @@ export default {
   methods: {
     fetchData() {
       this.loading = "error"
-      IncidentApi.getMetricForecast(this.value).then(response => {
+      let expression = SearchUtils.createFilterExpression(this.value)
+      let params = { filter: JSON.stringify(expression) }
+      IncidentApi.getMetricForecast(params).then(response => {
         this.loading = false
         this.series = response.data.series
         this.categories = response.data.categories
@@ -86,8 +90,10 @@ export default {
     }
   },
 
-  mounted() {
-    this.fetchData()
+  watch: {
+    value: function() {
+      this.fetchData()
+    }
   }
 }
 </script>

--- a/src/dispatch/static/dispatch/src/incident/api.js
+++ b/src/dispatch/static/dispatch/src/incident/api.js
@@ -11,8 +11,8 @@ export default {
     return API.get(`${resource}/${incidentId}`)
   },
 
-  getMetricForecast(incidentType) {
-    return API.get(`${resource}/metric/forecast/${incidentType}`)
+  getMetricForecast(options) {
+    return API.get(`${resource}/metric/forecast`, { params: { ...options } })
   },
 
   create(payload) {

--- a/src/dispatch/static/dispatch/src/search/SearchFilterCreateDialog.vue
+++ b/src/dispatch/static/dispatch/src/search/SearchFilterCreateDialog.vue
@@ -158,7 +158,6 @@
 
 <script>
 import { mapFields } from "vuex-map-fields"
-import { forEach, each, has } from "lodash"
 import { ValidationObserver, ValidationProvider, extend } from "vee-validate"
 import { required } from "vee-validate/dist/rules"
 
@@ -172,22 +171,12 @@ import IncidentPriorityCombobox from "@/incident_priority/IncidentPriorityCombob
 import IncidentStatus from "@/incident/IncidentStatus.vue"
 import IncidentPriority from "@/incident/IncidentPriority.vue"
 import AdvancedEditor from "@/search/AdvancedEditor.vue"
+import SearchUtils from "@/search/utils"
 
 extend("required", {
   ...required,
   message: "This field is required"
 })
-
-const toPascalCase = str =>
-  `${str}`
-    .replace(new RegExp(/[-_]+/, "g"), " ")
-    .replace(new RegExp(/[^\w\s]/, "g"), "")
-    .replace(
-      new RegExp(/\s+(.)(\w+)/, "g"),
-      ($1, $2, $3) => `${$2.toUpperCase() + $3.toLowerCase()}`
-    )
-    .replace(new RegExp(/\s/, "g"), "")
-    .replace(new RegExp(/\w/), s => s.toUpperCase())
 
 export default {
   name: "SearchFilterCreateDialog",
@@ -239,34 +228,6 @@ export default {
   methods: {
     ...mapActions("search", ["closeCreateDialog", "save"]),
 
-    createFilterExpression(filters) {
-      let filterExpression = []
-      forEach(filters, function(value, key) {
-        let subFilter = []
-        each(value, function(value) {
-          if (has(value, "id")) {
-            subFilter.push({
-              model: toPascalCase(key),
-              field: "id",
-              op: "==",
-              value: value.id
-            })
-          } else {
-            subFilter.push({ field: key, op: "==", value: value })
-          }
-        })
-        if (subFilter.length > 0) {
-          filterExpression.push({ or: subFilter })
-        }
-      })
-
-      if (filterExpression.length > 0) {
-        return [{ and: filterExpression }]
-      } else {
-        return []
-      }
-    },
-
     saveFilter() {
       // reset local data
       Object.assign(this.$data, this.$options.data.apply(this))
@@ -294,7 +255,7 @@ export default {
         vm.filters.tag
       ],
       () => {
-        this.expression = this.createFilterExpression(this.filters)
+        this.expression = SearchUtils.createFilterExpression(this.filters)
         this.getPreviewData()
       }
     )

--- a/src/dispatch/static/dispatch/src/search/utils.js
+++ b/src/dispatch/static/dispatch/src/search/utils.js
@@ -1,0 +1,42 @@
+import { forEach, each, has } from "lodash"
+
+const toPascalCase = str =>
+  `${str}`
+    .replace(new RegExp(/[-_]+/, "g"), " ")
+    .replace(new RegExp(/[^\w\s]/, "g"), "")
+    .replace(
+      new RegExp(/\s+(.)(\w+)/, "g"),
+      ($1, $2, $3) => `${$2.toUpperCase() + $3.toLowerCase()}`
+    )
+    .replace(new RegExp(/\s/, "g"), "")
+    .replace(new RegExp(/\w/), s => s.toUpperCase())
+
+export default {
+  createFilterExpression(filters) {
+    let filterExpression = []
+    forEach(filters, function(value, key) {
+      let subFilter = []
+      each(value, function(value) {
+        if (has(value, "id")) {
+          subFilter.push({
+            model: toPascalCase(key),
+            field: "id",
+            op: "==",
+            value: value.id
+          })
+        } else {
+          subFilter.push({ field: key, op: "==", value: value })
+        }
+      })
+      if (subFilter.length > 0) {
+        filterExpression.push({ or: subFilter })
+      }
+    })
+
+    if (filterExpression.length > 0) {
+      return [{ and: filterExpression }]
+    } else {
+      return []
+    }
+  }
+}

--- a/src/dispatch/tag/recommender.py
+++ b/src/dispatch/tag/recommender.py
@@ -136,7 +136,9 @@ def find_highest_correlations(correlated_dataframe, recommendations):
     return corr_df_sliced
 
 
-def get_recommendations(db_session: SessionLocal, tag_ids: List[str], model_name: str, recommendations: int = 5):
+def get_recommendations(
+    db_session: SessionLocal, tag_ids: List[str], model_name: str, recommendations: int = 5
+):
     """Get recommendations based on current tag."""
     try:
         correlation_dataframe = load_model(model_name)
@@ -160,7 +162,9 @@ def get_recommendations(db_session: SessionLocal, tag_ids: List[str], model_name
     for t in recommendations_dataframe["tag"][:recommendations]:
         tags.append(tag_service.get(db_session=db_session, tag_id=int(t)))
 
-    log.debug(f"Making tag recommendation. RecommendedTags: {','.join([t.name for t in tags])} ModelName: {model_name}")
+    log.debug(
+        f"Making tag recommendation. RecommendedTags: {','.join([t.name for t in tags])} ModelName: {model_name}"
+    )
     return tags
 
 

--- a/src/dispatch/tag/views.py
+++ b/src/dispatch/tag/views.py
@@ -98,7 +98,9 @@ def get_tag_recommendations(*, db_session: Session = Depends(get_db), model_name
     model = db_session.query(model_object).filter(model_object.id == id).one_or_none()
 
     if not model:
-        raise HTTPException(status_code=404, detail=f"No model found. ModelName: {model_name} Id: {id}")
+        raise HTTPException(
+            status_code=404, detail=f"No model found. ModelName: {model_name} Id: {id}"
+        )
 
     tags = get_recommendations(db_session, [t.id for t in model.tags], model_name)
     return {"items": tags, "total": len(tags)}


### PR DESCRIPTION
This PR improves our ability to forecast incidents and show historical accuracy. It attempts to get the best of both worlds by doing a forward-looking forecast to see how many incidents will be handled in the future, as well as "rolling historical forecasts". By restricting the data sets in the past we are able to re-forecast a historical month as if it were the last day of the previous month. 

We are then able to use that forecast to compare against the actual number of incidents in a given month. Combining these two strategies allows us to both observe the historical accuracy of our forecasting while using all currently available data for future forecasting.

Additionally, this PR adds the ability for us to forecast based on different subsets of data, e.g. how many incidents of type `foo` do we expect to see? how many incidents of priority `bar`, how many incidents of type `foo` AND priority `bar` and so on. 

See also #923 

@snkilmartin I had to remove the `box cot` fit to the model due to it having issues with the smaller filtered datasets, in my tests I didn't see that this had any effect. Please let me know if this will greatly affect forecasting. 