### PR TITLE
Uses the simple search dictionary for fulltext search

### DIFF
--- a/src/dispatch/tag/models.py
+++ b/src/dispatch/tag/models.py
@@ -27,7 +27,8 @@ class Tag(Base, TimeStampMixin, ProjectMixin):
     tag_type_id = Column(Integer, ForeignKey("tag_type.id"), nullable=False)
     tag_type = relationship("TagType", backref="tag")
 
-    search_vector = Column(TSVectorType("name"))
+    # the catalog here is simple to help matching "named entities"
+    search_vector = Column(TSVectorType("name", regconfig='pg_catalog.simple'))
 
 
 # Pydantic models


### PR DESCRIPTION
This change allows for more accurate searching for tag names. Since most tags are single words, we use the simple dictionary to capture the entire name (instead of breaking up lexemes like 'hack' & 'ing'. The search also enables better control when exact matching is required by wrapping your query in quotes. for example:

names: hacking, thehacking, thebiggesthack
lexemes: "hack"

query: hacking -> matches all
query: hack -> matches all
query: "hacking" -> matches hacking