### PR TITLE
Allows all roles except member to see restricted incidents

### DIFF
--- a/src/dispatch/database/service.py
+++ b/src/dispatch/database/service.py
@@ -45,8 +45,8 @@ QueryStr = constr(regex=r"^[ -~]+$", min_length=1)
 
 def restricted_incident_filter(query: orm.Query, current_user: DispatchUser, role: UserRoles):
     """Adds additional incident filters to query (usually for permissions)."""
-    if role != UserRoles.owner:
-        # We don't allow users that are not owners to see restricted incidents
+    if role == UserRoles.member:
+        # We filter out resticted incidents for users with a member role if the user is not an incident participant
         query = (
             query.join(Participant, Incident.id == Participant.incident_id)
             .join(IndividualContact)

--- a/src/dispatch/static/dispatch/src/dashboard/IncidentOverview.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/IncidentOverview.vue
@@ -57,7 +57,7 @@
         <incident-cost-bar-chart-card v-model="groupedItems" :loading="loading" />
       </v-flex>
       <v-flex lg12 sm12 xs12>
-        <incident-forecast-card :filterOptions="filterOptions" />
+        <incident-forecast-card :filter-options="filterOptions" />
       </v-flex>
       <v-flex lg6 sm6 xs12>
         <incident-active-time-card v-model="groupedItems" :loading="loading" />


### PR DESCRIPTION
This PR modifies the restricted incident filter applied when querying all incidents to allow all roles except `member` to see restricted incidents.