### PR TITLE
Fix table name for incident_role_incident_priority in db migration

### DIFF
--- a/src/dispatch/database/revisions/tenant/versions/2021-08-09_b73416df5744.py
+++ b/src/dispatch/database/revisions/tenant/versions/2021-08-09_b73416df5744.py
@@ -58,7 +58,7 @@ assoc_incident_roles_incident_types = Table(
 )
 
 assoc_incident_roles_incident_priorities = Table(
-    "incident_role_incident_priorities",
+    "incident_role_incident_priority",
     Base.metadata,
     Column("incident_role_id", Integer, ForeignKey("incident_role.id")),
     Column("incident_priority_id", Integer, ForeignKey("incident_priority.id")),


### PR DESCRIPTION
The name of the table is singular `incident_role_incident_priority`, not plural `priorities`. The migration fails without this fix. Check the names of the variables and table for the `incident_role_incident_type` table for a working example.