### PR TITLE
Initializes data properties to avoid typerror exceptions in report submission card

### DIFF
--- a/src/dispatch/static/dispatch/src/incident/ReportSubmissionCard.vue
+++ b/src/dispatch/static/dispatch/src/incident/ReportSubmissionCard.vue
@@ -166,14 +166,17 @@ export default {
   },
 
   created() {
+    this.project = { name: "" }
     if (this.query.project) {
       this.project = { name: this.query.project }
     }
 
+    this.incident_type = { name: "" }
     if (this.query.incident_type) {
       this.incident_type = { name: this.query.incident_type }
     }
 
+    this.incident_priority = { name: "" }
     if (this.query.incident_priority) {
       this.incident_priority = { name: this.query.incident_priority }
     }


### PR DESCRIPTION
This PR attempts to address the following error:
```
TypeError: Cannot read properties of null (reading 'name')
  at n/a(webpack:///src/incident/ReportSubmissionCard.vue:155:0)
  at n/a(webpack:///src/incident/ReportSubmissionCard.vue:181:9)
```