### PR TITLE
Only get users that have permission

### DIFF
--- a/src/dispatch/plugins/dispatch_jira/plugin.py
+++ b/src/dispatch/plugins/dispatch_jira/plugin.py
@@ -179,7 +179,6 @@ class JiraTicketPlugin(TicketPlugin):
             incident_type_plugin_metadata
         )
 
-        # should we move to project keys?
         project = client.project(project_id)
         assignee = get_user_field(client, commander_email, project.key)
         reporter = get_user_field(client, reporter_email, project.key)


### PR DESCRIPTION
This addresses an issue with Jira server where we may retrieve a user that doesn't have access to the given project (e.g. multiple users for a given email). 