### PR TITLE
Add hint to using CLI to install plugins

### DIFF
--- a/docs/admin-guide/administration/cli.md
+++ b/docs/admin-guide/administration/cli.md
@@ -229,3 +229,19 @@ Google Docs - Document            google-docs-document            0.1.0       do
 Google Group - Participant Group  google-group-participant-group  0.1.0       participant_group  Kevin Glisson  Uses Google Groups to help manage participant membership.
 ...
 ```
+
+### Install
+
+The `install` command will try installing all available plugins.
+
+```bash
+> dispatch plugins install
+INFO:dispatch.common.utils.cli:Attempting to load plugin: dispatch_basic_auth
+INFO:dispatch.common.utils.cli:Successfully loaded plugin: dispatch_basic_auth
+INFO:dispatch.common.utils.cli:Attempting to load plugin: dispatch_contact
+INFO:dispatch.common.utils.cli:Successfully loaded plugin: dispatch_contact
+INFO:dispatch.common.utils.cli:Attempting to load plugin: dispatch_document_resolver
+...
+```
+
+Keep in mind that this will only make plugins available. To enable them [create and configure the plugin instance](./plugins/README.md)

--- a/docs/admin-guide/administration/cli.md
+++ b/docs/admin-guide/administration/cli.md
@@ -220,7 +220,7 @@ The `plugin` command contains all of the logic for dealing with Dispatch's plugi
 The `list` command lists all currently available plugins. This command is useful in determining which plugins are available to be used via configuration variables.
 
 ```bash
-> dispatch database list
+> dispatch plugins list
 Title                             Slug                            Version     Type               Author         Description
 --------------------------------  ------------------------------  ----------  -----------------  -------------  ---------------------------------------------------------
 Dispatch - Document Resolver      dispatch-document-resolver      0.1.0       document-resolver  Kevin Glisson  Uses dispatch itself to resolve incident documents.

--- a/docs/admin-guide/administration/plugins/README.md
+++ b/docs/admin-guide/administration/plugins/README.md
@@ -4,14 +4,12 @@ description: Plugin Configurations
 
 # Plugins
 
-Much of Dispatch's functionality comes from its plugins. The current Dispatch web UI is limited to enabling and disabling plugins on a per-project basis. To make modifications to how plugins behave or are configured, changes must be deployed via the server configuration file. See the [server](../server.md) configuration documentation for more infomation.
+Before being able to configure and use the plugins, refer to the [CLI](../cli.md#plugins) documentation about installing plugins.
+
+Much of Dispatch's functionality comes from its plugins. The current Dispatch web UI is limited to enabling and disabling plugins on a per-project basis. To make modifications to how plugins behave or are configured, changes must be deployed via the server configuration file. See the [server](../server.md) configuration documentation for more information.
 
 By default, no plugins are _required_ to create an incident. As you enable plugins, they will be additive to the incident process (e.g., creating slack channels, google docs, etc.)
 
 ![](../../../.gitbook/assets/admin-ui-incident-plugins.png)
 
 Looking to add your own functionality to Dispatch via plugins? See the [contributing](../../../contributing/plugins/README.md) documentation.
-
-# Install plugins
-
-Before being able to configure and use the available plugins, use the [CLI](../cli.md) to install them. Running `dispatch plugins install` will attempt to install all available plugins.

--- a/docs/admin-guide/administration/plugins/README.md
+++ b/docs/admin-guide/administration/plugins/README.md
@@ -11,3 +11,7 @@ By default, no plugins are _required_ to create an incident. As you enable plugi
 ![](../../../.gitbook/assets/admin-ui-incident-plugins.png)
 
 Looking to add your own functionality to Dispatch via plugins? See the [contributing](../../../contributing/plugins/README.md) documentation.
+
+# Install plugins
+
+Before being able to configure and use the available plugins, use the [CLI](../cli.md) to install them. Running `dispatch plugins install` will attempt to install all available plugins.


### PR DESCRIPTION
I've spent a considerable amount of time trying to debug why the plugins wouldn't show up in the `Add Plugin` form in the dashboard. Maybe it's missing because most people start with the prepopulated DB? If so, wouldn't it be better to add some of this to the init db script?