### PR TITLE
Sets response model to None for all delete endpoints to address breaking changes in FastAPI v0.80.0

### DIFF
--- a/src/dispatch/case/views.py
+++ b/src/dispatch/case/views.py
@@ -154,7 +154,7 @@ def update_case(
 
 @router.delete(
     "/{case_id}",
-    response_model=CaseRead,
+    response_model=None,
     summary="Deletes an existing case.",
     # dependencies=[Depends(PermissionsDependency([CaseEditPermission]))],
 )
@@ -183,7 +183,7 @@ def delete_case(
                 {
                     "msg": (
                         f"Case {case.name} could not be deleted. Make sure the case has no ",
-                        "relationshipts to other cases or incidents before deleting it.",
+                        "relationships to other cases or incidents before deleting it.",
                     )
                 }
             ],

--- a/src/dispatch/data/alert/views.py
+++ b/src/dispatch/data/alert/views.py
@@ -16,7 +16,7 @@ router = APIRouter()
 
 @router.get("/{alert_id}", response_model=AlertRead)
 def get_alert(*, db_session: Session = Depends(get_db), alert_id: PrimaryKey):
-    """Given its unique ID, retrieve details about a single alert."""
+    """Given its unique id, retrieve details about a single alert."""
     alert = get(db_session=db_session, alert_id=alert_id)
     if not alert:
         raise HTTPException(
@@ -28,33 +28,31 @@ def get_alert(*, db_session: Session = Depends(get_db), alert_id: PrimaryKey):
 
 @router.post("", response_model=AlertRead)
 def create_alert(*, db_session: Session = Depends(get_db), alert_in: AlertCreate):
-    """Create a new alert."""
-    alert = create(db_session=db_session, alert_in=alert_in)
-    return alert
+    """Creates a new alert."""
+    return create(db_session=db_session, alert_in=alert_in)
 
 
 @router.put("/{alert_id}", response_model=AlertRead)
 def update_alert(
     *, db_session: Session = Depends(get_db), alert_id: PrimaryKey, alert_in: AlertUpdate
 ):
-    """Update a alert."""
+    """Updates an alert."""
     alert = get(db_session=db_session, alert_id=alert_id)
     if not alert:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An alert with this ID does not exist."}],
+            detail=[{"msg": "An alert with this id does not exist."}],
         )
-    alert = update(db_session=db_session, alert=alert, alert_in=alert_in)
-    return alert
+    return update(db_session=db_session, alert=alert, alert_in=alert_in)
 
 
-@router.delete("/{alert_id}")
+@router.delete("/{alert_id}", response_model=None)
 def delete_alert(*, db_session: Session = Depends(get_db), alert_id: PrimaryKey):
-    """Delete a alert, returning only an HTTP 200 OK if successful."""
+    """Deletes an alert, returning only an HTTP 200 OK if successful."""
     alert = get(db_session=db_session, alert_id=alert_id)
     if not alert:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An alert with this ID does not exist."}],
+            detail=[{"msg": "An alert with this id does not exist."}],
         )
     delete(db_session=db_session, alert_id=alert_id)

--- a/src/dispatch/data/query/views.py
+++ b/src/dispatch/data/query/views.py
@@ -36,33 +36,31 @@ def get_query(*, db_session: Session = Depends(get_db), query_id: PrimaryKey):
 
 @router.post("", response_model=QueryRead)
 def create_query(*, db_session: Session = Depends(get_db), query_in: QueryCreate):
-    """Create a new query."""
-    query = create(db_session=db_session, query_in=query_in)
-    return query
+    """Creates a new data query."""
+    return create(db_session=db_session, query_in=query_in)
 
 
 @router.put("/{query_id}", response_model=QueryRead)
 def update_query(
     *, db_session: Session = Depends(get_db), query_id: PrimaryKey, query_in: QueryUpdate
 ):
-    """Update a query."""
+    """Updates a data query."""
     query = get(db_session=db_session, query_id=query_id)
     if not query:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "A query with this ID does not exist."}],
+            detail=[{"msg": "A data query with this id does not exist."}],
         )
-    query = update(db_session=db_session, query=query, query_in=query_in)
-    return query
+    return update(db_session=db_session, query=query, query_in=query_in)
 
 
-@router.delete("/{query_id}")
+@router.delete("/{query_id}", response_model=None)
 def delete_query(*, db_session: Session = Depends(get_db), query_id: PrimaryKey):
-    """Delete a query, returning only an HTTP 200 OK if successful."""
+    """Deletes a data query, returning only an HTTP 200 OK if successful."""
     query = get(db_session=db_session, query_id=query_id)
     if not query:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "A query with this ID does not exist."}],
+            detail=[{"msg": "A data query with this id does not exist."}],
         )
     delete(db_session=db_session, query_id=query_id)

--- a/src/dispatch/data/source/data_format/views.py
+++ b/src/dispatch/data/source/data_format/views.py
@@ -20,7 +20,7 @@ router = APIRouter()
 
 @router.get("", response_model=SourceDataFormatPagination)
 def get_source_data_formats(*, common: dict = Depends(common_parameters)):
-    """Get all source_data_format data formats, or only those matching a given search term."""
+    """Get all source data formats, or only those matching a given search term."""
     return search_filter_sort_paginate(model="SourceDataFormat", **common)
 
 
@@ -28,7 +28,7 @@ def get_source_data_formats(*, common: dict = Depends(common_parameters)):
 def get_source_data_format(
     *, db_session: Session = Depends(get_db), source_data_format_id: PrimaryKey
 ):
-    """Given its unique ID, retrieve details about a data format."""
+    """Given its unique id, retrieve details about a source data format."""
     source_data_format = get(db_session=db_session, source_data_format_id=source_data_format_id)
     if not source_data_format:
         raise HTTPException(
@@ -42,9 +42,8 @@ def get_source_data_format(
 def create_source_data_format(
     *, db_session: Session = Depends(get_db), source_data_format_in: SourceDataFormatCreate
 ):
-    """Create a new data format."""
-    source_data_format = create(db_session=db_session, source_data_format_in=source_data_format_in)
-    return source_data_format
+    """Creates a new source data format."""
+    return create(db_session=db_session, source_data_format_in=source_data_format_in)
 
 
 @router.put("/{source_data_format_id}", response_model=SourceDataFormatRead)
@@ -54,30 +53,29 @@ def update_source_data_format(
     source_data_format_id: PrimaryKey,
     source_data_format_in: SourceDataFormatUpdate,
 ):
-    """Update a data format."""
+    """Updates a source data format."""
     source_data_format = get(db_session=db_session, source_data_format_id=source_data_format_id)
     if not source_data_format:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An data format with this ID does not exist."}],
+            detail=[{"msg": "A source data format with this id does not exist."}],
         )
-    source_data_format = update(
+    return update(
         db_session=db_session,
         source_data_format=source_data_format,
         source_data_format_in=source_data_format_in,
     )
-    return source_data_format
 
 
-@router.delete("/{source_data_format_id}")
+@router.delete("/{source_data_format_id}", response_model=None)
 def delete_source_data_format(
     *, db_session: Session = Depends(get_db), source_data_format_id: PrimaryKey
 ):
-    """Delete a data format, returning only an HTTP 200 OK if successful."""
+    """Delete a source data format, returning only an HTTP 200 OK if successful."""
     source_data_format = get(db_session=db_session, source_data_format_id=source_data_format_id)
     if not source_data_format:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An data format with this ID does not exist."}],
+            detail=[{"msg": "A source data format with this id does not exist."}],
         )
     delete(db_session=db_session, source_data_format_id=source_data_format_id)

--- a/src/dispatch/data/source/environment/views.py
+++ b/src/dispatch/data/source/environment/views.py
@@ -28,7 +28,7 @@ def get_source_environments(*, common: dict = Depends(common_parameters)):
 def get_source_environment(
     *, db_session: Session = Depends(get_db), source_environment_id: PrimaryKey
 ):
-    """Given its unique ID, retrieve details about a single source_environment environment."""
+    """Given its unique id, retrieve details about a single source_environment environment."""
     source_environment = get(db_session=db_session, source_environment_id=source_environment_id)
     if not source_environment:
         raise HTTPException(
@@ -42,9 +42,8 @@ def get_source_environment(
 def create_source_environment(
     *, db_session: Session = Depends(get_db), source_environment_in: SourceEnvironmentCreate
 ):
-    """Create a new source_environment environment."""
-    source_environment = create(db_session=db_session, source_environment_in=source_environment_in)
-    return source_environment
+    """Creates a new source environment."""
+    return create(db_session=db_session, source_environment_in=source_environment_in)
 
 
 @router.put("/{source_environment_id}", response_model=SourceEnvironmentRead)
@@ -54,30 +53,29 @@ def update_source_environment(
     source_environment_id: PrimaryKey,
     source_environment_in: SourceEnvironmentUpdate,
 ):
-    """Update a source_environment environment."""
+    """Updates a source environment."""
     source_environment = get(db_session=db_session, source_environment_id=source_environment_id)
     if not source_environment:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An source_environment environment with this ID does not exist."}],
+            detail=[{"msg": "A source environment with this id does not exist."}],
         )
-    source_environment = update(
+    return update(
         db_session=db_session,
         source_environment=source_environment,
         source_environment_in=source_environment_in,
     )
-    return source_environment
 
 
-@router.delete("/{source_environment_id}")
+@router.delete("/{source_environment_id}", response_model=None)
 def delete_source_environment(
     *, db_session: Session = Depends(get_db), source_environment_id: PrimaryKey
 ):
-    """Delete a source_environment environment, returning only an HTTP 200 OK if successful."""
+    """Delete a source environment, returning only an HTTP 200 OK if successful."""
     source_environment = get(db_session=db_session, source_environment_id=source_environment_id)
     if not source_environment:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An source_environment environment with this ID does not exist."}],
+            detail=[{"msg": "A source environment with this id does not exist."}],
         )
     delete(db_session=db_session, source_environment_id=source_environment_id)

--- a/src/dispatch/data/source/status/views.py
+++ b/src/dispatch/data/source/status/views.py
@@ -26,7 +26,7 @@ def get_source_statuses(*, common: dict = Depends(common_parameters)):
 
 @router.get("/{source_status_id}", response_model=SourceStatusRead)
 def get_source_status(*, db_session: Session = Depends(get_db), source_status_id: PrimaryKey):
-    """Given its unique ID, retrieve details about a single source status."""
+    """Given its unique id, retrieve details about a single source status."""
     status = get(db_session=db_session, source_status_id=source_status_id)
     if not status:
         raise HTTPException(
@@ -40,7 +40,7 @@ def get_source_status(*, db_session: Session = Depends(get_db), source_status_id
 def create_source_status(
     *, db_session: Session = Depends(get_db), source_status_in: SourceStatusCreate
 ):
-    """Create a new source status."""
+    """Creates a new source status."""
     return create(db_session=db_session, source_status_in=source_status_in)
 
 
@@ -51,24 +51,23 @@ def update_source_status(
     source_status_id: PrimaryKey,
     source_status_in: SourceStatusUpdate,
 ):
-    """Update a status status."""
+    """Updates a source status."""
     status = get(db_session=db_session, source_status_id=source_status_id)
     if not status:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An source status with this ID does not exist."}],
+            detail=[{"msg": "A source status with this id does not exist."}],
         )
-    status = update(db_session=db_session, source_status=status, source_status_in=source_status_in)
-    return status
+    return update(db_session=db_session, source_status=status, source_status_in=source_status_in)
 
 
-@router.delete("/{source_status_id}")
+@router.delete("/{source_status_id}", response_model=None)
 def delete_source_status(*, db_session: Session = Depends(get_db), source_status_id: PrimaryKey):
-    """Delete a source status, returning only an HTTP 200 OK if successful."""
+    """Deletes a source status, returning only an HTTP 200 OK if successful."""
     status = get(db_session=db_session, source_status_id=source_status_id)
     if not status:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An source status with this ID does not exist."}],
+            detail=[{"msg": "A source status with this id does not exist."}],
         )
     delete(db_session=db_session, source_status_id=source_status_id)

--- a/src/dispatch/data/source/transport/views.py
+++ b/src/dispatch/data/source/transport/views.py
@@ -26,7 +26,7 @@ def get_source_transports(*, common: dict = Depends(common_parameters)):
 
 @router.get("/{source_transport_id}", response_model=SourceTransportRead)
 def get_source_transport(*, db_session: Session = Depends(get_db), source_transport_id: PrimaryKey):
-    """Given its unique ID, retrieve details about a single source transport."""
+    """Given its unique id, retrieve details about a single source transport."""
     transport = get(db_session=db_session, source_transport_id=source_transport_id)
     if not transport:
         raise HTTPException(
@@ -40,7 +40,7 @@ def get_source_transport(*, db_session: Session = Depends(get_db), source_transp
 def create_source_transport(
     *, db_session: Session = Depends(get_db), source_transport_in: SourceTransportCreate
 ):
-    """Create a new source transport."""
+    """Creates a new source transport."""
     return create(db_session=db_session, source_transport_in=source_transport_in)
 
 
@@ -51,27 +51,27 @@ def update_source_transport(
     source_transport_id: PrimaryKey,
     source_transport_in: SourceTransportUpdate,
 ):
-    """Update a source transport."""
+    """Updates a source transport."""
     transport = get(db_session=db_session, source_transport_id=source_transport_id)
     if not transport:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An source transport with this ID does not exist."}],
+            detail=[{"msg": "A source transport with this id does not exist."}],
         )
     return update(
         db_session=db_session, source_transport=transport, source_transport_in=source_transport_in
     )
 
 
-@router.delete("/{source_transport_id}")
+@router.delete("/{source_transport_id}", response_model=None)
 def delete_source_transport(
     *, db_session: Session = Depends(get_db), source_transport_id: PrimaryKey
 ):
-    """Delete a source transport, returning only an HTTP 200 OK if successful."""
+    """Deletes a source transport, returning only an HTTP 200 OK if successful."""
     transport = get(db_session=db_session, source_transport_id=source_transport_id)
     if not transport:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An source transport with this ID does not exist."}],
+            detail=[{"msg": "A source transport with this id does not exist."}],
         )
     delete(db_session=db_session, source_transport_id=source_transport_id)

--- a/src/dispatch/data/source/type/views.py
+++ b/src/dispatch/data/source/type/views.py
@@ -26,7 +26,7 @@ def get_source_types(*, common: dict = Depends(common_parameters)):
 
 @router.get("/{source_type_id}", response_model=SourceTypeRead)
 def get_source_type(*, db_session: Session = Depends(get_db), source_type_id: PrimaryKey):
-    """Given its unique ID, retrieve details about a single source type."""
+    """Given its unique id, retrieve details about a single source type."""
     source_type = get(db_session=db_session, source_type_id=source_type_id)
     if not source_type:
         raise HTTPException(
@@ -38,7 +38,7 @@ def get_source_type(*, db_session: Session = Depends(get_db), source_type_id: Pr
 
 @router.post("", response_model=SourceTypeRead)
 def create_source_type(*, db_session: Session = Depends(get_db), source_type_in: SourceTypeCreate):
-    """Create a new source type."""
+    """Creates a new source type."""
     return create(db_session=db_session, source_type_in=source_type_in)
 
 
@@ -49,23 +49,23 @@ def update_source_type(
     source_type_id: PrimaryKey,
     source_type_in: SourceTypeUpdate,
 ):
-    """Update a source type."""
+    """Updates a source type."""
     source_type = get(db_session=db_session, source_type_id=source_type_id)
     if not source_type:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An source type with this ID does not exist."}],
+            detail=[{"msg": "An source type with this id does not exist."}],
         )
     return update(db_session=db_session, source_type=source_type, source_type_in=source_type_in)
 
 
-@router.delete("/{source_type_id}")
+@router.delete("/{source_type_id}", response_model=None)
 def delete_source_type(*, db_session: Session = Depends(get_db), source_type_id: PrimaryKey):
-    """Delete a source type, returning only an HTTP 200 OK if successful."""
+    """Deletes a source type, returning only an HTTP 200 OK if successful."""
     source_type = get(db_session=db_session, source_type_id=source_type_id)
     if not source_type:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An source type with this ID does not exist."}],
+            detail=[{"msg": "An source type with this id does not exist."}],
         )
     delete(db_session=db_session, source_type_id=source_type_id)

--- a/src/dispatch/data/source/views.py
+++ b/src/dispatch/data/source/views.py
@@ -24,7 +24,7 @@ def get_sources(*, common: dict = Depends(common_parameters)):
 
 @router.get("/{source_id}", response_model=SourceRead)
 def get_source(*, db_session: Session = Depends(get_db), source_id: PrimaryKey):
-    """Given its unique ID, retrieve details about a single source."""
+    """Given its unique id, retrieve details about a single source."""
     source = get(db_session=db_session, source_id=source_id)
     if not source:
         raise HTTPException(
@@ -36,33 +36,31 @@ def get_source(*, db_session: Session = Depends(get_db), source_id: PrimaryKey):
 
 @router.post("", response_model=SourceRead)
 def create_source(*, db_session: Session = Depends(get_db), source_in: SourceCreate):
-    """Create a new source."""
-    source = create(db_session=db_session, source_in=source_in)
-    return source
+    """Creates a new source."""
+    return create(db_session=db_session, source_in=source_in)
 
 
 @router.put("/{source_id}", response_model=SourceRead)
 def update_source(
     *, db_session: Session = Depends(get_db), source_id: PrimaryKey, source_in: SourceUpdate
 ):
-    """Update a source."""
+    """Updates a source."""
     source = get(db_session=db_session, source_id=source_id)
     if not source:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An source with this ID does not exist."}],
+            detail=[{"msg": "A source with this id does not exist."}],
         )
-    source = update(db_session=db_session, source=source, source_in=source_in)
-    return source
+    return update(db_session=db_session, source=source, source_in=source_in)
 
 
-@router.delete("/{source_id}")
+@router.delete("/{source_id}", response_model=None)
 def delete_source(*, db_session: Session = Depends(get_db), source_id: PrimaryKey):
-    """Delete a source, returning only an HTTP 200 OK if successful."""
+    """Deletes a source, returning only an HTTP 200 OK if successful."""
     source = get(db_session=db_session, source_id=source_id)
     if not source:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An source with this ID does not exist."}],
+            detail=[{"msg": "A source with this id does not exist."}],
         )
     delete(db_session=db_session, source_id=source_id)

--- a/src/dispatch/definition/views.py
+++ b/src/dispatch/definition/views.py
@@ -31,7 +31,7 @@ def get_definition(*, db_session: Session = Depends(get_db), definition_id: Prim
     if not definition:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "The definition with this id does not exist."}],
+            detail=[{"msg": "A definition with this id does not exist."}],
         )
     return definition
 
@@ -50,8 +50,7 @@ def create_definition(*, db_session: Session = Depends(get_db), definition_in: D
             model=DefinitionRead,
         )
 
-    definition = create(db_session=db_session, definition_in=definition_in)
-    return definition
+    return create(db_session=db_session, definition_in=definition_in)
 
 
 @router.put("/{definition_id}", response_model=DefinitionRead)
@@ -66,19 +65,18 @@ def update_definition(
     if not definition:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "The definition with this id does not exist."}],
+            detail=[{"msg": "A definition with this id does not exist."}],
         )
-    definition = update(db_session=db_session, definition=definition, definition_in=definition_in)
-    return definition
+    return update(db_session=db_session, definition=definition, definition_in=definition_in)
 
 
-@router.delete("/{definition_id}")
+@router.delete("/{definition_id}", response_model=None)
 def delete_definition(*, db_session: Session = Depends(get_db), definition_id: PrimaryKey):
     """Delete a definition."""
     definition = get(db_session=db_session, definition_id=definition_id)
     if not definition:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "The definition with this id does not exist."}],
+            detail=[{"msg": "A definition with this id does not exist."}],
         )
     delete(db_session=db_session, definition_id=definition_id)

--- a/src/dispatch/document/views.py
+++ b/src/dispatch/document/views.py
@@ -24,7 +24,7 @@ def get_document(*, db_session: Session = Depends(get_db), document_id: PrimaryK
     if not document:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "The document with this id does not exist."}],
+            detail=[{"msg": "A document with this id does not exist."}],
         )
     return document
 
@@ -44,19 +44,19 @@ def update_document(
     if not document:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "The document with this id does not exist."}],
+            detail=[{"msg": "A document with this id does not exist."}],
         )
     document = update(db_session=db_session, document=document, document_in=document_in)
     return document
 
 
-@router.delete("/{document_id}")
+@router.delete("/{document_id}", response_model=None)
 def delete_document(*, db_session: Session = Depends(get_db), document_id: PrimaryKey):
     """Delete a document."""
     document = get(db_session=db_session, document_id=document_id)
     if not document:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "The document with this id does not exist."}],
+            detail=[{"msg": "A document with this id does not exist."}],
         )
     delete(db_session=db_session, document_id=document_id)

--- a/src/dispatch/feedback/views.py
+++ b/src/dispatch/feedback/views.py
@@ -57,7 +57,7 @@ def update_feedback(
     return feedback
 
 
-@router.delete("/{feedback_id}")
+@router.delete("/{feedback_id}", response_model=None)
 def delete_feedback(*, db_session: Session = Depends(get_db), feedback_id: PrimaryKey):
     """Delete a feedback entry, returning only an HTTP 200 OK if successful."""
     feedback = get(db_session=db_session, feedback_id=feedback_id)

--- a/src/dispatch/incident/views.py
+++ b/src/dispatch/incident/views.py
@@ -1,7 +1,5 @@
 import logging
 from typing import List
-from pydantic import Json
-
 import json
 import calendar
 from datetime import date
@@ -53,7 +51,7 @@ def get_current_incident(*, db_session: Session = Depends(get_db), request: Requ
     if not incident:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "The requested incident does not exist."}],
+            detail=[{"msg": "An incident with this id does not existt."}],
         )
     return incident
 
@@ -264,7 +262,7 @@ def create_executive_report(
 
 @router.delete(
     "/{incident_id}",
-    response_model=IncidentRead,
+    response_model=None,
     summary="Delete an incident.",
     dependencies=[Depends(PermissionsDependency([IncidentEditPermission]))],
 )

--- a/src/dispatch/incident_cost/views.py
+++ b/src/dispatch/incident_cost/views.py
@@ -77,6 +77,7 @@ def update_incident_cost(
 
 @router.delete(
     "/{incident_cost_id}",
+    response_model=None,
     dependencies=[Depends(PermissionsDependency([SensitiveProjectActionPermission]))],
 )
 def delete_incident_cost(*, db_session: Session = Depends(get_db), incident_cost_id: PrimaryKey):

--- a/src/dispatch/incident_cost_type/views.py
+++ b/src/dispatch/incident_cost_type/views.py
@@ -86,6 +86,7 @@ def update_incident_cost_type(
 
 @router.delete(
     "/{incident_cost_type_id}",
+    response_model=None,
     dependencies=[Depends(PermissionsDependency([SensitiveProjectActionPermission]))],
 )
 def delete_incident_cost_type(

--- a/src/dispatch/individual/views.py
+++ b/src/dispatch/individual/views.py
@@ -2,9 +2,9 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
 from sqlalchemy.orm import Session
 
+from dispatch.auth.permissions import PermissionsDependency, SensitiveProjectActionPermission
 from dispatch.database.core import get_db
 from dispatch.database.service import common_parameters, search_filter_sort_paginate
-from dispatch.auth.permissions import PermissionsDependency, SensitiveProjectActionPermission
 from dispatch.exceptions import ExistsError
 from dispatch.models import PrimaryKey
 
@@ -20,6 +20,18 @@ from .service import get, get_by_email_and_project, create, update, delete
 router = APIRouter()
 
 
+@router.get("/{individual_contact_id}", response_model=IndividualContactRead)
+def get_individual(*, db_session: Session = Depends(get_db), individual_contact_id: PrimaryKey):
+    """Gets an individual contact."""
+    individual = get(db_session=db_session, individual_contact_id=individual_contact_id)
+    if not individual:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=[{"msg": "An individual with this id does not exist."}],
+        )
+    return individual
+
+
 @router.get("", response_model=IndividualContactPagination)
 def get_individuals(*, common: dict = Depends(common_parameters)):
     """Retrieve individual contacts."""
@@ -30,7 +42,7 @@ def get_individuals(*, common: dict = Depends(common_parameters)):
 def create_individual(
     *, db_session: Session = Depends(get_db), individual_contact_in: IndividualContactCreate
 ):
-    """Create a new individual contact."""
+    """Creates a new individual contact."""
     individual = get_by_email_and_project(
         db_session=db_session,
         email=individual_contact_in.email,
@@ -46,26 +58,13 @@ def create_individual(
             ],
             model=IndividualContactRead,
         )
-    individual = create(db_session=db_session, individual_contact_in=individual_contact_in)
-    return individual
-
-
-@router.get("/{individual_contact_id}", response_model=IndividualContactRead)
-def get_individual(*, db_session: Session = Depends(get_db), individual_contact_id: PrimaryKey):
-    """Get an individual contact."""
-    individual = get(db_session=db_session, individual_contact_id=individual_contact_id)
-    if not individual:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An individual with this id does not exist."}],
-        )
-    return individual
+    return create(db_session=db_session, individual_contact_in=individual_contact_in)
 
 
 @router.put(
     "/{individual_contact_id}",
     response_model=IndividualContactRead,
-    summary="Update an individual's contact information.",
+    summary="Updates an individual's contact information.",
     dependencies=[Depends(PermissionsDependency([SensitiveProjectActionPermission]))],
 )
 def update_individual(
@@ -74,35 +73,32 @@ def update_individual(
     individual_contact_id: PrimaryKey,
     individual_contact_in: IndividualContactUpdate,
 ):
-    """Update an individual contact."""
+    """Updates an individual contact."""
     individual = get(db_session=db_session, individual_contact_id=individual_contact_id)
     if not individual:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=[{"msg": "An individual with this id does not exist."}],
         )
-    individual = update(
+    return update(
         db_session=db_session,
         individual_contact=individual,
         individual_contact_in=individual_contact_in,
     )
-    return individual
 
 
 @router.delete(
     "/{individual_contact_id}",
-    summary="Delete an individual contact.",
+    response_model=None,
+    summary="Deletes an individual contact.",
     dependencies=[Depends(PermissionsDependency([SensitiveProjectActionPermission]))],
 )
-async def delete_individual(
-    *, db_session: Session = Depends(get_db), individual_contact_id: PrimaryKey
-):
-    """Delete an individual contact."""
+def delete_individual(*, db_session: Session = Depends(get_db), individual_contact_id: PrimaryKey):
+    """Deletes an individual contact."""
     individual = get(db_session=db_session, individual_contact_id=individual_contact_id)
     if not individual:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=[{"msg": "An individual with this id does not exist."}],
         )
-
     delete(db_session=db_session, individual_contact_id=individual_contact_id)

--- a/src/dispatch/notification/views.py
+++ b/src/dispatch/notification/views.py
@@ -75,6 +75,7 @@ def update_notification(
 
 @router.delete(
     "/{notification_id}",
+    response_model=None,
     dependencies=[Depends(PermissionsDependency([SensitiveProjectActionPermission]))],
 )
 def delete_notification(*, db_session: Session = Depends(get_db), notification_id: PrimaryKey):

--- a/src/dispatch/plugin/views.py
+++ b/src/dispatch/plugin/views.py
@@ -93,6 +93,7 @@ def update_plugin_instance(
 
 @router.delete(
     "/instances/{plugin_instance_id}",
+    response_model=None,
     dependencies=[Depends(PermissionsDependency([SensitiveProjectActionPermission]))],
 )
 def delete_plugin_instances(
@@ -107,5 +108,4 @@ def delete_plugin_instances(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=[{"msg": "A plugin instance with this id does not exist."}],
         )
-
     delete_instance(db_session=db_session, plugin_instance_id=plugin_instance_id)

--- a/src/dispatch/project/views.py
+++ b/src/dispatch/project/views.py
@@ -90,7 +90,7 @@ def update_project(
 
 @router.delete(
     "/{project_id}",
-    response_model=ProjectRead,
+    response_model=None,
     dependencies=[Depends(PermissionsDependency([ProjectUpdatePermission]))],
 )
 def delete_project(*, db_session: Session = Depends(get_db), project_id: PrimaryKey):
@@ -101,6 +101,4 @@ def delete_project(*, db_session: Session = Depends(get_db), project_id: Primary
             status_code=status.HTTP_404_NOT_FOUND,
             detail=[{"msg": "A project with this id does not exist."}],
         )
-
     delete(db_session=db_session, project_id=project_id)
-    return project

--- a/src/dispatch/search_filter/views.py
+++ b/src/dispatch/search_filter/views.py
@@ -16,6 +16,7 @@ from .models import (
 )
 from .service import create, delete, get, update
 
+
 router = APIRouter()
 
 
@@ -73,7 +74,7 @@ def update_search_filter(
     return search_filter
 
 
-@router.delete("/{search_filter_id}")
+@router.delete("/{search_filter_id}", response_model=None)
 def delete_filter(*, db_session: Session = Depends(get_db), search_filter_id: PrimaryKey):
     """Delete a search filter."""
     search_filter = get(db_session=db_session, search_filter_id=search_filter_id)
@@ -82,5 +83,4 @@ def delete_filter(*, db_session: Session = Depends(get_db), search_filter_id: Pr
             status_code=status.HTTP_404_NOT_FOUND,
             detail=[{"msg": "A search filter with this id does not exist."}],
         )
-
     delete(db_session=db_session, search_filter_id=search_filter_id)

--- a/src/dispatch/service/views.py
+++ b/src/dispatch/service/views.py
@@ -81,7 +81,7 @@ def update_service(
 
 @router.get("/{service_id}", response_model=ServiceRead)
 def get_service(*, db_session: Session = Depends(get_db), service_id: PrimaryKey):
-    """Gets a single service."""
+    """Gets a service."""
     service = get(db_session=db_session, service_id=service_id)
     if not service:
         raise HTTPException(
@@ -91,9 +91,9 @@ def get_service(*, db_session: Session = Depends(get_db), service_id: PrimaryKey
     return service
 
 
-@router.delete("/{service_id}")
+@router.delete("/{service_id}", response_model=None)
 def delete_service(*, db_session: Session = Depends(get_db), service_id: PrimaryKey):
-    """Deletes a single service."""
+    """Deletes a service."""
     service = get(db_session=db_session, service_id=service_id)
     if not service:
         raise HTTPException(

--- a/src/dispatch/tag/views.py
+++ b/src/dispatch/tag/views.py
@@ -25,7 +25,7 @@ def get_tags(*, common: dict = Depends(common_parameters)):
 
 @router.get("/{tag_id}", response_model=TagRead)
 def get_tag(*, db_session: Session = Depends(get_db), tag_id: PrimaryKey):
-    """Given its unique ID, retrieve details about a single tag."""
+    """Given its unique id, retrieve details about a single tag."""
     tag = get(db_session=db_session, tag_id=tag_id)
     if not tag:
         raise HTTPException(
@@ -37,32 +37,30 @@ def get_tag(*, db_session: Session = Depends(get_db), tag_id: PrimaryKey):
 
 @router.post("", response_model=TagRead)
 def create_tag(*, db_session: Session = Depends(get_db), tag_in: TagCreate):
-    """Create a new tag."""
-    tag = create(db_session=db_session, tag_in=tag_in)
-    return tag
+    """Creates a new tag."""
+    return create(db_session=db_session, tag_in=tag_in)
 
 
 @router.put("/{tag_id}", response_model=TagRead)
 def update_tag(*, db_session: Session = Depends(get_db), tag_id: PrimaryKey, tag_in: TagUpdate):
-    """Update a tag."""
+    """Updates an exisiting tag."""
     tag = get(db_session=db_session, tag_id=tag_id)
     if not tag:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An tag with this ID does not exist."}],
+            detail=[{"msg": "A tag with this id does not exist."}],
         )
-    tag = update(db_session=db_session, tag=tag, tag_in=tag_in)
-    return tag
+    return update(db_session=db_session, tag=tag, tag_in=tag_in)
 
 
-@router.delete("/{tag_id}")
+@router.delete("/{tag_id}", response_model=None)
 def delete_tag(*, db_session: Session = Depends(get_db), tag_id: PrimaryKey):
-    """Delete a tag, returning only an HTTP 200 OK if successful."""
+    """Deletes a tag, returning only an HTTP 200 OK if successful."""
     tag = get(db_session=db_session, tag_id=tag_id)
     if not tag:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "An tag with this ID does not exist."}],
+            detail=[{"msg": "A tag with this id does not exist."}],
         )
     delete(db_session=db_session, tag_id=tag_id)
 

--- a/src/dispatch/tag_type/views.py
+++ b/src/dispatch/tag_type/views.py
@@ -51,7 +51,6 @@ def create_tag_type(*, db_session: Session = Depends(get_db), tag_type_in: TagTy
             ],
             model=TagTypeCreate,
         )
-
     return tag_type
 
 
@@ -81,7 +80,7 @@ def update_tag_type(
     return tag_type
 
 
-@router.delete("/{tag_type_id}")
+@router.delete("/{tag_type_id}", response_model=None)
 def delete_tag_type(*, db_session: Session = Depends(get_db), tag_type_id: PrimaryKey):
     """Delete a tag type."""
     tag_type = get(db_session=db_session, tag_type_id=tag_type_id)

--- a/src/dispatch/task/views.py
+++ b/src/dispatch/task/views.py
@@ -14,6 +14,7 @@ from dispatch.models import PrimaryKey
 from .models import TaskCreate, TaskUpdate, TaskRead, TaskPagination
 from .service import get, update, create, delete
 
+
 router = APIRouter()
 
 
@@ -48,8 +49,7 @@ def create_task(
 ):
     """Creates a new task."""
     task_in.creator = {"individual": {"email": current_user.email}}
-    task = create(db_session=db_session, task_in=task_in)
-    return task
+    return create(db_session=db_session, task_in=task_in)
 
 
 @router.put("/{task_id}", response_model=TaskRead, tags=["tasks"])
@@ -61,11 +61,10 @@ def update_task(*, db_session: Session = Depends(get_db), task_id: PrimaryKey, t
             status_code=status.HTTP_404_NOT_FOUND,
             detail=[{"msg": "A task with this id does not exist."}],
         )
-    task = update(db_session=db_session, task=task, task_in=task_in)
-    return task
+    return update(db_session=db_session, task=task, task_in=task_in)
 
 
-@router.delete("/{task_id}", response_model=TaskRead, tags=["tasks"])
+@router.delete("/{task_id}", response_model=None, tags=["tasks"])
 def delete_task(*, db_session: Session = Depends(get_db), task_id: PrimaryKey):
     """Deletes an existing task."""
     task = get(db_session=db_session, task_id=task_id)
@@ -75,4 +74,3 @@ def delete_task(*, db_session: Session = Depends(get_db), task_id: PrimaryKey):
             detail=[{"msg": "A task with this id does not exist."}],
         )
     delete(db_session=db_session, task_id=task_id)
-    return task

--- a/src/dispatch/team/views.py
+++ b/src/dispatch/team/views.py
@@ -35,8 +35,7 @@ def create_team(*, db_session: Session = Depends(get_db), team_contact_in: TeamC
             [ErrorWrapper(ExistsError(msg="A team with this name already exists."), loc="name")],
             model=TeamContactCreate,
         )
-    team = create(db_session=db_session, team_contact_in=team_contact_in)
-    return team
+    return create(db_session=db_session, team_contact_in=team_contact_in)
 
 
 @router.get("/{team_contact_id}", response_model=TeamContactRead)
@@ -46,7 +45,7 @@ def get_team(*, db_session: Session = Depends(get_db), team_contact_id: PrimaryK
     if not team:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "The team with this id does not exist."}],
+            detail=[{"msg": "A team with this id does not exist."}],
         )
     return team
 
@@ -63,21 +62,18 @@ def update_team(
     if not team:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "The team with this id does not exist."}],
+            detail=[{"msg": "A team with this id does not exist."}],
         )
-    team = update(db_session=db_session, team_contact=team, team_contact_in=team_contact_in)
-    return team
+    return update(db_session=db_session, team_contact=team, team_contact_in=team_contact_in)
 
 
-@router.delete("/{team_contact_id}", response_model=TeamContactRead)
+@router.delete("/{team_contact_id}", response_model=None)
 def delete_team(*, db_session: Session = Depends(get_db), team_contact_id: PrimaryKey):
     """Delete a team contact."""
     team = get(db_session=db_session, team_contact_id=team_contact_id)
     if not team:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "The team with this id does not exist."}],
+            detail=[{"msg": "A team with this id does not exist."}],
         )
-
     delete(db_session=db_session, team_contact_id=team_contact_id)
-    return team

--- a/src/dispatch/term/views.py
+++ b/src/dispatch/term/views.py
@@ -39,7 +39,7 @@ def get_term(*, db_session: Session = Depends(get_db), term_id: PrimaryKey):
     if not term:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "The term with this id does not exist."}],
+            detail=[{"msg": "A term with this id does not exist."}],
         )
     return term
 
@@ -51,19 +51,19 @@ def update_term(*, db_session: Session = Depends(get_db), term_id: PrimaryKey, t
     if not term:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "The term with this id does not exist."}],
+            detail=[{"msg": "A term with this id does not exist."}],
         )
     term = update(db_session=db_session, term=term, term_in=term_in)
     return term
 
 
-@router.delete("/{term_id}")
+@router.delete("/{term_id}", response_model=None)
 def delete_term(*, db_session: Session = Depends(get_db), term_id: PrimaryKey):
     """Delete a term."""
     term = get(db_session=db_session, term_id=term_id)
     if not term:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=[{"msg": "The term with this id does not exist."}],
+            detail=[{"msg": "A term with this id does not exist."}],
         )
-    return delete(db_session=db_session, term_id=term_id)
+    delete(db_session=db_session, term_id=term_id)

--- a/src/dispatch/workflow/views.py
+++ b/src/dispatch/workflow/views.py
@@ -3,13 +3,14 @@ from pydantic.error_wrappers import ErrorWrapper, ValidationError
 from sqlalchemy.orm import Session
 
 from dispatch.database.core import get_db
-from dispatch.exceptions import NotFoundError
 from dispatch.database.service import common_parameters, search_filter_sort_paginate
+from dispatch.exceptions import NotFoundError
 from dispatch.models import PrimaryKey
-
 from dispatch.plugin import service as plugin_service
+
 from .models import WorkflowPagination, WorkflowRead, WorkflowCreate, WorkflowUpdate
 from .service import create, delete, get, update
+
 
 router = APIRouter()
 
@@ -44,8 +45,7 @@ def create_workflow(*, db_session: Session = Depends(get_db), workflow_in: Workf
             model=WorkflowCreate,
         )
 
-    workflow = create(db_session=db_session, workflow_in=workflow_in)
-    return workflow
+    return create(db_session=db_session, workflow_in=workflow_in)
 
 
 @router.put("/{workflow_id}", response_model=WorkflowRead)
@@ -59,11 +59,10 @@ def update_workflow(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=[{"msg": "A workflow with this id does not exist."}],
         )
-    workflow = update(db_session=db_session, workflow=workflow, workflow_in=workflow_in)
-    return workflow
+    return update(db_session=db_session, workflow=workflow, workflow_in=workflow_in)
 
 
-@router.delete("/{workflow_id}")
+@router.delete("/{workflow_id}", response_model=None)
 def delete_workflow(*, db_session: Session = Depends(get_db), workflow_id: PrimaryKey):
     """Delete a workflow."""
     workflow = get(db_session=db_session, workflow_id=workflow_id)


### PR DESCRIPTION
In FastAPI versions 0.80.0 or newer, the server now raises an internal server error if you are using `response_model` with some type that doesn't include `None`, but the function is returning `None`. More details [here](https://github.com/tiangolo/fastapi/releases/tag/0.80.0).

This PR sets `response_model` for all delete endpoints to `None` to prevent errors, and fixes some typos, docstrings, and response messages.