### PR TITLE
Reverts to IncidentRead in IncidentPagination Pydantic model

### DIFF
--- a/src/dispatch/incident/models.py
+++ b/src/dispatch/incident/models.py
@@ -415,4 +415,4 @@ class IncidentPagination(DispatchBase):
     total: int
     itemsPerPage: int
     page: int
-    items: List[IncidentReadMinimal] = []
+    items: List[IncidentRead] = []

--- a/src/dispatch/static/dispatch/src/incident/ParticipantsTab.vue
+++ b/src/dispatch/static/dispatch/src/incident/ParticipantsTab.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="participants.length">
+    <div v-if="participants && participants.length">
       <span v-for="participant in participants" :key="participant.id">
         <v-list-item :href="participant.individual.weblink" target="_blank">
           <v-list-item-content>
@@ -33,6 +33,7 @@ import { mapFields } from "vuex-map-fields"
 
 export default {
   name: "IncidentParticipantsTab",
+
   computed: {
     ...mapFields("incident", ["selected.participants"]),
   },

--- a/src/dispatch/static/dispatch/src/incident/TimelineTab.vue
+++ b/src/dispatch/static/dispatch/src/incident/TimelineTab.vue
@@ -11,7 +11,7 @@
         Export
       </v-btn>
     </v-row>
-    <v-timeline v-if="events.length" dense clipped>
+    <v-timeline v-if="events && events.length" dense clipped>
       <v-timeline-item
         v-for="event in sortedEvents"
         :key="event.id"

--- a/src/dispatch/static/dispatch/src/incident/WorkflowInstanceTab.vue
+++ b/src/dispatch/static/dispatch/src/incident/WorkflowInstanceTab.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div v-if="workflow_instances.length">
+    <div v-if="workflow_instances && workflow_instances.length">
       <span v-for="instance in workflow_instances" :key="instance.id">
         <v-card>
           <div>


### PR DESCRIPTION
Changes to pydantic models in https://github.com/Netflix/dispatch/pull/1828/ broke our ability to load the contents of the resources, participants, timeline, and workflow incident tabs. This PR reverts to using the IncidentRead pydantic model.