### PR TITLE
Removed resource weblink resource validation as web link is not necessarily a URL.

### DIFF
--- a/src/dispatch/models.py
+++ b/src/dispatch/models.py
@@ -123,13 +123,6 @@ class ResourceBase(DispatchBase):
     resource_id: Optional[str] = Field(None, nullable=True)
     weblink: Optional[str] = Field(None, nullable=True)
 
-    @validator("weblink")
-    def sanitize_weblink(cls, v):
-        if v:
-            if not validators.url(v):
-                raise ValueError("Weblink must be a valid url.")
-        return v
-
 
 class ContactBase(DispatchBase):
     email: EmailStr


### PR DESCRIPTION
We don't validate any other "weblink" properties, so this removes an edge case.