### PR TITLE
Improves logging configuration

### DIFF
--- a/src/dispatch/enums.py
+++ b/src/dispatch/enums.py
@@ -55,3 +55,10 @@ class DocumentResourceTemplateTypes(DispatchEnum):
     incident = "dispatch-incident-document-template"
     review = "dispatch-incident-review-document-template"
     tracking = "dispatch-incident-sheet-template"
+
+
+class LogLevels(DispatchEnum):
+    info = "INFO"
+    warn = "WARN"
+    error = "ERROR"
+    debug = "DEBUG"

--- a/src/dispatch/logging.py
+++ b/src/dispatch/logging.py
@@ -1,12 +1,24 @@
 import logging
+
 from dispatch.config import LOG_LEVEL
+from dispatch.enums import LogLevels
+
+
+DEFAULT_LOG_LEVEL = LogLevels.error
+LOG_FORMAT_DEBUG = "%(levelname)s:%(message)s:%(pathname)s:%(funcName)s:%(lineno)d"
 
 
 def configure_logging():
-    level = LOG_LEVEL.upper()
-    if level == "DEBUG":
-        # log level:logged message:full module path:function invoked:line number of logging call
-        LOGFORMAT = "%(levelname)s:%(message)s:%(pathname)s:%(funcName)s:%(lineno)d"
-        logging.basicConfig(level=level, format=LOGFORMAT)
-    else:
-        logging.basicConfig(level=level)
+    log_level = str(LOG_LEVEL).upper()  # cast to string
+    log_levels = [level for level in LogLevels]
+
+    if log_level not in log_levels:
+        # we use the default log level
+        logging.basicConfig(level=DEFAULT_LOG_LEVEL)
+        return
+
+    if log_level == LogLevels.debug:
+        logging.basicConfig(level=log_level, format=LOG_FORMAT_DEBUG)
+        return
+
+    logging.basicConfig(level=log_level)


### PR DESCRIPTION
Defines and uses default log level if no level or unknown level is provided in the `.env` file.