### PR TITLE
Unprocessable entity on any API request due to insufficient parameters

### DIFF
--- a/src/dispatch/auth/permissions.py
+++ b/src/dispatch/auth/permissions.py
@@ -58,7 +58,10 @@ class BasePermission(ABC):
         if request.path_params.get("organization"):
             organization = organization_service.get_by_slug_or_raise(
                 db_session=request.state.db,
-                organization_in=OrganizationRead(slug=request.path_params["organization"]),
+                organization_in=OrganizationRead(
+                    slug=request.path_params["organization"],
+                    name=request.path_params["organization"],
+                ),
             )
         elif request.path_params.get("organization_id"):
             organization = organization_service.get(


### PR DESCRIPTION
Unprocessable entity on any API request due to insufficient parameters supplied. Thus raising a pydantic exception which being in middleware will be handled as a 422 response