### PR TITLE
Replaces localhost with 127.0.0.1 in devServer vue.config.js

### DIFF
--- a/src/dispatch/static/dispatch/vue.config.js
+++ b/src/dispatch/static/dispatch/vue.config.js
@@ -39,7 +39,7 @@ module.exports = {
     // https://github.com/chimurai/http-proxy-middleware#http-proxy-options
     proxy: {
       "^/api": {
-        target: "http://localhost:8000",
+        target: "http://127.0.0.1:8000",
         ws: false,
         changeOrigin: true,
       },


### PR DESCRIPTION
This change seem to solve the following proxying issue:

```
Proxy error: Could not proxy request /api/v1/organizations?itemsPerPage=50&sortBy[]=name&descending[]=false from localhost:8080 to http://localhost:8000.
See https://nodejs.org/api/errors.html#errors_common_system_errors for more information (ECONNREFUSED).
```