### PR TITLE
Fixes doc creation issue if template is None

### DIFF
--- a/src/dispatch/plugins/dispatch_google/drive/drive.py
+++ b/src/dispatch/plugins/dispatch_google/drive/drive.py
@@ -167,8 +167,11 @@ def create_file(
     file_type: str = "folder",
 ):
     """Creates a new folder with the specified parents."""
-    mimetype = "application/vnd.google-apps.document"
-    if file_type == "folder":
+    if file_type == "document":
+        mimetype = "application/vnd.google-apps.document"
+    elif file_type == "sheet":
+        mimetype = "application/vnd.google-apps.spreadsheet"
+    elif file_type == "folder":
         mimetype = "application/vnd.google-apps.folder"
 
     file_metadata = {"name": name, "mimeType": mimetype, "parents": [parent_id]}


### PR DESCRIPTION
During create_flow, if the reporting template doesn't exist, we create a new one, but immediately try to access the non-existent `description` attr during update(), which throws an exception. This fixes it.

Added code to create a new tracking sheet if template is not in config, with update() moved like above.

Added if/else flow based on the mimeType.

Tested my changes.