### PR TITLE
Don't attempt to sync triggers automatically on database upgrade

### DIFF
--- a/src/dispatch/cli.py
+++ b/src/dispatch/cli.py
@@ -374,20 +374,6 @@ def upgrade_database(tag, sql, revision, revision_type):
                 alembic_cfg.set_main_option("script_location", path)
                 alembic_command.upgrade(alembic_cfg, revision, sql=sql, tag=tag)
 
-    # ensure triggers
-    conn.execute("set search_path to dispatch_core")
-    setup_fulltext_search(conn, get_core_tables())
-
-    for s in inspect(engine).get_schema_names():
-        if not s.startswith("dispatch_organization_"):
-            continue
-
-        tenant_tables = get_tenant_tables()
-        for t in tenant_tables:
-            t.schema = s
-        conn.execute(f"set search_path to {s}")
-        setup_fulltext_search(conn, tenant_tables)
-
     click.secho("Success.", fg="green")
 
 


### PR DESCRIPTION
When fulltext search triggers already exist, syncing new triggers can be problematic as the functions and expressions are tightly coupled with the columns they monitor. This change removes the automatic syncing functionality to make migrations more reliable. From now on if you add a new column that requires fulltext search functionality, you will have to manually sync the trigger in the migration file itself. See:

https://sqlalchemy-searchable.readthedocs.io/en/latest/alembic_migrations.html#sqlalchemy_searchable.sync_trigger 