### PR TITLE
Changes default time range to current month plus full previous month

### DIFF
--- a/src/dispatch/static/dispatch/src/dashboard/DialogFilter.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/DialogFilter.vue
@@ -68,6 +68,11 @@ let today = function () {
   return new Date(now.getFullYear(), now.getMonth(), now.getDate())
 }
 
+let thisMonth = function () {
+  let now = new Date()
+  return new Date(now.getFullYear(), now.getMonth())
+}
+
 export default {
   name: "IncidentOverviewFilterBar",
 
@@ -164,7 +169,7 @@ export default {
       ...this.filters,
       ...{
         reported_at: {
-          start: subMonths(today(), 1).toISOString().substr(0, 10),
+          start: subMonths(thisMonth(), 1).toISOString().substr(0, 10),
           end: today().toISOString().substr(0, 10),
         },
       },


### PR DESCRIPTION
This PR changes the default time range from 30 days lookback to current month plus full previous month to align with user expectations that all incidents should be included in the graph for previous month.