### PR TITLE
Removes tracking-only checkbox from incident reporting form

### DIFF
--- a/src/dispatch/static/dispatch/src/incident/ReportReceiptCard.vue
+++ b/src/dispatch/static/dispatch/src/incident/ReportReceiptCard.vue
@@ -86,7 +86,7 @@
           </v-list-item-group>
         </v-list-group>
       </v-list>
-      <v-list three-line v-if="!trackingOnly">
+      <v-list three-line>
         <v-list-group :value="true">
           <template v-slot:activator>
             <v-list-item-title class="title"> Incident Resources </v-list-item-title>
@@ -282,7 +282,6 @@ export default {
       "selected.storage",
       "selected.documents",
       "selected.project",
-      "selected.trackingOnly",
       "selected.loading",
       "selected.ticket",
       "selected.id",

--- a/src/dispatch/static/dispatch/src/incident/ReportSubmissionCard.vue
+++ b/src/dispatch/static/dispatch/src/incident/ReportSubmissionCard.vue
@@ -62,23 +62,6 @@
               <v-flex xs12>
                 <tag-filter-combobox :project="project" v-model="tags" label="Tags" />
               </v-flex>
-              <v-flex xs12>
-                <v-checkbox v-model="trackingOnly" label="Tracking Only">
-                  <template v-slot:label>
-                    <div>
-                      Tracking Only
-                      <v-tooltip max-width="250px" bottom>
-                        <template v-slot:activator="{ on, attrs }">
-                          <v-icon v-bind="attrs" v-on="on"> help_outline </v-icon>
-                        </template>
-                        Dispatch will only create a ticket for this incident. The status of the
-                        incident will be closed and no collaboration resources will be created. No
-                        further action from you will be needed.
-                      </v-tooltip>
-                    </div>
-                  </template>
-                </v-checkbox>
-              </v-flex>
             </v-layout>
             <template>
               <v-btn
@@ -150,7 +133,6 @@ export default {
       "selected.loading",
       "selected.ticket",
       "selected.project",
-      "selected.trackingOnly",
       "selected.id",
     ]),
     ...mapFields("route", ["query"]),

--- a/src/dispatch/static/dispatch/src/incident/store.js
+++ b/src/dispatch/static/dispatch/src/incident/store.js
@@ -21,17 +21,16 @@ const getDefaultSelectedState = () => {
     incident_type: null,
     name: null,
     participants: null,
+    project: null,
     reported_at: null,
     reporter: null,
     stable_at: null,
     status: null,
     storage: null,
     tags: [],
-    project: null,
     terms: [],
     ticket: null,
     title: null,
-    trackingOnly: null,
     visibility: null,
     workflow_instances: null,
     loading: false,
@@ -199,9 +198,6 @@ const actions = {
   },
   report({ commit, dispatch }) {
     commit("SET_SELECTED_LOADING", true)
-    if (state.selected.trackingOnly === true) {
-      state.selected.status = "Closed"
-    }
     return IncidentApi.create(state.selected)
       .then((response) => {
         commit("SET_SELECTED", response.data)


### PR DESCRIPTION
We've decided to remove the tracking-only checkbox in the reporting form, because it was creating confusion. If you wish to open an incident for tracking purposes, you can still go to the Dispatch UI and open an incident as closed, which is what the checkbox instructed Dispatch to do.