### PR TITLE
Fixes issue with comboboxes not displaying multiple items with the same name.

### DIFF
--- a/src/dispatch/static/dispatch/src/data/query/QuerySelect.vue
+++ b/src/dispatch/static/dispatch/src/data/query/QuerySelect.vue
@@ -7,6 +7,7 @@
     :search-input.sync="search"
     @update:search-input="getFilteredData({ q: $event })"
     item-text="name"
+    item-value="id"
     clearable
     v-model="query"
   >

--- a/src/dispatch/static/dispatch/src/data/query/store.js
+++ b/src/dispatch/static/dispatch/src/data/query/store.js
@@ -12,6 +12,7 @@ const getDefaultSelectedState = () => {
     description: null,
     source: null,
     text: null,
+    project: null,
     language: null,
   }
 }
@@ -39,11 +40,6 @@ const state = {
         tag: [],
         project: [],
         tag_type: [],
-        query_environment: [],
-        query_status: [],
-        query_type: [],
-        query_transport: [],
-        query_data_format: [],
       },
     },
     loading: false,

--- a/src/dispatch/static/dispatch/src/data/source/SourceSelect.vue
+++ b/src/dispatch/static/dispatch/src/data/source/SourceSelect.vue
@@ -7,6 +7,7 @@
     :search-input.sync="search"
     @update:search-input="getFilteredData({ q: $event })"
     item-text="name"
+    item-value="id"
     clearable
     v-model="source"
   >

--- a/src/dispatch/static/dispatch/src/data/source/dataFormat/DataFormatCombobox.vue
+++ b/src/dispatch/static/dispatch/src/data/source/dataFormat/DataFormatCombobox.vue
@@ -10,6 +10,7 @@
     deletable-chips
     hide-selected
     item-text="name"
+    item-value="id"
     multiple
     no-filter
     v-model="dataFormats"

--- a/src/dispatch/static/dispatch/src/data/source/dataFormat/DataFormatSelect.vue
+++ b/src/dispatch/static/dispatch/src/data/source/dataFormat/DataFormatSelect.vue
@@ -7,6 +7,7 @@
     :search-input.sync="search"
     @update:search-input="getFilteredData({ q: $event })"
     item-text="name"
+    item-value="id"
     clearable
     v-model="dataFormat"
   >

--- a/src/dispatch/static/dispatch/src/data/source/environment/EnvironmentCombobox.vue
+++ b/src/dispatch/static/dispatch/src/data/source/environment/EnvironmentCombobox.vue
@@ -10,6 +10,7 @@
     deletable-chips
     hide-selected
     item-text="name"
+    item-value="id"
     multiple
     no-filter
     v-model="environments"

--- a/src/dispatch/static/dispatch/src/data/source/environment/EnvironmentSelect.vue
+++ b/src/dispatch/static/dispatch/src/data/source/environment/EnvironmentSelect.vue
@@ -7,6 +7,7 @@
     :search-input.sync="search"
     @update:search-input="getFilteredData({ q: $event })"
     item-text="name"
+    item-value="id"
     clearable
     v-model="environment"
   >

--- a/src/dispatch/static/dispatch/src/data/source/status/StatusCombobox.vue
+++ b/src/dispatch/static/dispatch/src/data/source/status/StatusCombobox.vue
@@ -10,6 +10,7 @@
     deletable-chips
     hide-selected
     item-text="name"
+    item-value="id"
     multiple
     no-filter
     v-model="statuses"
@@ -18,7 +19,7 @@
       <v-list-item>
         <v-list-item-content>
           <v-list-item-title>
-            No Projects matching "
+            No statuses matching "
             <strong>{{ search }}</strong
             >".
           </v-list-item-title>

--- a/src/dispatch/static/dispatch/src/data/source/status/StatusSelect.vue
+++ b/src/dispatch/static/dispatch/src/data/source/status/StatusSelect.vue
@@ -7,6 +7,7 @@
     :search-input.sync="search"
     @update:search-input="getFilteredData({ q: $event })"
     item-text="name"
+    item-value="id"
     clearable
     v-model="status"
   >
@@ -14,7 +15,7 @@
       <v-list-item>
         <v-list-item-content>
           <v-list-item-title>
-            No statuss matching
+            No statuses matching
             <strong>"{{ search }}"</strong>
           </v-list-item-title>
         </v-list-item-content>

--- a/src/dispatch/static/dispatch/src/data/source/transport/TransportCombobox.vue
+++ b/src/dispatch/static/dispatch/src/data/source/transport/TransportCombobox.vue
@@ -10,6 +10,7 @@
     deletable-chips
     hide-selected
     item-text="name"
+    item-value="id"
     multiple
     no-filter
     v-model="transports"

--- a/src/dispatch/static/dispatch/src/data/source/transport/TransportSelect.vue
+++ b/src/dispatch/static/dispatch/src/data/source/transport/TransportSelect.vue
@@ -7,6 +7,7 @@
     :search-input.sync="search"
     @update:search-input="getFilteredData({ q: $event })"
     item-text="name"
+    item-value="id"
     clearable
     v-model="transport"
   >

--- a/src/dispatch/static/dispatch/src/data/source/type/TypeCombobox.vue
+++ b/src/dispatch/static/dispatch/src/data/source/type/TypeCombobox.vue
@@ -10,6 +10,7 @@
     deletable-chips
     hide-selected
     item-text="name"
+    item-value="id"
     multiple
     no-filter
     v-model="types"

--- a/src/dispatch/static/dispatch/src/data/source/type/TypeSelect.vue
+++ b/src/dispatch/static/dispatch/src/data/source/type/TypeSelect.vue
@@ -7,6 +7,7 @@
     :search-input.sync="search"
     @update:search-input="getFilteredData({ q: $event })"
     item-text="name"
+    item-value="id"
     clearable
     v-model="type"
   >

--- a/src/dispatch/static/dispatch/src/document/template/TemplateSelect.vue
+++ b/src/dispatch/static/dispatch/src/document/template/TemplateSelect.vue
@@ -6,6 +6,7 @@
       :search-input.sync="search"
       :menu-props="{ maxHeight: '400' }"
       item-text="name"
+      item-value="id"
       :label="label"
       placeholder="Start typing to search"
       return-object

--- a/src/dispatch/static/dispatch/src/incident/IncidentCombobox.vue
+++ b/src/dispatch/static/dispatch/src/incident/IncidentCombobox.vue
@@ -11,6 +11,7 @@
     deletable-chips
     hide-selected
     item-text="name"
+    item-value="id"
     multiple
     no-filter
     v-model="incident"

--- a/src/dispatch/static/dispatch/src/incident/IncidentFilterCombobox.vue
+++ b/src/dispatch/static/dispatch/src/incident/IncidentFilterCombobox.vue
@@ -10,6 +10,7 @@
     deletable-chips
     hide-selected
     item-text="name"
+    item-value="id"
     multiple
     no-filter
     v-model="incidents"

--- a/src/dispatch/static/dispatch/src/incident/IncidentSelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/IncidentSelect.vue
@@ -7,6 +7,7 @@
     :search-input.sync="search"
     @update:search-input="getFilteredData({ q: $event })"
     item-text="name"
+    item-value="id"
     clearable
     v-model="incident"
   >

--- a/src/dispatch/static/dispatch/src/incident_cost_type/IncidentCostTypeCombobox.vue
+++ b/src/dispatch/static/dispatch/src/incident_cost_type/IncidentCostTypeCombobox.vue
@@ -8,6 +8,7 @@
     deletable-chips
     hide-selected
     item-text="name"
+    item-value="id"
     no-filter
     v-model="incident_cost_type"
   >

--- a/src/dispatch/static/dispatch/src/incident_type/IncidentTypeCombobox.vue
+++ b/src/dispatch/static/dispatch/src/incident_type/IncidentTypeCombobox.vue
@@ -10,6 +10,7 @@
     deletable-chips
     hide-selected
     item-text="name"
+    item-value="id"
     multiple
     no-filter
     v-model="incidentType"

--- a/src/dispatch/static/dispatch/src/individual/IndividualCombobox.vue
+++ b/src/dispatch/static/dispatch/src/individual/IndividualCombobox.vue
@@ -12,6 +12,7 @@
     deletable-chips
     hide-selected
     item-text="name"
+    item-value="id"
     multiple
     no-filter
     v-model="individual"

--- a/src/dispatch/static/dispatch/src/individual/IndividualSelect.vue
+++ b/src/dispatch/static/dispatch/src/individual/IndividualSelect.vue
@@ -7,6 +7,7 @@
     :search-input.sync="search"
     @update:search-input="fetchData({ q: $event })"
     item-text="name"
+    item-value="id"
     v-model="individual"
   >
     <template v-slot:no-data>

--- a/src/dispatch/static/dispatch/src/project/ProjectCombobox.vue
+++ b/src/dispatch/static/dispatch/src/project/ProjectCombobox.vue
@@ -10,6 +10,7 @@
     deletable-chips
     hide-selected
     item-text="name"
+    item-value="id"
     multiple
     no-filter
     v-model="project"

--- a/src/dispatch/static/dispatch/src/project/ProjectSelect.vue
+++ b/src/dispatch/static/dispatch/src/project/ProjectSelect.vue
@@ -7,6 +7,7 @@
     :search-input.sync="search"
     @update:search-input="getFilteredData({ q: $event })"
     item-text="name"
+    item-value="id"
     v-model="project"
   >
     <template v-slot:no-data>
@@ -89,6 +90,7 @@ export default {
       this.error = null
       this.loading = "error"
       let filterOptions = {
+        q: this.search,
         itemsPerPage: this.numItems,
         sortBy: ["name"],
         descending: [false],

--- a/src/dispatch/static/dispatch/src/search/SearchFilterCombobox.vue
+++ b/src/dispatch/static/dispatch/src/search/SearchFilterCombobox.vue
@@ -14,6 +14,7 @@
         deletable-chips
         hide-selected
         item-text="name"
+        item-value="id"
         multiple
         no-filter
         v-model="searchFilters"

--- a/src/dispatch/static/dispatch/src/service/ServiceSelect.vue
+++ b/src/dispatch/static/dispatch/src/service/ServiceSelect.vue
@@ -5,6 +5,7 @@
     :search-input.sync="search"
     :menu-props="{ maxHeight: '400' }"
     item-text="name"
+    item-value="id"
     :label="label"
     placeholder="Start typing to search"
     return-object

--- a/src/dispatch/static/dispatch/src/service/ServiceSelectNew.vue
+++ b/src/dispatch/static/dispatch/src/service/ServiceSelectNew.vue
@@ -5,6 +5,7 @@
     :search-input.sync="search"
     :menu-props="{ maxHeight: '400' }"
     item-text="name"
+    item-value="id"
     :label="label"
     placeholder="Start typing to search"
     return-object

--- a/src/dispatch/static/dispatch/src/tag/TagFilterAutoComplete.vue
+++ b/src/dispatch/static/dispatch/src/tag/TagFilterAutoComplete.vue
@@ -8,6 +8,7 @@
     chips
     clearable
     item-text="name"
+    item-value="id"
     hide-selected
     multiple
     no-filter

--- a/src/dispatch/static/dispatch/src/tag_type/TagTypeFilterCombobox.vue
+++ b/src/dispatch/static/dispatch/src/tag_type/TagTypeFilterCombobox.vue
@@ -9,6 +9,7 @@
     clearable
     hide-selected
     item-text="name"
+    item-value="id"
     multiple
     no-filter
     v-model="tags"


### PR DESCRIPTION
In some cases (typically with cross-project entities) there can be multiple entries with the same name. We denote the ID of the value instead of it's name such that these "duplicates" are correctly displayed in the dropdown.