### PR TITLE
Fixed a command issue and added clarification

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,8 +43,11 @@ For any new Dispatch installation, new users are expected to register themselves
 For these users, we have a CLI command that allows users to be granted the role of their choosing:
 
 ```bash
-dispatch user update --role Admin <email-address-of-registered-user>
+docker exec -it dispatch_web_1 bash
+dispatch user update --role Admin <email-address-of-registered-user> --project <name-of-the-project>
 ```
+
+The default project name in the sample data file is "default".
 
 After one admin user has been established, they can grant this role to others via the UI.
 


### PR DESCRIPTION
Without adding the project name it was giving a Traceback error - 
project name -> 
   none is not an allowed value (type=type_error.none.not_allowed)