### PR TITLE
Always upper log_level before logging config

### DIFF
--- a/src/dispatch/logging.py
+++ b/src/dispatch/logging.py
@@ -3,9 +3,10 @@ from dispatch.config import LOG_LEVEL
 
 
 def configure_logging():
-    if LOG_LEVEL == "DEBUG":
+    level = LOG_LEVEL.upper()
+    if level == "DEBUG":
         # log level:logged message:full module path:function invoked:line number of logging call
         LOGFORMAT = "%(levelname)s:%(message)s:%(pathname)s:%(funcName)s:%(lineno)d"
-        logging.basicConfig(level=LOG_LEVEL, format=LOGFORMAT)
+        logging.basicConfig(level=level, format=LOGFORMAT)
     else:
-        logging.basicConfig(level=LOG_LEVEL)
+        logging.basicConfig(level=level)


### PR DESCRIPTION
Hello,
thank you for dispatch, looks great and super useful!

While testing/deploying I came across an inconsistency between cli's `--log-level` and `LOG_LEVEL` in env/config. Namely the latter can be only uppercase while the former is lower case. What do you think of the attached commit ?

thank you!