### PR TITLE
slack_menu empty tag list fix; uvloop support.

### DIFF
--- a/requirements-base.in
+++ b/requirements-base.in
@@ -42,4 +42,5 @@ statsmodels
 tabulate
 tenacity
 uvicorn
+uvloop
 validators==0.18.2

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -410,6 +410,8 @@ urllib3==1.26.11
     #   sentry-sdk
 uvicorn==0.18.2
     # via -r requirements-base.in
+uvloop==0.16.0
+    # via -r requirements-base.in
 validators==0.18.2
     # via -r requirements-base.in
 wasabi==0.10.0

--- a/src/dispatch/plugins/dispatch_slack/decorators.py
+++ b/src/dispatch/plugins/dispatch_slack/decorators.py
@@ -61,7 +61,7 @@ def get_organization_scope_from_channel_id(channel_id: str) -> SessionLocal:
 
 
 def get_organization_scope_from_slug(slug: str) -> SessionLocal:
-    """Iterate all organizations looking for a relevant channel_id."""
+    """Iterate all organizations looking for a matching slug."""
     db_session = SessionLocal()
     organization = organization_service.get_by_slug(db_session=db_session, slug=slug)
     db_session.close()

--- a/src/dispatch/plugins/dispatch_slack/views.py
+++ b/src/dispatch/plugins/dispatch_slack/views.py
@@ -231,7 +231,6 @@ async def handle_menu(
     verify_timestamp(x_slack_request_timestamp)
 
     # We verify the signature
-    verify_signature(organization, raw_request_body, x_slack_request_timestamp, x_slack_signature)
     current_configuration = verify_signature(
         organization, raw_request_body, x_slack_request_timestamp, x_slack_signature
     )
@@ -248,5 +247,6 @@ async def handle_menu(
         config=current_configuration,
         client=slack_async_client,
         request=request,
+        organization=organization,
     )
     return JSONResponse(content=body)


### PR DESCRIPTION
Add uvloop support to run the async event loop; uvicorn will pick this over asyncio, if available. Not sure about others, but In my setup (ubuntu VM), not having uvloop was resulting in 8/10 calls failing (some like /dispatch-update-incident failed 10/10) to Slack's API with the 'expired_trigger_id' error. I still see that error (w/uvloop), but it is more like 1/10. Also, this is an configurable option: "--loop [auto|asyncio|uvloop]    Event loop implementation.  [default: auto]"

Also, including the commit from earlier today which fixes slack_menu returning empty tag list from non-incident channels. Not sure how that was missing in the master branch although. 

Some minor str changes.
