### PR TITLE
Copy over incident_costs, terms & duplicates before updating incident from Slack

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/modals/incident/handlers.py
+++ b/src/dispatch/plugins/dispatch_slack/modals/incident/handlers.py
@@ -204,6 +204,9 @@ def update_incident_from_submitted_form(
     # we don't allow visibility to be set in slack so we copy it over
     incident_in.visibility = incident.visibility
 
+    # We don't (yet) present incident_costs field in Slack's modal; copy it over.
+    incident_in.incident_costs = incident.incident_costs
+
     updated_incident = incident_service.update(
         db_session=db_session, incident=incident, incident_in=incident_in
     )

--- a/src/dispatch/plugins/dispatch_slack/modals/incident/handlers.py
+++ b/src/dispatch/plugins/dispatch_slack/modals/incident/handlers.py
@@ -201,7 +201,8 @@ def update_incident_from_submitted_form(
 
     previous_incident = IncidentRead.from_orm(incident)
 
-    # we don't allow visibility, incident_costs, terms & duplicates to be set in slack, so we copy it over
+    # we currently don't allow users to update the incident's visibility,
+    # costs, terms, or duplicates via Slack, so we copy them over
     incident_in.visibility = incident.visibility
     incident_in.incident_costs = incident.incident_costs
     incident_in.terms = incident.terms

--- a/src/dispatch/plugins/dispatch_slack/modals/incident/handlers.py
+++ b/src/dispatch/plugins/dispatch_slack/modals/incident/handlers.py
@@ -201,11 +201,11 @@ def update_incident_from_submitted_form(
 
     previous_incident = IncidentRead.from_orm(incident)
 
-    # we don't allow visibility to be set in slack so we copy it over
+    # we don't allow visibility, incident_costs, terms & duplicates to be set in slack, so we copy it over
     incident_in.visibility = incident.visibility
-
-    # We don't (yet) present incident_costs field in Slack's modal; copy it over.
     incident_in.incident_costs = incident.incident_costs
+    incident_in.terms = incident.terms
+    incident_in.duplicates = incident.duplicates
 
     updated_incident = incident_service.update(
         db_session=db_session, incident=incident, incident_in=incident_in


### PR DESCRIPTION
We don't (yet) present incident_costs attribute/field in Slack's update_incident modal, causing the update function to incorrectly (re)set it to zero. 