### PR TITLE
chore: improved GitHub actions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,7 +3,15 @@ name: Python Lint and Test
 on: pull_request
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable
+
   build:
+    needs: lint
     runs-on: ubuntu-latest
 
     services:
@@ -32,10 +40,6 @@ jobs:
           export DISPATCH_LIGHT_BUILD=1
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-
-      - name: Run Black
-        run: |
-          black .
 
       - name: Run Flake8
         run: |


### PR DESCRIPTION
Fixes #1207 
1) Added black as a separate job
2) Made build dependent on lint so if lint fails, build job will be skipped
Thus, improved the use of GitHub actions in the repository 


