### PR TITLE
Runs every scheduled job in it's own thread.

### DIFF
--- a/src/dispatch/scheduler.py
+++ b/src/dispatch/scheduler.py
@@ -7,12 +7,19 @@
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 .. moduleauthor:: Marc Vilanova <mvilanova@netflix.com>
 """
+import threading
 import logging
 import time
 
 import schedule
 
 log = logging.getLogger(__name__)
+
+
+def run_threaded(job_func):
+    """Runs a given job in a thread."""
+    job_thread = threading.Thread(target=job_func)
+    job_thread.start()
 
 
 #  See: https://schedule.readthedocs.io/en/stable/ for documentation on job syntax
@@ -30,7 +37,9 @@ class Scheduler(object):
             else:
                 name = kwargs.pop("name")
 
-            self.registered_tasks.append({"name": name, "func": func, "job": job.do(func)})
+            self.registered_tasks.append(
+                {"name": name, "func": func, "job": job.do(run_threaded, func)}
+            )
 
         return decorator
 


### PR DESCRIPTION
This ensures that each scheduled task is not run serially. This should increase the reliability of the scheduled tasks, guaranteeing that long-running tasks do not cause other tasks to miss their execution windows. 