### PR TITLE
Only update the cost of active and stable incidents

### DIFF
--- a/src/dispatch/incident_cost/scheduled.py
+++ b/src/dispatch/incident_cost/scheduled.py
@@ -35,8 +35,8 @@ def calculate_incidents_response_cost(db_session: SessionLocal, project: Project
         )
         return
 
-    # we only update the cost of active and stable incidents to avoid impacting old cost metrics
-    # when we relied on a different values for parameters such as average cost per employee or anuual business hours
+    # we only update the cost of active and stable incidents to avoid impacting older cost metrics
+    # when we make changes to average cost per employee and/ or number of annual business hours.
     active_incidents = incident_service.get_all_by_status(
         db_session=db_session, project_id=project.id, status=IncidentStatus.active
     )

--- a/src/dispatch/incident_cost/scheduled.py
+++ b/src/dispatch/incident_cost/scheduled.py
@@ -1,8 +1,9 @@
 import logging
 
 from schedule import every
-from dispatch.database.core import SessionLocal
 
+from dispatch.database.core import SessionLocal
+from dispatch.incident.enums import IncidentStatus
 from dispatch.incident import service as incident_service
 from dispatch.decorators import scheduled_project_task
 from dispatch.project.models import Project
@@ -34,8 +35,16 @@ def calculate_incidents_response_cost(db_session: SessionLocal, project: Project
         )
         return
 
-    # we want to update the response cost of all incidents, all the time
-    incidents = incident_service.get_all(db_session=db_session, project_id=project.id)
+    # we only update the cost of active and stable incidents to avoid impacting old cost metrics
+    # when we relied on a different values for parameters such as average cost per employee or anuual business hours
+    active_incidents = incident_service.get_all_by_status(
+        db_session=db_session, project_id=project.id, status=IncidentStatus.active
+    )
+    stable_incidents = incident_service.get_all_by_status(
+        db_session=db_session, project_id=project.id, status=IncidentStatus.stable
+    )
+    incidents = active_incidents + stable_incidents
+
     for incident in incidents:
         try:
             # we get the response cost for the given incident

--- a/src/dispatch/static/dispatch/src/incident/IncidentPriorityBarChartCard.vue
+++ b/src/dispatch/static/dispatch/src/incident/IncidentPriorityBarChartCard.vue
@@ -44,14 +44,16 @@ export default {
 
   created: function () {
     IncidentPriorityApi.getAll().then((response) => {
-      this.priorities = [...new Set(
-        map(
-          sortBy(response.data.items, function (value) {
-            return value.view_order
-          }),
-          "name"
-        )
-      )]
+      this.priorities = [
+        ...new Set(
+          map(
+            sortBy(response.data.items, function (value) {
+              return value.view_order
+            }),
+            "name"
+          )
+        ),
+      ]
     })
   },
 


### PR DESCRIPTION
We currently update the cost of _all_ incidents regardless of their status. This PR introduces changes, so Dispatch only updates the cost of active and stable incidents to avoid impacting older cost metrics when changes to average cost per employee or number of annual business hours are made.