### PR TITLE
Support windows file path & env vars for CLI serve command

### DIFF
--- a/src/dispatch/cli.py
+++ b/src/dispatch/cli.py
@@ -704,11 +704,13 @@ def run_server(log_level):
         # take our frontend vars and export them for the frontend to consume
         envvars = os.environ.copy()
         envvars.update({x: getattr(config, x) for x in dir(config) if x.startswith("VUE_APP_")})
-
+        is_windows = os.name == "nt"
+        windows_cmds = ["cmd", "/c"]
+        default_cmds = ["npm", "run", "serve"]
+        cmds = windows_cmds + default_cmds if is_windows else default_cmds
         p = Popen(
-            ["npm", "run", "serve"],
+            cmds,
             cwd=os.path.join("src", "dispatch", "static", "dispatch"),
-            shell=True,
             env=envvars,
         )
         atexit.register(p.terminate)

--- a/src/dispatch/cli.py
+++ b/src/dispatch/cli.py
@@ -705,7 +705,12 @@ def run_server(log_level):
         envvars = os.environ.copy()
         envvars.update({x: getattr(config, x) for x in dir(config) if x.startswith("VUE_APP_")})
 
-        p = Popen(["npm", "run", "serve"], cwd="src/dispatch/static/dispatch", env=envvars)
+        p = Popen(
+            ["npm", "run", "serve"],
+            cwd=os.path.join("src", "dispatch", "static", "dispatch"),
+            shell=True,
+            env=envvars,
+        )
         atexit.register(p.terminate)
     uvicorn.run("dispatch.main:app", debug=True, log_level=log_level)
 

--- a/src/dispatch/cli.py
+++ b/src/dispatch/cli.py
@@ -697,7 +697,7 @@ def run_server(log_level):
     """Runs a simple server for development."""
     # Uvicorn expects lowercase logging levels; the logging package expects upper.
     os.environ["LOG_LEVEL"] = log_level.upper()
-    if not config.STATIC_DIR:
+    if not os.path.isdir(config.STATIC_DIR):
         import atexit
         from subprocess import Popen
 

--- a/src/dispatch/config.py
+++ b/src/dispatch/config.py
@@ -153,7 +153,7 @@ VUE_APP_DISPATCH_AUTHENTICATION_PROVIDER_USE_ID_TOKEN = config(
 
 # static files
 DEFAULT_STATIC_DIR = os.path.join(
-    os.path.abspath(os.path.dirname(__file__)), "static/dispatch/dist"
+    os.path.abspath(os.path.dirname(__file__)), os.path.join("static", "dispatch", "dist")
 )
 STATIC_DIR = config("STATIC_DIR", default=DEFAULT_STATIC_DIR)
 

--- a/src/dispatch/main.py
+++ b/src/dispatch/main.py
@@ -214,7 +214,7 @@ install_plugin_events(api_router)
 api.include_router(api_router)
 
 # we mount the frontend and app
-if STATIC_DIR:
+if STATIC_DIR and path.isdir(STATIC_DIR):
     frontend.mount("/", StaticFiles(directory=STATIC_DIR), name="app")
 
 app.mount("/api/v1", app=api)

--- a/src/dispatch/static/dispatch/package.json
+++ b/src/dispatch/static/dispatch/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "NODE_ENV=dev NODE_OPTIONS='--max-http-header-size=100000' vue-cli-service serve",
+    "serve": "cross-env NODE_ENV=dev NODE_OPTIONS='--max-http-header-size=100000' vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "build-report": "vue-cli-service build --report"
@@ -44,6 +44,7 @@
     "@vue/cli-service": "^4.1.1",
     "@vue/eslint-config-prettier": "^6.0.0",
     "babel-eslint": "^10.1.0",
+    "cross-env": "^7.0.3",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.3.1",


### PR DESCRIPTION
Hello,

Currently, running `dispatch server develop` fails on windows because of the static file paths.
Also the front-end will never be served  because the env var `STATIC_DIR` has a default.