### PR TITLE
Adds correct resource type when FAQs are created.

### DIFF
--- a/src/dispatch/static/dispatch/src/document/reference/store.js
+++ b/src/dispatch/static/dispatch/src/document/reference/store.js
@@ -25,7 +25,7 @@ const getDefaultSelectedState = () => {
 
 export const referenceDocumentTypes = [
   {
-    resource_type: "",
+    resource_type: "dispatch-incident-reference-faq-document",
     title: "FAQ",
     description: "Create a new FAQ reference document",
     icon: "mdi-file-document-edit-outline",


### PR DESCRIPTION
Fixes an issue where FAQs were being created without the correct resource type and thus never associated with incidents.