### PR TITLE
Wrap gmail.send in try/except due to tenacity.RetryError

### DIFF
--- a/src/dispatch/evergreen/scheduled.py
+++ b/src/dispatch/evergreen/scheduled.py
@@ -54,15 +54,20 @@ def create_evergreen_reminder(
     notification_template = EVERGREEN_REMINDER
     notification_type = "evergreen-reminder"
     name = subject = notification_text = "Evergreen Reminder"
-    success = plugin.instance.send(
-        owner_email,
-        notification_text,
-        notification_template,
-        notification_type,
-        name=name,
-        subject=subject,
-        items=items,  # plugin expect dicts
-    )
+
+    # Can raise exception "tenacity.RetryError: RetryError". (Email may still go through).
+    try:
+        success = plugin.instance.send(
+            owner_email,
+            notification_text,
+            notification_template,
+            notification_type,
+            name=name,
+            subject=subject,
+            items=items,  # plugin expect dicts
+        )
+    except Exception as e:
+        log.error(f"Error in sending {notification_text} email to {owner_email}: {e}")
 
     if not success:
         log.error(f"Unable to send evergreen message. Email: {owner_email}")

--- a/src/dispatch/feedback/messaging.py
+++ b/src/dispatch/feedback/messaging.py
@@ -44,17 +44,21 @@ def send_incident_feedback_daily_report(
     commander_fullname = feedback[0].incident.commander.individual.name
     commander_weblink = feedback[0].incident.commander.individual.weblink
 
-    plugin.instance.send(
-        commander_email,
-        notification_text,
-        INCIDENT_FEEDBACK_DAILY_REPORT,
-        MessageType.incident_feedback_daily_report,
-        name=name,
-        subject=subject,
-        cc=plugin.project.owner_email,
-        items=items,
-        contact_fullname=commander_fullname,
-        contact_weblink=commander_weblink,
-    )
+    # Can raise exception "tenacity.RetryError: RetryError". (Email may still go through).
+    try:
+        plugin.instance.send(
+            commander_email,
+            notification_text,
+            INCIDENT_FEEDBACK_DAILY_REPORT,
+            MessageType.incident_feedback_daily_report,
+            name=name,
+            subject=subject,
+            cc=plugin.project.owner_email,
+            items=items,
+            contact_fullname=commander_fullname,
+            contact_weblink=commander_weblink,
+        )
+    except Exception as e:
+        log.error(f"Error in sending {notification_text} email to {commander_email}: {e}")
 
     log.debug(f"Incident feedback daily report sent to {commander_email}.")

--- a/src/dispatch/incident/messaging.py
+++ b/src/dispatch/incident/messaging.py
@@ -185,7 +185,7 @@ def send_welcome_email_to_participant(
             **message_kwargs,
         )
     except Exception as e:
-        log.error(f"Error in sending welcome email to {participant_email}: {e}.")
+        log.error(f"Error in sending welcome email to {participant_email}: {e}")
 
     log.debug(f"Welcome email sent to {participant_email}.")
 

--- a/src/dispatch/incident/messaging.py
+++ b/src/dispatch/incident/messaging.py
@@ -174,13 +174,18 @@ def send_welcome_email_to_participant(
         )
 
     notification_text = "Incident Notification"
-    plugin.instance.send(
-        participant_email,
-        notification_text,
-        INCIDENT_PARTICIPANT_WELCOME_MESSAGE,
-        MessageType.incident_participant_welcome,
-        **message_kwargs,
-    )
+
+    # Can raise exception "tenacity.RetryError: RetryError". (Email may still go through).
+    try:
+        plugin.instance.send(
+            participant_email,
+            notification_text,
+            INCIDENT_PARTICIPANT_WELCOME_MESSAGE,
+            MessageType.incident_participant_welcome,
+            **message_kwargs,
+        )
+    except Exception as e:
+        log.error(f"Error in sending welcome email to {participant_email}: {e}.")
 
     log.debug(f"Welcome email sent to {participant_email}.")
 

--- a/src/dispatch/plugins/dispatch_slack/config.py
+++ b/src/dispatch/plugins/dispatch_slack/config.py
@@ -76,7 +76,7 @@ class SlackConversationConfiguration(SlackConfiguration):
     slack_command_assign_role: str = Field(
         "/dispatch-assign-role",
         title="Assign Role Command String",
-        description="Defines the string used assign a role in an incident. Must match what is defined in Slack.",
+        description="Defines the string used to assign a role in an incident. Must match what is defined in Slack.",
     )
     slack_command_update_incident: str = Field(
         "/dispatch-update-incident",


### PR DESCRIPTION
Gmail is consistency throwing below exception during .send(). GCP "golden signals" for the API look fine. Also, no similar issues with other gsuite calls like drive and groups. 

`ERROR:Error/Exception in sending Tactical Report email to ...... RetryError[<Future at 0x7f613d72ce80 state=finished raised KeyError>]  `

Weird thing is, the emails are still being sent. Actually, sent three times (tenacity retry_count of 3) to a domain account; one email to a regular gmail account (despite making three calls and same end error). 

Without the wrap, incident creation fails at the send_inc_notifs stage. Not sure if anyone else is experiencing this, but if they do,  this should help in the interim. 

I will continue to dig deeper. 