### PR TITLE
Creates an incident when a case is moved to the escalated status

### DIFF
--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -196,6 +196,7 @@ def case_update_flow(
 
     # we update the group membership
     group_flows.update_group(
+        obj=case,
         group=case.tactical_group,
         group_action=GroupAction.add_member,
         group_member=case.assignee.email,

--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -309,15 +309,6 @@ def case_status_transition_flow_dispatcher(
             # Escalated -> Closed
             case_closed_status_flow(case=case, db_session=db_session)
 
-    if current_status != previous_status:
-        # we update the timeline
-        event_service.log_case_event(
-            db_session=db_session,
-            source="Dispatch Core App",
-            description=f"The case status has been changed to {case.status.lower()}",
-            case_id=case.id,
-        )
-
 
 def case_to_incident_escalate_flow(
     case: Case, organization_slug: OrganizationSlug, db_session=None

--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -191,9 +191,11 @@ def case_update_flow(
         db_session=db_session,
     )
 
+    # TODO(mvilanova): check if ticket has changed
     # we update the ticket
     ticket_flows.update_case_ticket(case=case, db_session=db_session)
 
+    # TODO(mvilanova): check if assignee has changed
     # we update the group membership
     group_flows.update_group(
         obj=case,
@@ -335,7 +337,8 @@ def case_to_incident_escalate_flow(
 
     # we add information about the case in the incident's description
     description = (
-        f"{case.description}\n\nThis incident was the result of escalating case {case.name} "
+        f"{case.description}\n\n"
+        f"This incident was the result of escalating case {case.name} "
         f"in the {case.project.name} project. Check out the case in the Dispatch Web UI for additional context."
     )
 
@@ -369,16 +372,17 @@ def case_to_incident_escalate_flow(
 
     # we add the incident's tactical group to the case's storage folder
     # to allow incident participants to access the case's artifacts in the folder
+    storage_members = [incident.tactical_group.email]
     storage_flows.update_storage(
         obj=case,
         storage_action=StorageAction.add_members,
-        storage_members=[incident.tactical_group.email],
+        storage_members=storage_members,
         db_session=db_session,
     )
 
     event_service.log_case_event(
         db_session=db_session,
         source="Dispatch Core App",
-        description=f"The incident's tactical group {incident.tactical_group.email} has been added to the case's storage folder",
+        description=f"The members of the incident's tactical group {incident.tactical_group.email} have been given permission to access the case's storage folder",
         case_id=case.id,
     )

--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -14,6 +14,7 @@ from dispatch.incident import service as incident_service
 from dispatch.incident.enums import IncidentStatus
 from dispatch.incident.models import IncidentCreate
 from dispatch.individual.models import IndividualContactRead
+from dispatch.models import OrganizationSlug
 from dispatch.participant.models import ParticipantUpdate
 from dispatch.storage import flows as storage_flows
 from dispatch.ticket import flows as ticket_flows
@@ -26,7 +27,7 @@ log = logging.getLogger(__name__)
 
 
 @background_task
-def case_new_create_flow(*, case_id: int, organization_slug: str, db_session=None):
+def case_new_create_flow(*, case_id: int, organization_slug: OrganizationSlug, db_session=None):
     """Runs the case new creation flow."""
     # we get the case
     case = get(db_session=db_session, case_id=case_id)
@@ -110,7 +111,7 @@ def case_new_create_flow(*, case_id: int, organization_slug: str, db_session=Non
 
 
 @background_task
-def case_triage_create_flow(*, case_id: int, organization_slug: str = None, db_session=None):
+def case_triage_create_flow(*, case_id: int, organization_slug: OrganizationSlug, db_session=None):
     """Runs the case triage creation flow."""
     # we run the case new creation flow
     case_new_create_flow(
@@ -125,7 +126,9 @@ def case_triage_create_flow(*, case_id: int, organization_slug: str = None, db_s
 
 
 @background_task
-def case_escalated_create_flow(*, case_id: int, organization_slug: str = None, db_session=None):
+def case_escalated_create_flow(
+    *, case_id: int, organization_slug: OrganizationSlug, db_session=None
+):
     """Runs the case escalated creation flow."""
     # we run the case new creation flow
     case_new_create_flow(
@@ -139,11 +142,13 @@ def case_escalated_create_flow(*, case_id: int, organization_slug: str = None, d
     case_triage_status_flow(case=case, db_session=db_session)
 
     # we transition the case to the escalated state
-    case_escalated_status_flow(case=case, db_session=db_session)
+    case_escalated_status_flow(
+        case=case, organization_slug=organization_slug, db_session=db_session
+    )
 
 
 @background_task
-def case_closed_create_flow(*, case_id: int, organization_slug: str = None, db_session=None):
+def case_closed_create_flow(*, case_id: int, organization_slug: OrganizationSlug, db_session=None):
     """Runs the case closed creation flow."""
     # we run the case new creation flow
     case_new_create_flow(
@@ -166,7 +171,7 @@ def case_update_flow(
     case_id: int,
     previous_case: CaseRead,
     user_email: str,
-    organization_slug: str = None,
+    organization_slug: OrganizationSlug,
     db_session=None,
 ):
     """Runs the case update flow."""
@@ -175,7 +180,11 @@ def case_update_flow(
 
     # we run the transition flow based on the current and previous status of the case
     case_status_transition_flow_dispatcher(
-        case, case.status, previous_case.status, db_session=db_session
+        case=case,
+        current_status=case.status,
+        previous_status=previous_case.status,
+        organization_slug=organization_slug,
+        db_session=db_session,
     )
 
     # we update the ticket
@@ -205,23 +214,9 @@ def case_delete_flow(case: Case, db_session: SessionLocal):
         storage_flows.delete_storage(storage=case.storage, db_session=db_session)
 
 
-def case_status_flow_common(case: Case, db_session=None):
-    """Runs tasks common across case status transition flows."""
-    # we update the ticket
-    ticket_flows.update_case_ticket(case=case, db_session=db_session)
-
-    # we update the timeline
-    event_service.log_case_event(
-        db_session=db_session,
-        source="Dispatch Core App",
-        description=f"The case status has been changed to {case.status.lower()}",
-        case_id=case.id,
-    )
-
-
 def case_new_status_flow(case: Case, db_session=None):
     """Runs the case new transition flow."""
-    case_status_flow_common(case=case, db_session=db_session)
+    pass
 
 
 def case_triage_status_flow(case: Case, db_session=None):
@@ -231,19 +226,17 @@ def case_triage_status_flow(case: Case, db_session=None):
     db_session.add(case)
     db_session.commit()
 
-    case_status_flow_common(case=case, db_session=db_session)
 
-
-def case_escalated_status_flow(case: Case, db_session=None):
+def case_escalated_status_flow(case: Case, organization_slug: OrganizationSlug, db_session=None):
     """Runs the case escalated transition flow."""
     # we set the escalated_at time
     case.escalated_at = datetime.utcnow()
     db_session.add(case)
     db_session.commit()
 
-    case_status_flow_common(case=case, db_session=db_session)
-
-    case_to_incident_escalate_flow(case=case, db_session=db_session)
+    case_to_incident_escalate_flow(
+        case=case, organization_slug=organization_slug, db_session=db_session
+    )
 
 
 def case_closed_status_flow(case: Case, db_session=None):
@@ -253,14 +246,13 @@ def case_closed_status_flow(case: Case, db_session=None):
     db_session.add(case)
     db_session.commit()
 
-    case_status_flow_common(case=case, db_session=db_session)
-
 
 def case_status_transition_flow_dispatcher(
     case: Case,
     current_status: CaseStatus,
     previous_status: CaseStatus,
-    db_session=SessionLocal,
+    organization_slug: OrganizationSlug,
+    db_session: SessionLocal,
 ):
     """Runs the correct flows based on the current and previous status of the case."""
     # we changed the status of the case to new
@@ -279,7 +271,7 @@ def case_status_transition_flow_dispatcher(
     elif current_status == CaseStatus.triage:
         if previous_status == CaseStatus.new:
             # New -> Triage
-            case_triage_status_flow(case, db_session)
+            case_triage_status_flow(case=case, db_session=db_session)
         elif previous_status == CaseStatus.escalated:
             # Escalated -> Triage
             pass
@@ -291,11 +283,15 @@ def case_status_transition_flow_dispatcher(
     elif current_status == CaseStatus.escalated:
         if previous_status == CaseStatus.new:
             # New -> Escalated
-            case_triage_status_flow(case, db_session)
-            case_escalated_status_flow(case, db_session)
+            case_triage_status_flow(case=case, db_session=db_session)
+            case_escalated_status_flow(
+                case=case, organization_slug=organization_slug, db_session=db_session
+            )
         elif previous_status == CaseStatus.triage:
             # Triage -> Escalated
-            case_escalated_status_flow(case, db_session)
+            case_escalated_status_flow(
+                case=case, organization_slug=organization_slug, db_session=db_session
+            )
         elif previous_status == CaseStatus.closed:
             # Closed -> Escalated
             pass
@@ -304,16 +300,28 @@ def case_status_transition_flow_dispatcher(
     elif current_status == CaseStatus.closed:
         if previous_status == CaseStatus.new:
             # New -> Closed
-            case_closed_status_flow(case, db_session)
+            case_triage_status_flow(case=case, db_session=db_session)
+            case_closed_status_flow(case=case, db_session=db_session)
         elif previous_status == CaseStatus.triage:
             # Triage -> Closed
-            case_closed_status_flow(case, db_session)
+            case_closed_status_flow(case=case, db_session=db_session)
         elif previous_status == CaseStatus.escalated:
             # Escalated -> Closed
-            case_closed_status_flow(case, db_session)
+            case_closed_status_flow(case=case, db_session=db_session)
+
+    if current_status != previous_status:
+        # we update the timeline
+        event_service.log_case_event(
+            db_session=db_session,
+            source="Dispatch Core App",
+            description=f"The case status has been changed to {case.status.lower()}",
+            case_id=case.id,
+        )
 
 
-def case_to_incident_escalate_flow(case: Case, db_session=None):
+def case_to_incident_escalate_flow(
+    case: Case, organization_slug: OrganizationSlug, db_session=None
+):
     """Escalates a case to an incident if the case's type is mapped to an incident type."""
     if not case.case_type.incident_type:
         # the case type is not mapped to any incident type
@@ -333,13 +341,19 @@ def case_to_incident_escalate_flow(case: Case, db_session=None):
         project=case.case_type.incident_type.project,
         reporter=reporter,
     )
-
     incident = incident_service.create(db_session=db_session, incident_in=incident_in)
-
-    # we run the incident creation flow
-    incident_flows.incident_create_flow(incident_id=incident.id, db_session=db_session)
 
     # we map the case to the newly created incident
     case.incidents.append(incident)
 
-    db_session.commit()
+    # we run the incident creation flow
+    incident_flows.incident_create_flow(
+        incident_id=incident.id, organization_slug=organization_slug, db_session=db_session
+    )
+
+    event_service.log_case_event(
+        db_session=db_session,
+        source="Dispatch Core App",
+        description=f"The case has been linked to incident {incident.name} in the {incident.project.name} project",  # noqa: E501
+        case_id=case.id,
+    )

--- a/src/dispatch/group/flows.py
+++ b/src/dispatch/group/flows.py
@@ -81,36 +81,36 @@ def create_group(
     return group
 
 
-def update_group(group: Group, group_action: GroupAction, db_session: SessionLocal):
+def update_group(
+    group: Group, group_action: GroupAction, group_member: str, db_session: SessionLocal
+):
     """Updates an existing group."""
     plugin = plugin_service.get_active_instance(
         db_session=db_session, project_id=group.case.project.id, plugin_type="participant-group"
     )
-    if plugin:
-        # we check if the assignee is a member of the group
+    if not plugin:
+        log.warning("Group not updated. No group plugin enabled.")
+        return
+
+    # we get the list of group members
+    try:
+        group_members = plugin.instance.list(email=group.email)
+    except Exception as e:
+        log.exception(e)
+
+    # we add the member to the group if it's not a member
+    if group_action == GroupAction.add_member and group_member not in group_members:
         try:
-            group_members = plugin.instance.list(email=group.email)
+            plugin.instance.add(email=group.email, participants=[group_member])
         except Exception as e:
             log.exception(e)
 
-        if (
-            group_action == GroupAction.add_member
-            and group.case.assignee.email not in group_members
-        ):
-            # we only try to add the user to the group if it's not a member
-            try:
-                plugin.instance.add(email=group.email, participants=[group.case.assignee.email])
-            except Exception as e:
-                log.exception(e)
-
-        if group_action == GroupAction.remove_member and group.case.assignee.email in group_members:
-            # we only try to remove the user from the group if it's a member
-            try:
-                plugin.instance.remove(email=group.email, participants=[group.case.assignee.email])
-            except Exception as e:
-                log.exception(e)
-    else:
-        log.warning("Group not updated. No group plugin enabled.")
+    # we remove the member from the group if it's a member
+    if group_action == GroupAction.remove_member and group_member in group_members:
+        try:
+            plugin.instance.remove(email=group.email, participants=[group_member])
+        except Exception as e:
+            log.exception(e)
 
 
 def delete_group(group: Group, db_session: SessionLocal):

--- a/src/dispatch/plugins/dispatch_google/drive/drive.py
+++ b/src/dispatch/plugins/dispatch_google/drive/drive.py
@@ -312,12 +312,12 @@ def add_permission(
     )
 
 
-def remove_permission(client: Any, email: str, folder_id: str):
+def remove_permission(client: Any, email: str, team_drive_or_file_id: str):
     """Removes permission from team drive or file."""
     permissions = make_call(
         client.permissions(),
         "list",
-        fileId=folder_id,
+        fileId=team_drive_or_file_id,
         fields="permissions(id, emailAddress)",
         supportsAllDrives=True,
     )
@@ -327,7 +327,7 @@ def remove_permission(client: Any, email: str, folder_id: str):
             make_call(
                 client.permissions(),
                 "delete",
-                fileId=folder_id,
+                fileId=team_drive_or_file_id,
                 permissionId=p["id"],
                 supportsAllDrives=True,
             )

--- a/src/dispatch/plugins/dispatch_google/drive/drive.py
+++ b/src/dispatch/plugins/dispatch_google/drive/drive.py
@@ -31,6 +31,7 @@ class UserTypes(DispatchEnum):
 
 
 class Roles(DispatchEnum):
+    # NOTE: https://developers.google.com/drive/api/guides/ref-roles
     owner = "owner"
     organizer = "organizer"
     file_organizer = "fileOrganizer"
@@ -279,7 +280,7 @@ def add_domain_permission(
     role: Roles = Roles.commenter,
     user_type: UserTypes = UserTypes.domain,
 ):
-    """Adds a domain permission to team drive or file."""
+    """Adds a domain permission to a team drive or file."""
     permission = {"type": user_type, "role": role, "domain": domain}
     return make_call(
         client.permissions(),
@@ -299,7 +300,7 @@ def add_permission(
     role: Roles = Roles.owner,
     user_type: UserTypes = UserTypes.user,
 ):
-    """Adds a permission to team drive"""
+    """Adds a permission to a team drive or file."""
     permission = {"type": user_type, "role": role, "emailAddress": email}
     return make_call(
         client.permissions(),
@@ -313,7 +314,7 @@ def add_permission(
 
 
 def remove_permission(client: Any, email: str, team_drive_or_file_id: str):
-    """Removes permission from team drive or file."""
+    """Removes permission from a team drive or file."""
     permissions = make_call(
         client.permissions(),
         "list",
@@ -334,7 +335,7 @@ def remove_permission(client: Any, email: str, team_drive_or_file_id: str):
 
 
 def move_file(client: Any, folder_id: str, file_id: str):
-    """Moves a file from one team drive to another"""
+    """Moves a file from one team drive to another."""
     f = make_call(client.files(), "get", fileId=file_id, fields="parents", supportsAllDrives=True)
 
     previous_parents = ",".join(f.get("parents"))

--- a/src/dispatch/plugins/dispatch_google/drive/plugin.py
+++ b/src/dispatch/plugins/dispatch_google/drive/plugin.py
@@ -9,6 +9,7 @@ from dispatch.plugins.dispatch_google.config import GoogleConfiguration
 
 from .drive import (
     Roles,
+    UserTypes,
     add_domain_permission,
     add_permission,
     add_reply,
@@ -69,8 +70,8 @@ class GoogleDriveStoragePlugin(StoragePlugin):
         self,
         team_drive_or_file_id: str,
         participants: List[str],
-        role: str = "owner",
-        user_type: str = "user",
+        role: str = Roles.writer,
+        user_type: str = UserTypes.user,
     ):
         """Adds participants to an existing Google Drive."""
         client = get_service(self.configuration, "drive", "v3", self.scopes)

--- a/src/dispatch/plugins/dispatch_google/drive/plugin.py
+++ b/src/dispatch/plugins/dispatch_google/drive/plugin.py
@@ -77,11 +77,11 @@ class GoogleDriveStoragePlugin(StoragePlugin):
         for p in participants:
             add_permission(client, p, team_drive_or_file_id, role, user_type)
 
-    def remove_participant(self, folder_id: str, participants: List[str]):
+    def remove_participant(self, team_drive_or_file_id: str, participants: List[str]):
         """Removes participants from an existing Google Drive."""
         client = get_service(self.configuration, "drive", "v3", self.scopes)
         for p in participants:
-            remove_permission(client, p, folder_id)
+            remove_permission(client, p, team_drive_or_file_id)
 
     def open(self, folder_id: str):
         """Adds the domain permission to the folder."""

--- a/src/dispatch/storage/enums.py
+++ b/src/dispatch/storage/enums.py
@@ -1,0 +1,6 @@
+from dispatch.enums import DispatchEnum
+
+
+class StorageAction(DispatchEnum):
+    add_members = "add_members"
+    remove_members = "remove_members"

--- a/src/dispatch/storage/flows.py
+++ b/src/dispatch/storage/flows.py
@@ -6,6 +6,7 @@ from dispatch.database.core import get_table_name_by_class_instance
 from dispatch.event import service as event_service
 from dispatch.plugin import service as plugin_service
 
+from .enums import StorageAction
 from .models import Storage, StorageCreate
 from .service import create
 
@@ -13,7 +14,7 @@ from .service import create
 log = logging.getLogger(__name__)
 
 
-def create_storage(obj: Any, members: List[str], db_session: SessionLocal):
+def create_storage(obj: Any, storage_members: List[str], db_session: SessionLocal):
     """Creates a storage."""
     plugin = plugin_service.get_active_instance(
         db_session=db_session, project_id=obj.project.id, plugin_type="storage"
@@ -26,7 +27,7 @@ def create_storage(obj: Any, members: List[str], db_session: SessionLocal):
     external_storage_root_id = plugin.configuration.root_id
     try:
         external_storage = plugin.instance.create_file(
-            parent_id=external_storage_root_id, name=obj.name, participants=members
+            parent_id=external_storage_root_id, name=obj.name, participants=storage_members
         )
     except Exception as e:
         log.exception(e)
@@ -64,7 +65,7 @@ def create_storage(obj: Any, members: List[str], db_session: SessionLocal):
             description="Case storage created",
             case_id=obj.id,
         )
-    else:
+    if obj_type == "incident":
         event_service.log_incident_event(
             db_session=db_session,
             source=plugin.plugin.title,
@@ -73,6 +74,57 @@ def create_storage(obj: Any, members: List[str], db_session: SessionLocal):
         )
 
     return storage
+
+
+def update_storage(
+    obj: Any,
+    storage_action: StorageAction,
+    storage_members: List[str],
+    db_session: SessionLocal,
+):
+    """Updates an exisiting storage."""
+    plugin = plugin_service.get_active_instance(
+        db_session=db_session, project_id=obj.project.id, plugin_type="storage"
+    )
+    if not plugin:
+        log.warning("Storage not updated. No storage plugin enabled.")
+        return
+
+    # we add the member(s) to the storage folder
+    if storage_action == StorageAction.add_members:
+        try:
+            plugin.instance.add_participant(
+                team_drive_or_file_id=obj.storage.resource_id, participants=storage_members
+            )
+        except Exception as e:
+            log.exception(e)
+            return
+
+    # we remove the member(s) from the storage folder
+    if storage_action == StorageAction.remove_members:
+        try:
+            plugin.instance.remove_participant(
+                team_drive_or_file_id=obj.storage.resource_id, participants=storage_members
+            )
+        except Exception as e:
+            log.exception(e)
+            return
+
+    obj_type = get_table_name_by_class_instance(obj)
+    if obj_type == "case":
+        event_service.log_case_event(
+            db_session=db_session,
+            source=plugin.plugin.title,
+            description="Case storage updated",
+            case_id=obj.id,
+        )
+    if obj_type == "incident":
+        event_service.log_incident_event(
+            db_session=db_session,
+            source=plugin.plugin.title,
+            description="Incident storage updated",
+            incident_id=obj.id,
+        )
 
 
 def delete_storage(storage: Storage, db_session: SessionLocal):

--- a/src/dispatch/ticket/flows.py
+++ b/src/dispatch/ticket/flows.py
@@ -164,7 +164,7 @@ def create_case_ticket(case: Case, db_session: SessionLocal):
         case_id=case.id,
     )
 
-    return ticket
+    return case.ticket
 
 
 def update_case_ticket(

--- a/src/dispatch/ticket/flows.py
+++ b/src/dispatch/ticket/flows.py
@@ -131,8 +131,9 @@ def create_case_ticket(case: Case, db_session: SessionLocal):
         case_type_in=case.case_type,
     ).get_meta(plugin.plugin.slug)
 
+    # we create the external case ticket
     try:
-        ticket = plugin.instance.create_case_ticket(
+        external_ticket = plugin.instance.create_case_ticket(
             case.id,
             title,
             case.assignee.email,
@@ -143,16 +144,17 @@ def create_case_ticket(case: Case, db_session: SessionLocal):
         log.exception(e)
         return
 
-    if not ticket:
+    if not external_ticket:
         log.error(f"Case ticket not created. Plugin {plugin.plugin.slug} encountered an error.")
         return
 
-    ticket.update({"resource_type": plugin.plugin.slug})
+    external_ticket.update({"resource_type": plugin.plugin.slug})
 
-    ticket_in = TicketCreate(**ticket)
-    case.ticket = create(db_session=db_session, ticket_in=ticket_in)
-
-    case.name = ticket["resource_id"]
+    # we create the internal case ticket
+    ticket_in = TicketCreate(**external_ticket)
+    ticket = create(db_session=db_session, ticket_in=ticket_in)
+    case.ticket = ticket
+    case.name = external_ticket["resource_id"]
 
     db_session.add(case)
     db_session.commit()
@@ -164,7 +166,7 @@ def create_case_ticket(case: Case, db_session: SessionLocal):
         case_id=case.id,
     )
 
-    return case.ticket
+    return ticket
 
 
 def update_case_ticket(
@@ -190,20 +192,25 @@ def update_case_ticket(
         case_type_in=case.case_type,
     ).get_meta(plugin.plugin.slug)
 
-    plugin.instance.update_case_ticket(
-        case.ticket.resource_id,
-        title,
-        description,
-        case.resolution,
-        case.case_type.name,
-        case.case_severity.name,
-        case.case_priority.name,
-        case.status.lower(),
-        case.assignee.email,
-        resolve_attr(case, "case_document.weblink"),
-        resolve_attr(case, "storage.weblink"),
-        case_type_plugin_metadata=case_type_plugin_metadata,
-    )
+    # we update the external case ticket
+    try:
+        plugin.instance.update_case_ticket(
+            case.ticket.resource_id,
+            title,
+            description,
+            case.resolution,
+            case.case_type.name,
+            case.case_severity.name,
+            case.case_priority.name,
+            case.status.lower(),
+            case.assignee.email,
+            resolve_attr(case, "case_document.weblink"),
+            resolve_attr(case, "storage.weblink"),
+            case_type_plugin_metadata=case_type_plugin_metadata,
+        )
+    except Exception as e:
+        log.exception(e)
+        return
 
     event_service.log_case_event(
         db_session=db_session,


### PR DESCRIPTION
This PR adds support for creating an incident when a case is moved to the escalated status if the case's type is mapped to an incident type and the case is not linked to any incidents already. The case assignee becomes the incident's reporter and the members of the incident's tactical group are given permission to access the case's storage folder and its contents.