### PR TITLE
Python script to assist with generating release notes

### DIFF
--- a/utils/release_notes.py
+++ b/utils/release_notes.py
@@ -1,0 +1,44 @@
+"""
+Python script to generate releases notes using the GitHub CLI (gh).
+
+Instructions on how to install gh can be found here: https://github.com/cli/cli#installation
+"""
+import click
+
+
+@click.command()
+@click.option(
+    "--pull-request-number",
+    "-n",
+    required=True,
+    type=int,
+    help="Pull request number from where to generate the release notes.",
+)
+def release_notes(pull_request_number):
+    """Simple utility function to assist with generating release notes."""
+    import json
+    import os
+
+    dispatch_pr_url = "https://github.com/Netflix/dispatch/pull/"
+    exclude_authors = ["dependabot"]
+    gh_command = 'gh pr list -s closed --json "title,author,number" -L 250'
+
+    stream = os.popen(gh_command)
+    pull_requests = json.loads(stream.read())
+
+    for pull_request in pull_requests:
+        author = pull_request["author"]["login"]
+        title = pull_request["title"]
+        number = pull_request["number"]
+
+        if number < pull_request_number:
+            break
+
+        if author in exclude_authors:
+            continue
+
+        print(f"* {title} by @{author} ([#{number}]({dispatch_pr_url}{number}))")
+
+
+if __name__ == "__main__":
+    release_notes()

--- a/utils/release_notes.py
+++ b/utils/release_notes.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """
 Python script to generate releases notes using the GitHub CLI (gh).
 


### PR DESCRIPTION
Usage:

```
Usage: release_notes.py [OPTIONS]

  Simple utility function to assist with generating release notes.

Options:
  -n, --pull-request-number INTEGER
                                  Pull request number from where to generate
                                  the release notes.  [required]
  --help                          Show this message and exit.
```

Example:
```
$ ./release_notes.py --pull-request-number 1430

* Bugfix/task creator by @mvilanova ([#1438](https://github.com/Netflix/dispatch/pull/1438))
* We don't send messages to the participant or channel if the incident is closed by @mvilanova ([#1437](https://github.com/Netflix/dispatch/pull/1437))
* Fixing faq and conversation reference by @kevgliss ([#1434](https://github.com/Netflix/dispatch/pull/1434))
* Fixing task source documents by @kevgliss ([#1433](https://github.com/Netflix/dispatch/pull/1433))
* Allow tag sync plugins to create tag types dynamically by @kevgliss ([#1432](https://github.com/Netflix/dispatch/pull/1432))
* Fixing button by @kevgliss ([#1431](https://github.com/Netflix/dispatch/pull/1431))
* Fixing incident document creation by @kevgliss ([#1430](https://github.com/Netflix/dispatch/pull/1430))
```