### PR TITLE
Save app theme in localStorage

### DIFF
--- a/src/dispatch/static/dispatch/src/components/AppToolbar.vue
+++ b/src/dispatch/static/dispatch/src/components/AppToolbar.vue
@@ -205,7 +205,7 @@ export default {
       if (theme === "true") {
         this.$vuetify.theme.dark = true
       } else {
-          this.$vuetify.theme.dark = false;
+        this.$vuetify.theme.dark = false
       }
     }
 


### PR DESCRIPTION
Fixes issue #1706  by storing the dark mode preference in localStorage.
