### PR TITLE
Uses the 'simple' dictionary to provide better search consistancy

### DIFF
--- a/src/dispatch/auth/models.py
+++ b/src/dispatch/auth/models.py
@@ -57,7 +57,9 @@ class DispatchUser(Base, TimeStampMixin):
     # relationships
     events = relationship("Event", backref="dispatch_user")
 
-    search_vector = Column(TSVectorType("email", weights={"email": "A"}))
+    search_vector = Column(
+        TSVectorType("email", regconfig="pg_catalog.simple", weights={"email": "A"})
+    )
 
     def check_password(self, password):
         return bcrypt.checkpw(password.encode("utf-8"), self.password)

--- a/src/dispatch/case/severity/models.py
+++ b/src/dispatch/case/severity/models.py
@@ -25,7 +25,13 @@ class CaseSeverity(Base, ProjectMixin):
     # Lower numbers will be shown first.
     view_order = Column(Integer, default=9999)
 
-    search_vector = Column(TSVectorType("name", "description"))
+    search_vector = Column(
+        TSVectorType(
+            "name",
+            "description",
+            regconfig="pg_catalog.simple",
+        )
+    )
 
 
 listen(CaseSeverity.default, "set", ensure_unique_default_per_project)

--- a/src/dispatch/data/alert/models.py
+++ b/src/dispatch/data/alert/models.py
@@ -15,7 +15,7 @@ class Alert(Base, TimeStampMixin):
     orginator = Column(String)
     external_link = Column(String)
     source_id = Column(Integer, ForeignKey("source.id"))
-    search_vector = Column(TSVectorType("name"))
+    search_vector = Column(TSVectorType("name", regconfig="pg_catalog.simple"))
 
 
 # Pydantic models

--- a/src/dispatch/data/query/models.py
+++ b/src/dispatch/data/query/models.py
@@ -39,7 +39,7 @@ class Query(Base, TimeStampMixin, ProjectMixin):
     source_id = Column(Integer, ForeignKey("source.id"))
     source = relationship("Source", backref="queries")
     tags = relationship("Tag", secondary=assoc_query_tags, backref="queries")
-    search_vector = Column(TSVectorType("name"))
+    search_vector = Column(TSVectorType("name", regconfig="pg_catalog.simple"))
 
 
 # Pydantic models

--- a/src/dispatch/data/source/data_format/models.py
+++ b/src/dispatch/data/source/data_format/models.py
@@ -20,7 +20,7 @@ class SourceDataFormat(Base, ProjectMixin):
     id = Column(Integer, primary_key=True)
     name = Column(String)
     description = Column(String)
-    search_vector = Column(TSVectorType("name"))
+    search_vector = Column(TSVectorType("name", regconfig="pg_catalog.simple"))
 
 
 class SourceDataFormatBase(DispatchBase):

--- a/src/dispatch/data/source/environment/models.py
+++ b/src/dispatch/data/source/environment/models.py
@@ -20,7 +20,7 @@ class SourceEnvironment(Base, ProjectMixin):
     id = Column(Integer, primary_key=True)
     name = Column(String)
     description = Column(String)
-    search_vector = Column(TSVectorType("name"))
+    search_vector = Column(TSVectorType("name", regconfig="pg_catalog.simple"))
 
 
 class SourceEnvironmentBase(DispatchBase):

--- a/src/dispatch/data/source/models.py
+++ b/src/dispatch/data/source/models.py
@@ -87,7 +87,7 @@ class Source(Base, TimeStampMixin, ProjectMixin):
     tags = relationship("Tag", secondary=assoc_source_tags, backref="sources")
     alerts = relationship("Alert", backref="source", cascade="all, delete-orphan")
 
-    search_vector = Column(TSVectorType("name"))
+    search_vector = Column(TSVectorType("name", regconfig="pg_catalog.simple"))
 
 
 class QueryReadNested(DispatchBase):

--- a/src/dispatch/data/source/status/models.py
+++ b/src/dispatch/data/source/status/models.py
@@ -20,7 +20,7 @@ class SourceStatus(Base, ProjectMixin):
     id = Column(Integer, primary_key=True)
     name = Column(String)
     description = Column(String)
-    search_vector = Column(TSVectorType("name"))
+    search_vector = Column(TSVectorType("name", regconfig="pg_catalog.simple"))
 
 
 class SourceStatusBase(DispatchBase):

--- a/src/dispatch/data/source/transport/models.py
+++ b/src/dispatch/data/source/transport/models.py
@@ -20,7 +20,7 @@ class SourceTransport(Base, ProjectMixin):
     id = Column(Integer, primary_key=True)
     name = Column(String)
     description = Column(String)
-    search_vector = Column(TSVectorType("name"))
+    search_vector = Column(TSVectorType("name", regconfig="pg_catalog.simple"))
 
 
 class SourceTransportBase(DispatchBase):

--- a/src/dispatch/data/source/type/models.py
+++ b/src/dispatch/data/source/type/models.py
@@ -20,7 +20,7 @@ class SourceType(Base, ProjectMixin):
     id = Column(Integer, primary_key=True)
     name = Column(String)
     description = Column(String)
-    search_vector = Column(TSVectorType("name"))
+    search_vector = Column(TSVectorType("name", regconfig="pg_catalog.simple"))
 
 
 class SourceTypeBase(DispatchBase):

--- a/src/dispatch/definition/models.py
+++ b/src/dispatch/definition/models.py
@@ -40,7 +40,12 @@ class Definition(Base, ProjectMixin):
     source = Column(String, default="dispatch")
     terms = relationship("Term", secondary=definition_terms, backref="definitions")
     teams = relationship("TeamContact", secondary=definition_teams)
-    search_vector = Column(TSVectorType("text"))
+    search_vector = Column(
+        TSVectorType(
+            "text",
+            regconfig="pg_catalog.simple",
+        )
+    )
 
 
 class DefinitionTerm(DispatchBase):

--- a/src/dispatch/document/models.py
+++ b/src/dispatch/document/models.py
@@ -40,7 +40,7 @@ class Document(ProjectMixin, ResourceMixin, EvergreenMixin, Base):
 
     filters = relationship("SearchFilter", secondary=assoc_document_filters, backref="documents")
 
-    search_vector = Column(TSVectorType("name"))
+    search_vector = Column(TSVectorType("name", regconfig="pg_catalog.simple"))
 
 
 # Pydantic models...

--- a/src/dispatch/feedback/models.py
+++ b/src/dispatch/feedback/models.py
@@ -24,7 +24,13 @@ class Feedback(TimeStampMixin, Base):
     incident_id = Column(Integer, ForeignKey("incident.id", ondelete="CASCADE"))
     participant_id = Column(Integer, ForeignKey("participant.id"))
 
-    search_vector = Column(TSVectorType("feedback", "rating"))
+    search_vector = Column(
+        TSVectorType(
+            "feedback",
+            "rating",
+            regconfig="pg_catalog.simple",
+        )
+    )
 
     @hybrid_property
     def project(self):

--- a/src/dispatch/notification/models.py
+++ b/src/dispatch/notification/models.py
@@ -51,7 +51,13 @@ class Notification(Base, TimeStampMixin, ProjectMixin, EvergreenMixin):
         "SearchFilter", secondary=assoc_notification_filters, backref="notifications"
     )
 
-    search_vector = Column(TSVectorType("name", "description"))
+    search_vector = Column(
+        TSVectorType(
+            "name",
+            "description",
+            regconfig="pg_catalog.simple",
+        )
+    )
 
 
 # Pydantic models

--- a/src/dispatch/service/models.py
+++ b/src/dispatch/service/models.py
@@ -49,7 +49,7 @@ class Service(Base, TimeStampMixin, ProjectMixin, EvergreenMixin):
         "Incident", secondary=assoc_service_incidents, backref="services"
     )  # NOTE Delete this relationship and its associated table. It doesn't appear we're using it.
 
-    search_vector = Column(TSVectorType("name"))
+    search_vector = Column(TSVectorType("name", regconfig="pg_catalog.simple"))
 
 
 # Pydantic models...

--- a/src/dispatch/tag_type/models.py
+++ b/src/dispatch/tag_type/models.py
@@ -17,7 +17,7 @@ class TagType(Base, TimeStampMixin, ProjectMixin):
     name = Column(String)
     description = Column(String)
     exclusive = Column(Boolean, default=False)
-    search_vector = Column(TSVectorType("name"))
+    search_vector = Column(TSVectorType("name", regconfig="pg_catalog.simple"))
 
 
 # Pydantic models

--- a/src/dispatch/task/models.py
+++ b/src/dispatch/task/models.py
@@ -77,7 +77,12 @@ class Task(Base, ResourceMixin):
     # relationships
     tickets = relationship("Ticket", secondary=assoc_task_tickets, backref="tasks")
 
-    search_vector = Column(TSVectorType("description"))
+    search_vector = Column(
+        TSVectorType(
+            "description",
+            regconfig="pg_catalog.simple",
+        )
+    )
 
     @hybrid_property
     def project(self):

--- a/src/dispatch/term/models.py
+++ b/src/dispatch/term/models.py
@@ -21,7 +21,12 @@ class Term(Base, ProjectMixin):
     id = Column(Integer, primary_key=True)
     text = Column(String)
     discoverable = Column(Boolean, default=True)
-    search_vector = Column(TSVectorType("text"))
+    search_vector = Column(
+        TSVectorType(
+            "text",
+            regconfig="pg_catalog.simple",
+        )
+    )
 
 
 # Pydantic models...


### PR DESCRIPTION
This change unifies search expectations across models; we had this on some models but not others. Essentially, by using the `simple` dictionary, we are not attempting to filter out stop words from our search terms (e.g. the, from, to). 

This filtering was confusing to users, and we could run into situations where a resource (e.g. incident_type) was in the form of a stop, but we would not be able to filter for that resource due to the query filtering. 

This change simplifies the search expectation to; if a word is in the column that the search returns column. 

Additional context:
https://forestry.io/blog/full-text-searching-with-postgres/