### PR TITLE
Adds better repr for our sqlalchemy objects

### DIFF
--- a/src/dispatch/database/core.py
+++ b/src/dispatch/database/core.py
@@ -4,7 +4,7 @@ from typing import Any
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
 from pydantic.main import BaseModel
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, inspect
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.orm import sessionmaker, object_session
 from sqlalchemy.sql.expression import true
@@ -38,6 +38,9 @@ def resolve_attr(obj, attr, default=None):
 
 
 class CustomBase:
+    __repr_attrs__ = []
+    __repr_max_length__ = 15
+
     @declared_attr
     def __tablename__(self):
         return resolve_table_name(self.__name__)
@@ -45,6 +48,49 @@ class CustomBase:
     def dict(self):
         """Returns a dict representation of a model."""
         return {c.name: getattr(self, c.name) for c in self.__table__.columns}
+
+    @property
+    def _id_str(self):
+        ids = inspect(self).identity
+        if ids:
+            return "-".join([str(x) for x in ids]) if len(ids) > 1 else str(ids[0])
+        else:
+            return "None"
+
+    @property
+    def _repr_attrs_str(self):
+        max_length = self.__repr_max_length__
+
+        values = []
+        single = len(self.__repr_attrs__) == 1
+        for key in self.__repr_attrs__:
+            if not hasattr(self, key):
+                raise KeyError(
+                    "{} has incorrect attribute '{}' in "
+                    "__repr__attrs__".format(self.__class__, key)
+                )
+            value = getattr(self, key)
+            wrap_in_quote = isinstance(value, str)
+
+            value = str(value)
+            if len(value) > max_length:
+                value = value[:max_length] + "..."
+
+            if wrap_in_quote:
+                value = "'{}'".format(value)
+            values.append(value if single else "{}:{}".format(key, value))
+
+        return " ".join(values)
+
+    def __repr__(self):
+        # get id like '#123'
+        id_str = ("#" + self._id_str) if self._id_str else ""
+        # join class name, id and repr_attrs
+        return "<{} {}{}>".format(
+            self.__class__.__name__,
+            id_str,
+            " " + self._repr_attrs_str if self._repr_attrs_str else "",
+        )
 
 
 Base = declarative_base(cls=CustomBase)


### PR DESCRIPTION
Adds a more readable repr for sqlalchemy objects. For example, printing a list of models will now print:

```
{'items': [<Incident #864>, <Incident #848>, <Incident #846>, <Incident #841>, <Incident #822>, <Incident #813>, <Incident #812>, <Incident #791>, <Incident #788>, <Incident #787>], 'itemsPerPage': 10, 'page': 1, 'total': 575}
```

Additionally, it exposes a ` __repr_attrs__` property to all sqlalchemy models such that you can further specify other attributes that should be included in a model's repr.

