### PR TITLE
Update Admin Documentation on Environment variables

### DIFF
--- a/docs/admin-guide/administration/server.md
+++ b/docs/admin-guide/administration/server.md
@@ -21,9 +21,9 @@ In general, do not include any quotation marks when adding configuration values.
 
 ### General
 
-#### `LOG_LEVEL` \[default: 'warning'\]
+#### `LOG_LEVEL` \[default: 'WARNING'\]
 
-> Controls the level of logging the application will perform during operations.
+> Controls the level of logging the application will perform during operations. Possible values: CRITICAL, ERROR, WARNING, INFO, DEBUG
 
 #### `STATIC_DIR` \[default: './src/static/dispatch/dist'\]
 


### PR DESCRIPTION
I had to browse through the code to understand the possible values of Log levels. Apparently the log levels are in Upper case, and the default value is shown in lowercase, which misled me into believing that all log levels should be in lower case.

Hopefully, this change will be meaningful for other readers.