### PR TITLE
Cases Dashboard

### DIFF
--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseDialogFilter.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseDialogFilter.vue
@@ -30,21 +30,21 @@
             <tag-filter-auto-complete v-model="filters.tag" label="Tags" />
           </v-list-item-content>
         </v-list-item>
-        <!-- <v-list-item> -->
-        <!--   <v-list-item-content> -->
-        <!--     <case-type-combobox v-model="filters.case_type" /> -->
-        <!--   </v-list-item-content> -->
-        <!-- </v-list-item> -->
-        <!-- <v-list-item> -->
-        <!--   <v-list-item-content> -->
-        <!--     <case-severity-combobox v-model="filters.case_severity" /> -->
-        <!--   </v-list-item-content> -->
-        <!-- </v-list-item> -->
-        <!-- <v-list-item> -->
-        <!--   <v-list-item-content> -->
-        <!--     <case-priority-combobox v-model="filters.case_priority" /> -->
-        <!--   </v-list-item-content> -->
-        <!-- </v-list-item> -->
+        <v-list-item>
+          <v-list-item-content>
+            <case-type-combobox v-model="filters.case_type" />
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item>
+          <v-list-item-content>
+            <case-severity-combobox v-model="filters.case_severity" />
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item>
+          <v-list-item-content>
+            <case-priority-combobox v-model="filters.case_priority" />
+          </v-list-item-content>
+        </v-list-item>
       </v-list>
       <v-card-actions>
         <v-spacer />
@@ -62,9 +62,9 @@ import startOfMonth from "date-fns/startOfMonth"
 import subMonths from "date-fns/subMonths"
 
 import CaseApi from "@/case/api"
-// import CasePriorityCombobox from "@/case/priority/CasePriorityCombobox.vue"
-// import CaseSeverityCombobox from "@/case/severity/CaseSeverityCombobox.vue"
-// import CaseTypeCombobox from "@/case/type/CaseTypeCombobox.vue"
+import CasePriorityCombobox from "@/case/priority/CasePriorityCombobox.vue"
+import CaseSeverityCombobox from "@/case/severity/CaseSeverityCombobox.vue"
+import CaseTypeCombobox from "@/case/type/CaseTypeCombobox.vue"
 import DateWindowInput from "@/components/DateWindowInput.vue"
 import ProjectCombobox from "@/project/ProjectCombobox.vue"
 import RouterUtils from "@/router/utils"
@@ -80,9 +80,9 @@ export default {
   name: "CaseOverviewFilterDialog",
 
   components: {
-    // CasePriorityCombobox,
-    // CaseSeverityCombobox,
-    // CaseTypeCombobox,
+    CasePriorityCombobox,
+    CaseSeverityCombobox,
+    CaseTypeCombobox,
     DateWindowInput,
     ProjectCombobox,
     TagFilterAutoComplete,
@@ -103,9 +103,9 @@ export default {
       menuEnd: false,
       display: false,
       filters: {
-        // case_priority: [],
-        // case_severity: [],
-        // case_type: [],
+        case_priority: [],
+        case_severity: [],
+        case_type: [],
         project: this.projects,
         status: [],
         tag: [],
@@ -124,9 +124,9 @@ export default {
   computed: {
     numFilters: function () {
       return sum([
-        // this.filters.case_priority.length,
-        // this.filters.case_severity.length,
-        // this.filters.case_type.length,
+        this.filters.case_priority.length,
+        this.filters.case_severity.length,
+        this.filters.case_type.length,
         this.filters.project.length,
         this.filters.status.length,
         this.filters.tag.length,

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseDialogFilter.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseDialogFilter.vue
@@ -155,12 +155,15 @@ export default {
           "case_type",
           "closed_at",
           "duplicates",
+          "escalated_at",
+          "incidents",
           "name",
           "project",
           "reported_at",
           "status",
           "tags",
           "title",
+          "triage_at",
         ],
       }
 

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseEscalatedClosedAverageTimeCard.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseEscalatedClosedAverageTimeCard.vue
@@ -1,0 +1,105 @@
+<template>
+  <dashboard-card
+    :loading="loading"
+    type="line"
+    :options="chartOptions"
+    :series="series"
+    title="Escalated to Closed Average Time (Hours)"
+  />
+</template>
+
+<script>
+import { forEach, sumBy } from "lodash"
+import differenceInHours from "date-fns/differenceInHours"
+import parseISO from "date-fns/parseISO"
+
+import DashboardCard from "@/dashboard/DashboardCard.vue"
+
+export default {
+  name: "CaseEscalatedClosedAverageTimeCard",
+
+  props: {
+    value: {
+      type: Object,
+      default: function () {
+        return {}
+      },
+    },
+    interval: {
+      type: String,
+      default: function () {
+        return "Month"
+      },
+    },
+    loading: {
+      type: [String, Boolean],
+      default: function () {
+        return false
+      },
+    },
+  },
+
+  components: {
+    DashboardCard,
+  },
+
+  data() {
+    return {}
+  },
+
+  computed: {
+    series() {
+      let series = { name: "Escalated to Closed Average Time (Hours)", data: [] }
+      forEach(this.value, function (value) {
+        series.data.push(
+          Math.round(
+            sumBy(value, function (item) {
+              let endTime = new Date().toISOString()
+              if (item.closed_at) {
+                endTime = item.closed_at
+              }
+              return differenceInHours(parseISO(endTime), parseISO(item.escalated_at))
+            }) / value.length
+          )
+        )
+      })
+
+      return [series]
+    },
+    chartOptions() {
+      return {
+        chart: {
+          height: 350,
+          type: "line",
+          animations: {
+            enabled: false,
+          },
+        },
+        xaxis: {
+          categories: Object.keys(this.value) || [],
+          title: {
+            text: this.interval,
+          },
+        },
+        dataLabels: {
+          enabled: true,
+        },
+        stroke: {
+          curve: "smooth",
+        },
+        markers: {
+          size: 1,
+        },
+        yaxis: {
+          title: {
+            text: "Hours",
+          },
+        },
+        legend: {
+          position: "top",
+        },
+      }
+    },
+  },
+}
+</script>

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseNewClosedAverageTimeCard.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseNewClosedAverageTimeCard.vue
@@ -1,0 +1,105 @@
+<template>
+  <dashboard-card
+    :loading="loading"
+    type="line"
+    :options="chartOptions"
+    :series="series"
+    title="New to Closed Average Time (Hours)"
+  />
+</template>
+
+<script>
+import { forEach, sumBy } from "lodash"
+import differenceInHours from "date-fns/differenceInHours"
+import parseISO from "date-fns/parseISO"
+
+import DashboardCard from "@/dashboard/DashboardCard.vue"
+
+export default {
+  name: "CaseNewClosedAverageTimeCard",
+
+  props: {
+    value: {
+      type: Object,
+      default: function () {
+        return {}
+      },
+    },
+    interval: {
+      type: String,
+      default: function () {
+        return "Month"
+      },
+    },
+    loading: {
+      type: [String, Boolean],
+      default: function () {
+        return false
+      },
+    },
+  },
+
+  components: {
+    DashboardCard,
+  },
+
+  data() {
+    return {}
+  },
+
+  computed: {
+    series() {
+      let series = { name: "New to Closed Average Time (Hours)", data: [] }
+      forEach(this.value, function (value) {
+        series.data.push(
+          Math.round(
+            sumBy(value, function (item) {
+              let endTime = new Date().toISOString()
+              if (item.closed_at) {
+                endTime = item.closed_at
+              }
+              return differenceInHours(parseISO(endTime), parseISO(item.reported_at))
+            }) / value.length
+          )
+        )
+      })
+
+      return [series]
+    },
+    chartOptions() {
+      return {
+        chart: {
+          height: 350,
+          type: "line",
+          animations: {
+            enabled: false,
+          },
+        },
+        xaxis: {
+          categories: Object.keys(this.value) || [],
+          title: {
+            text: this.interval,
+          },
+        },
+        dataLabels: {
+          enabled: true,
+        },
+        stroke: {
+          curve: "smooth",
+        },
+        markers: {
+          size: 1,
+        },
+        yaxis: {
+          title: {
+            text: "Hours",
+          },
+        },
+        legend: {
+          position: "top",
+        },
+      }
+    },
+  },
+}
+</script>

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseNewTriageAverageTimeCard.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseNewTriageAverageTimeCard.vue
@@ -1,0 +1,105 @@
+<template>
+  <dashboard-card
+    :loading="loading"
+    type="line"
+    :options="chartOptions"
+    :series="series"
+    title="New to Triage Average Time (Hours)"
+  />
+</template>
+
+<script>
+import { forEach, sumBy } from "lodash"
+import differenceInHours from "date-fns/differenceInHours"
+import parseISO from "date-fns/parseISO"
+
+import DashboardCard from "@/dashboard/DashboardCard.vue"
+
+export default {
+  name: "CaseNewTriageAverageTimeCard",
+
+  props: {
+    value: {
+      type: Object,
+      default: function () {
+        return {}
+      },
+    },
+    interval: {
+      type: String,
+      default: function () {
+        return "Month"
+      },
+    },
+    loading: {
+      type: [String, Boolean],
+      default: function () {
+        return false
+      },
+    },
+  },
+
+  components: {
+    DashboardCard,
+  },
+
+  data() {
+    return {}
+  },
+
+  computed: {
+    series() {
+      let series = { name: "New to Triage Average Time (Hours)", data: [] }
+      forEach(this.value, function (value) {
+        series.data.push(
+          Math.round(
+            sumBy(value, function (item) {
+              let endTime = new Date().toISOString()
+              if (item.triage_at) {
+                endTime = item.triage_at
+              }
+              return differenceInHours(parseISO(endTime), parseISO(item.reported_at))
+            }) / value.length
+          )
+        )
+      })
+
+      return [series]
+    },
+    chartOptions() {
+      return {
+        chart: {
+          height: 350,
+          type: "line",
+          animations: {
+            enabled: false,
+          },
+        },
+        xaxis: {
+          categories: Object.keys(this.value) || [],
+          title: {
+            text: this.interval,
+          },
+        },
+        dataLabels: {
+          enabled: true,
+        },
+        stroke: {
+          curve: "smooth",
+        },
+        markers: {
+          size: 1,
+        },
+        yaxis: {
+          title: {
+            text: "Hours",
+          },
+        },
+        legend: {
+          position: "top",
+        },
+      }
+    },
+  },
+}
+</script>

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
@@ -31,13 +31,13 @@
       </v-flex>
       <!-- Widgets Ends -->
       <!-- Statistics Start -->
-      <!-- <v-flex lg6 sm6 xs12> -->
-      <!--   <case-type-bar-chart-card -->
-      <!--     v-model="groupedItems" -->
-      <!--     :loading="loading" -->
-      <!--     @detailsSelected="detailsSelected($event)" -->
-      <!--   /> -->
-      <!-- </v-flex> -->
+      <v-flex lg6 sm6 xs12>
+        <case-type-bar-chart-card
+          v-model="groupedItems"
+          :loading="loading"
+          @detailsSelected="detailsSelected($event)"
+        />
+      </v-flex>
       <!-- <v-flex lg6 sm6 xs12> -->
       <!--   <case-severity-bar-chart-card -->
       <!--     v-model="groupedItems" -->
@@ -67,7 +67,7 @@ import CaseDialogFilter from "@/dashboard/case/CaseDialogFilter.vue"
 // import CasesDrillDownSheet from "@/dashboard/case/CasesDrillDownSheet.vue"
 // import CasePriorityBarChartCard from "@/dashboard/case/CasePriorityBarChartCard.vue"
 // import CaseSeverityBarChartCard from "@/dashboard/case/CaseSeverityBarChartCard.vue"
-// import CaseTypeBarChartCard from "@/dashboard/case/CaseTypeBarChartCard.vue"
+import CaseTypeBarChartCard from "@/dashboard/case/CaseTypeBarChartCard.vue"
 import StatWidget from "@/components/StatWidget.vue"
 
 export default {
@@ -77,7 +77,7 @@ export default {
     CaseDialogFilter,
     // CasePriorityBarChartCard,
     // CaseSeverityBarChartCard,
-    // CaseTypeBarChartCard,
+    CaseTypeBarChartCard,
     // CasesDrillDownSheet,
     StatWidget,
   },

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
@@ -29,6 +29,10 @@
           sup-title="Total Hours"
         />
       </v-flex>
+      <v-flex lg3 sm6 xs12>
+      </v-flex>
+      <v-flex lg3 sm6 xs12>
+      </v-flex>
       <!-- Widgets Ends -->
       <!-- Statistics Start -->
       <v-flex lg6 sm6 xs12>

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
@@ -38,13 +38,13 @@
           @detailsSelected="detailsSelected($event)"
         />
       </v-flex>
-      <!-- <v-flex lg6 sm6 xs12> -->
-      <!--   <case-severity-bar-chart-card -->
-      <!--     v-model="groupedItems" -->
-      <!--     :loading="loading" -->
-      <!--     @detailsSelected="detailsSelected($event)" -->
-      <!--   /> -->
-      <!-- </v-flex> -->
+      <v-flex lg6 sm6 xs12>
+        <case-severity-bar-chart-card
+          v-model="groupedItems"
+          :loading="loading"
+          @detailsSelected="detailsSelected($event)"
+        />
+      </v-flex>
       <!-- <v-flex lg6 sm6 xs12> -->
       <!--   <case-priority-bar-chart-card -->
       <!--     v-model="groupedItems" -->
@@ -66,7 +66,7 @@ import differenceInHours from "date-fns/differenceInHours"
 import CaseDialogFilter from "@/dashboard/case/CaseDialogFilter.vue"
 // import CasesDrillDownSheet from "@/dashboard/case/CasesDrillDownSheet.vue"
 // import CasePriorityBarChartCard from "@/dashboard/case/CasePriorityBarChartCard.vue"
-// import CaseSeverityBarChartCard from "@/dashboard/case/CaseSeverityBarChartCard.vue"
+import CaseSeverityBarChartCard from "@/dashboard/case/CaseSeverityBarChartCard.vue"
 import CaseTypeBarChartCard from "@/dashboard/case/CaseTypeBarChartCard.vue"
 import StatWidget from "@/components/StatWidget.vue"
 
@@ -76,7 +76,7 @@ export default {
   components: {
     CaseDialogFilter,
     // CasePriorityBarChartCard,
-    // CaseSeverityBarChartCard,
+    CaseSeverityBarChartCard,
     CaseTypeBarChartCard,
     // CasesDrillDownSheet,
     StatWidget,

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
@@ -69,6 +69,15 @@
       <v-flex lg6 sm6 xs12>
         <case-new-triage-average-time-card v-model="groupedItems" :loading="loading" />
       </v-flex>
+      <v-flex lg6 sm6 xs12>
+        <case-triage-escalated-average-time-card v-model="groupedItems" :loading="loading" />
+      </v-flex>
+      <v-flex lg6 sm6 xs12>
+        <case-escalated-closed-average-time-card v-model="groupedItems" :loading="loading" />
+      </v-flex>
+      <v-flex lg6 sm6 xs12>
+        <case-new-closed-average-time-card v-model="groupedItems" :loading="loading" />
+      </v-flex>
       <!-- Statistics Ends -->
     </v-layout>
   </v-container>
@@ -83,9 +92,12 @@ import differenceInHours from "date-fns/differenceInHours"
 import CaseDialogFilter from "@/dashboard/case/CaseDialogFilter.vue"
 // import CasesDrillDownSheet from "@/dashboard/case/CasesDrillDownSheet.vue"
 // import CasePriorityBarChartCard from "@/dashboard/case/CasePriorityBarChartCard.vue"
-import CaseSeverityBarChartCard from "@/dashboard/case/CaseSeverityBarChartCard.vue"
-import CaseTypeBarChartCard from "@/dashboard/case/CaseTypeBarChartCard.vue"
+import CaseEscalatedClosedAverageTimeCard from "@/dashboard/case/CaseEscalatedClosedAverageTimeCard.vue"
+import CaseNewClosedAverageTimeCard from "@/dashboard/case/CaseNewClosedAverageTimeCard.vue"
 import CaseNewTriageAverageTimeCard from "@/dashboard/case/CaseNewTriageAverageTimeCard.vue"
+import CaseSeverityBarChartCard from "@/dashboard/case/CaseSeverityBarChartCard.vue"
+import CaseTriageEscalatedAverageTimeCard from "@/dashboard/case/CaseTriageEscalatedAverageTimeCard.vue"
+import CaseTypeBarChartCard from "@/dashboard/case/CaseTypeBarChartCard.vue"
 import StatWidget from "@/components/StatWidget.vue"
 
 export default {
@@ -97,7 +109,10 @@ export default {
     CaseSeverityBarChartCard,
     CaseTypeBarChartCard,
     // CasesDrillDownSheet,
+    CaseEscalatedClosedAverageTimeCard,
+    CaseNewClosedAverageTimeCard,
     CaseNewTriageAverageTimeCard,
+    CaseTriageEscalatedAverageTimeCard,
     StatWidget,
   },
 

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
@@ -24,14 +24,24 @@
       </v-flex>
       <v-flex lg3 sm6 xs12>
         <stat-widget
-          icon="watch_later"
-          :title="totalHours | toNumberString"
-          sup-title="Total Hours"
+          icon="domain"
+          :title="totalCasesTriaged | toNumberString"
+          sup-title="Cases Triaged"
         />
       </v-flex>
       <v-flex lg3 sm6 xs12>
+        <stat-widget
+          icon="domain"
+          :title="totalCasesEscalated | toNumberString"
+          sup-title="Cases Escalated"
+        />
       </v-flex>
       <v-flex lg3 sm6 xs12>
+        <stat-widget
+          icon="watch_later"
+          :title="totalHours | toNumberString"
+          sup-title="Total Hours (New to Closed)"
+        />
       </v-flex>
       <!-- Widgets Ends -->
       <!-- Statistics Start -->
@@ -171,6 +181,21 @@ export default {
     },
     totalCases() {
       return this.items.length
+    },
+    totalCasesTriaged() {
+      return sumBy(this.items, function (item) {
+        if (item.triage_at) {
+          return 1
+        }
+      })
+    },
+    totalCasesEscalated() {
+      return sumBy(this.items, function (item) {
+        if (item.escalated_at && item.incidents.length > 0) {
+          console.log(item)
+          return 1
+        }
+      })
     },
     totalHours() {
       return sumBy(this.items, function (item) {

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
@@ -66,6 +66,9 @@
       <!--     @detailsSelected="detailsSelected($event)" -->
       <!--   /> -->
       <!-- </v-flex> -->
+      <v-flex lg6 sm6 xs12>
+        <case-new-triage-average-time-card v-model="groupedItems" :loading="loading" />
+      </v-flex>
       <!-- Statistics Ends -->
     </v-layout>
   </v-container>
@@ -82,6 +85,7 @@ import CaseDialogFilter from "@/dashboard/case/CaseDialogFilter.vue"
 // import CasePriorityBarChartCard from "@/dashboard/case/CasePriorityBarChartCard.vue"
 import CaseSeverityBarChartCard from "@/dashboard/case/CaseSeverityBarChartCard.vue"
 import CaseTypeBarChartCard from "@/dashboard/case/CaseTypeBarChartCard.vue"
+import CaseNewTriageAverageTimeCard from "@/dashboard/case/CaseNewTriageAverageTimeCard.vue"
 import StatWidget from "@/components/StatWidget.vue"
 
 export default {
@@ -93,6 +97,7 @@ export default {
     CaseSeverityBarChartCard,
     CaseTypeBarChartCard,
     // CasesDrillDownSheet,
+    CaseNewTriageAverageTimeCard,
     StatWidget,
   },
 

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseSeverityBarChartCard.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseSeverityBarChartCard.vue
@@ -1,0 +1,124 @@
+<template>
+  <dashboard-card
+    :loading="loading"
+    type="bar"
+    :options="chartOptions"
+    :series="series"
+    title="Severities"
+  />
+</template>
+
+<script>
+import { map, sortBy } from "lodash"
+
+import DashboardCard from "@/dashboard/DashboardCard.vue"
+import DashboardUtils from "@/dashboard/utils"
+import CaseSeverityApi from "@/case/severity/api"
+
+export default {
+  name: "CaseSeverityarChartCard",
+
+  components: {
+    DashboardCard,
+  },
+
+  props: {
+    value: {
+      type: Object,
+      default: function () {
+        return {}
+      },
+    },
+    loading: {
+      type: [String, Boolean],
+      default: function () {
+        return false
+      },
+    },
+  },
+
+  data() {
+    return {
+      severities: [],
+    }
+  },
+
+  created: function () {
+    CaseSeverityApi.getAll().then((response) => {
+      this.severities = [
+        ...new Set(
+          map(
+            sortBy(response.data.items, function (value) {
+              return value.view_order
+            }),
+            "name"
+          )
+        ),
+      ]
+    })
+  },
+
+  computed: {
+    chartOptions() {
+      return {
+        chart: {
+          type: "bar",
+          height: 350,
+          stacked: true,
+          animations: {
+            enabled: false,
+          },
+          events: {
+            dataPointSelection: (event, chartContext, config) => {
+              var data = config.w.config.series[config.seriesIndex].data[config.dataPointIndex]
+              this.$emit("detailsSelected", data.items)
+            },
+          },
+        },
+        responsive: [
+          {
+            options: {
+              legend: {
+                position: "top",
+              },
+            },
+          },
+        ],
+        colors: [
+          function ({ seriesIndex, w }) {
+            for (let i = 0; i < w.config.series[seriesIndex].data.length; i++) {
+              if (w.config.series[seriesIndex].data[i].items.length > 0) {
+                return w.config.series[seriesIndex].data[i].items[0].case_severity.color
+              }
+            }
+            return "#008FFB"
+          },
+        ],
+        xaxis: {
+          categories: this.categoryData || [],
+          title: {
+            text: "Month",
+          },
+        },
+        fill: {
+          opacity: 1,
+        },
+        legend: {
+          position: "top",
+        },
+      }
+    },
+    series() {
+      let series = DashboardUtils.createCountedSeriesData(
+        this.value,
+        "case_severity.name",
+        this.severities
+      )
+      return series
+    },
+    categoryData() {
+      return Object.keys(this.value)
+    },
+  },
+}
+</script>

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseTriageEscalatedAverageTimeCard.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseTriageEscalatedAverageTimeCard.vue
@@ -1,0 +1,105 @@
+<template>
+  <dashboard-card
+    :loading="loading"
+    type="line"
+    :options="chartOptions"
+    :series="series"
+    title="Triage to Escalated Average Time (Hours)"
+  />
+</template>
+
+<script>
+import { forEach, sumBy } from "lodash"
+import differenceInHours from "date-fns/differenceInHours"
+import parseISO from "date-fns/parseISO"
+
+import DashboardCard from "@/dashboard/DashboardCard.vue"
+
+export default {
+  name: "CaseTriageEscalatedAverageTimeCard",
+
+  props: {
+    value: {
+      type: Object,
+      default: function () {
+        return {}
+      },
+    },
+    interval: {
+      type: String,
+      default: function () {
+        return "Month"
+      },
+    },
+    loading: {
+      type: [String, Boolean],
+      default: function () {
+        return false
+      },
+    },
+  },
+
+  components: {
+    DashboardCard,
+  },
+
+  data() {
+    return {}
+  },
+
+  computed: {
+    series() {
+      let series = { name: "Triage to Escalated Average Time (Hours)", data: [] }
+      forEach(this.value, function (value) {
+        series.data.push(
+          Math.round(
+            sumBy(value, function (item) {
+              let endTime = new Date().toISOString()
+              if (item.escalated_at) {
+                endTime = item.escalated_at
+              }
+              return differenceInHours(parseISO(endTime), parseISO(item.triage_at))
+            }) / value.length
+          )
+        )
+      })
+
+      return [series]
+    },
+    chartOptions() {
+      return {
+        chart: {
+          height: 350,
+          type: "line",
+          animations: {
+            enabled: false,
+          },
+        },
+        xaxis: {
+          categories: Object.keys(this.value) || [],
+          title: {
+            text: this.interval,
+          },
+        },
+        dataLabels: {
+          enabled: true,
+        },
+        stroke: {
+          curve: "smooth",
+        },
+        markers: {
+          size: 1,
+        },
+        yaxis: {
+          title: {
+            text: "Hours",
+          },
+        },
+        legend: {
+          position: "top",
+        },
+      }
+    },
+  },
+}
+</script>

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseTypeBarChartCard.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseTypeBarChartCard.vue
@@ -1,0 +1,106 @@
+<template>
+  <dashboard-card
+    :loading="loading"
+    type="bar"
+    :options="chartOptions"
+    :series="series"
+    title="Types"
+  />
+</template>
+
+<script>
+import { map, filter } from "lodash"
+
+import CaseTypeApi from "@/case/type/api"
+import DashboardCard from "@/dashboard/DashboardCard.vue"
+import DashboardUtils from "@/dashboard/utils"
+
+export default {
+  name: "CaseBarChartCard",
+
+  components: {
+    DashboardCard,
+  },
+
+  props: {
+    value: {
+      type: Object,
+      default: function () {
+        return {}
+      },
+    },
+    loading: {
+      type: [String, Boolean],
+      default: function () {
+        return false
+      },
+    },
+  },
+
+  data() {
+    return {
+      types: [],
+    }
+  },
+
+  created: function () {
+    CaseTypeApi.getAll({ itemsPerPage: -1 }).then((response) => {
+      this.types = map(
+        filter(response.data.items, function (item) {
+          return !item.exclude_from_metrics
+        }),
+        "name"
+      )
+    })
+  },
+
+  computed: {
+    chartOptions() {
+      return {
+        chart: {
+          type: "bar",
+          height: 350,
+          stacked: true,
+          animations: {
+            enabled: false,
+          },
+          events: {
+            dataPointSelection: (event, chartContext, config) => {
+              var data = config.w.config.series[config.seriesIndex].data[config.dataPointIndex]
+              this.$emit("detailsSelected", data.items)
+            },
+          },
+        },
+        colors: DashboardUtils.defaultColorTheme(),
+        responsive: [
+          {
+            options: {
+              legend: {
+                position: "top",
+              },
+            },
+          },
+        ],
+        xaxis: {
+          categories: this.categoryData || [],
+          title: {
+            text: "Month",
+          },
+        },
+        fill: {
+          opacity: 1,
+        },
+        legend: {
+          position: "top",
+        },
+      }
+    },
+    series() {
+      return DashboardUtils.createCountedSeriesData(this.value, "case_type.name", this.types)
+    },
+    categoryData() {
+      return Object.keys(this.value)
+    },
+  },
+}
+</script>


### PR DESCRIPTION
This PR adds the following widgets and charts to the cases dashboard:

Widgets
* Number of cases triaged
* Number of cases escalated

Charts
* Number of case types by month
* Number of case severities by month
* New to triage average time
* Triage to escalated average time
* Escalated to closed average time
* New to closed average time

![Screen Shot 2022-09-12 at 11 32 42 AM](https://user-images.githubusercontent.com/39573146/189730075-34686300-8925-4052-bf07-77964cbb5e93.png)