### PR TITLE
Allows setting breadcrumbs to utilize the whole width before collapsing

### DIFF
--- a/src/dispatch/static/dispatch/src/case/priority/Table.vue
+++ b/src/dispatch/static/dispatch/src/case/priority/Table.vue
@@ -1,20 +1,20 @@
 <template>
   <v-container fluid>
     <new-edit-sheet />
-    <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
-        <settings-breadcrumbs v-model="project" />
-      </v-col>
-      <v-col class="text-right">
-        <v-btn color="info" class="mr-2" @click="createEditShow()"> New </v-btn>
-      </v-col>
-    </v-row>
     <v-row no-gutters>
       <v-col>
         <v-alert dismissible icon="mdi-school" prominent text type="info">
           Priorities add another dimension to Dispatch's case categorization. They also allow for
           some configurability.
         </v-alert>
+      </v-col>
+    </v-row>
+    <v-row align="center" justify="space-between" no-gutters>
+      <v-col cols="8">
+        <settings-breadcrumbs v-model="project" />
+      </v-col>
+      <v-col class="text-right">
+        <v-btn color="info" class="mr-2" @click="createEditShow()"> New </v-btn>
       </v-col>
     </v-row>
     <v-row no-gutters>

--- a/src/dispatch/static/dispatch/src/case/severity/Table.vue
+++ b/src/dispatch/static/dispatch/src/case/severity/Table.vue
@@ -1,20 +1,20 @@
 <template>
   <v-container fluid>
     <new-edit-sheet />
-    <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
-        <settings-breadcrumbs v-model="project" />
-      </v-col>
-      <v-col class="text-right">
-        <v-btn color="info" class="mr-2" @click="createEditShow()"> New </v-btn>
-      </v-col>
-    </v-row>
     <v-row no-gutters>
       <v-col>
         <v-alert dismissible icon="mdi-school" prominent text type="info">
           Severities add another dimension to Dispatch's case categorization. They also allow for
           some configurability.
         </v-alert>
+      </v-col>
+    </v-row>
+    <v-row align="center" justify="space-between" no-gutters>
+      <v-col cols="8">
+        <settings-breadcrumbs v-model="project" />
+      </v-col>
+      <v-col class="text-right">
+        <v-btn color="info" class="mr-2" @click="createEditShow()"> New </v-btn>
       </v-col>
     </v-row>
     <v-row no-gutters>

--- a/src/dispatch/static/dispatch/src/case/type/Table.vue
+++ b/src/dispatch/static/dispatch/src/case/type/Table.vue
@@ -1,19 +1,19 @@
 <template>
   <v-container fluid>
     <new-edit-sheet />
-    <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
-        <settings-breadcrumbs v-model="project" />
-      </v-col>
-      <v-col class="text-right">
-        <v-btn color="info" class="mr-2" @click="createEditShow()"> New </v-btn>
-      </v-col>
-    </v-row>
     <v-row no-gutters>
       <v-col>
         <v-alert dismissible icon="mdi-school" prominent text type="info">
           Types categorize cases. Dispatch allows for configuration on a per-case type basis.
         </v-alert>
+      </v-col>
+    </v-row>
+    <v-row align="center" justify="space-between" no-gutters>
+      <v-col cols="8">
+        <settings-breadcrumbs v-model="project" />
+      </v-col>
+      <v-col class="text-right">
+        <v-btn color="info" class="mr-2" @click="createEditShow()"> New </v-btn>
       </v-col>
     </v-row>
     <v-row no-gutters>

--- a/src/dispatch/static/dispatch/src/data/source/dataFormat/Table.vue
+++ b/src/dispatch/static/dispatch/src/data/source/dataFormat/Table.vue
@@ -3,7 +3,7 @@
     <new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/data/source/environment/Table.vue
+++ b/src/dispatch/static/dispatch/src/data/source/environment/Table.vue
@@ -3,7 +3,7 @@
     <new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/data/source/status/Table.vue
+++ b/src/dispatch/static/dispatch/src/data/source/status/Table.vue
@@ -3,7 +3,7 @@
     <new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/data/source/transport/Table.vue
+++ b/src/dispatch/static/dispatch/src/data/source/transport/Table.vue
@@ -3,7 +3,7 @@
     <new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/data/source/type/Table.vue
+++ b/src/dispatch/static/dispatch/src/data/source/type/Table.vue
@@ -3,7 +3,7 @@
     <new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/definition/Table.vue
+++ b/src/dispatch/static/dispatch/src/definition/Table.vue
@@ -3,7 +3,7 @@
     <new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/document/reference/ReferenceTable.vue
+++ b/src/dispatch/static/dispatch/src/document/reference/ReferenceTable.vue
@@ -3,7 +3,7 @@
     <reference-new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
     </v-row>

--- a/src/dispatch/static/dispatch/src/document/runbook/RunbookTable.vue
+++ b/src/dispatch/static/dispatch/src/document/runbook/RunbookTable.vue
@@ -3,7 +3,7 @@
     <runbook-new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col class="grow">
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
     </v-row>

--- a/src/dispatch/static/dispatch/src/document/template/TemplateTable.vue
+++ b/src/dispatch/static/dispatch/src/document/template/TemplateTable.vue
@@ -3,7 +3,7 @@
     <template-new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
     </v-row>

--- a/src/dispatch/static/dispatch/src/incident_cost_type/Table.vue
+++ b/src/dispatch/static/dispatch/src/incident_cost_type/Table.vue
@@ -3,7 +3,7 @@
     <new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/incident_priority/Table.vue
+++ b/src/dispatch/static/dispatch/src/incident_priority/Table.vue
@@ -1,20 +1,20 @@
 <template>
   <v-container fluid>
     <new-edit-sheet />
-    <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
-        <settings-breadcrumbs v-model="project" />
-      </v-col>
-      <v-col class="text-right">
-        <v-btn color="info" class="mr-2" @click="createEditShow()"> New </v-btn>
-      </v-col>
-    </v-row>
     <v-row no-gutters>
       <v-col>
         <v-alert dismissible icon="mdi-school" prominent text type="info"
           >Priorities adds another dimension to Dispatch's incident categorization. They also allow
           for some configurability (e.g. only page a command for 'high' priority incidents).
         </v-alert>
+      </v-col>
+    </v-row>
+    <v-row align="center" justify="space-between" no-gutters>
+      <v-col cols="8">
+        <settings-breadcrumbs v-model="project" />
+      </v-col>
+      <v-col class="text-right">
+        <v-btn color="info" class="mr-2" @click="createEditShow()"> New </v-btn>
       </v-col>
     </v-row>
     <v-row no-gutters>

--- a/src/dispatch/static/dispatch/src/incident_role/Table.vue
+++ b/src/dispatch/static/dispatch/src/incident_role/Table.vue
@@ -2,7 +2,7 @@
   <v-layout wrap>
     <v-container fluid>
       <v-row align="center" justify="space-between" no-gutters>
-        <v-col>
+        <v-col cols="8">
           <settings-breadcrumbs v-model="breadCrumbProject" />
         </v-col>
       </v-row>

--- a/src/dispatch/static/dispatch/src/incident_type/Table.vue
+++ b/src/dispatch/static/dispatch/src/incident_type/Table.vue
@@ -1,20 +1,20 @@
 <template>
   <v-container fluid>
     <new-edit-sheet />
-    <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
-        <settings-breadcrumbs v-model="project" />
-      </v-col>
-      <v-col class="text-right">
-        <v-btn color="info" class="mr-2" @click="createEditShow()"> New </v-btn>
-      </v-col>
-    </v-row>
     <v-row no-gutters>
       <v-col>
         <v-alert dismissible icon="mdi-school" prominent text type="info"
           >Types categorize incidents. Dispatch allows for configuration on a per-incident type
           basis.
         </v-alert>
+      </v-col>
+    </v-row>
+    <v-row align="center" justify="space-between" no-gutters>
+      <v-col cols="8">
+        <settings-breadcrumbs v-model="project" />
+      </v-col>
+      <v-col class="text-right">
+        <v-btn color="info" class="mr-2" @click="createEditShow()"> New </v-btn>
       </v-col>
     </v-row>
     <v-row no-gutters>

--- a/src/dispatch/static/dispatch/src/individual/Table.vue
+++ b/src/dispatch/static/dispatch/src/individual/Table.vue
@@ -3,7 +3,7 @@
     <new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/notification/Table.vue
+++ b/src/dispatch/static/dispatch/src/notification/Table.vue
@@ -3,7 +3,7 @@
     <new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/plugin/Table.vue
+++ b/src/dispatch/static/dispatch/src/plugin/Table.vue
@@ -3,7 +3,7 @@
     <new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/service/Table.vue
+++ b/src/dispatch/static/dispatch/src/service/Table.vue
@@ -3,7 +3,7 @@
     <new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/tag/Table.vue
+++ b/src/dispatch/static/dispatch/src/tag/Table.vue
@@ -3,7 +3,7 @@
     <new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/tag_type/Table.vue
+++ b/src/dispatch/static/dispatch/src/tag_type/Table.vue
@@ -2,7 +2,7 @@
   <v-container fluid>
     <new-edit-sheet />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/team/Table.vue
+++ b/src/dispatch/static/dispatch/src/team/Table.vue
@@ -3,7 +3,7 @@
     <new-edit-sheet />
     <delete-dialog />
     <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
+      <v-col cols="8">
         <settings-breadcrumbs v-model="project" />
       </v-col>
       <v-col class="text-right">

--- a/src/dispatch/static/dispatch/src/workflow/Table.vue
+++ b/src/dispatch/static/dispatch/src/workflow/Table.vue
@@ -2,20 +2,20 @@
   <v-container fluid>
     <new-edit-sheet />
     <delete-dialog />
-    <v-row align="center" justify="space-between" no-gutters>
-      <v-col>
-        <settings-breadcrumbs v-model="project" />
-      </v-col>
-      <v-col class="text-right">
-        <v-btn color="info" class="mr-2" @click="createEditShow()"> New </v-btn>
-      </v-col>
-    </v-row>
     <v-row no-gutters>
       <v-col>
         <v-alert dismissible icon="mdi-school" prominent text type="info"
           >Workflows extend Dispatch into existing workflow orchestration systems and can be used
           for nearly anything as long as they report back their status to Dispatch.
         </v-alert>
+      </v-col>
+    </v-row>
+    <v-row align="center" justify="space-between" no-gutters>
+      <v-col cols="8">
+        <settings-breadcrumbs v-model="project" />
+      </v-col>
+      <v-col class="text-right">
+        <v-btn color="info" class="mr-2" @click="createEditShow()"> New </v-btn>
       </v-col>
     </v-row>
     <v-row no-gutters>


### PR DESCRIPTION
On smaller screen sizes the settings breadcrumbs will collapse when there is still whitespace available. This change will prioritize those UI elements over whitespace.