### PR TITLE
Attribute action_id missing in task actions button.

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/commands.py
+++ b/src/dispatch/plugins/dispatch_slack/commands.py
@@ -362,6 +362,7 @@ def list_tasks(
                         "type": "button",
                         "text": {"type": "plain_text", "text": button_text},
                         "value": task_button.json(),
+                        "action_id": f"{ConversationButtonActions.update_task_status}",
                     },
                 }
             )


### PR DESCRIPTION
Prior to this, Slack was assinging a random 4-digit action_id that was causing the resolve and re-open buttons for a task to be a no-op.

Adding this routes the slack action to the right block_action_function (update_task_status).

Tested on my end. 