### PR TITLE
Bugfix/incident-endpoint-performance

### DIFF
--- a/src/dispatch/case/models.py
+++ b/src/dispatch/case/models.py
@@ -183,7 +183,7 @@ class CaseCreate(CaseBase):
     tags: Optional[List[TagRead]] = []
 
 
-class CaseReadNested(CaseBase):
+class CaseReadReadMinimal(CaseBase):
     id: PrimaryKey
     assignee: Optional[UserRead]
     case_priority: CasePriorityRead
@@ -208,14 +208,14 @@ class CaseRead(CaseBase):
     closed_at: Optional[datetime] = None
     created_at: Optional[datetime] = None
     documents: Optional[List[DocumentRead]] = []
-    duplicates: Optional[List[CaseReadNested]] = []
+    duplicates: Optional[List[CaseReadReadMinimal]] = []
     escalated_at: Optional[datetime] = None
     events: Optional[List[EventRead]] = []
     groups: Optional[List[GroupRead]] = []
     incidents: Optional[List[IncidentRead]] = []
     name: Optional[NameStr]
     project: ProjectRead
-    related: Optional[List[CaseReadNested]] = []
+    related: Optional[List[CaseReadReadMinimal]] = []
     reported_at: Optional[datetime] = None
     storage: Optional[StorageRead] = None
     tags: Optional[List[TagRead]] = []
@@ -255,7 +255,7 @@ class CaseUpdate(CaseBase):
 
 
 class CasePagination(DispatchBase):
-    items: List[CaseRead] = []
+    items: List[CaseReadReadMinimal] = []
     itemsPerPage: int
     page: int
     total: int

--- a/src/dispatch/case/models.py
+++ b/src/dispatch/case/models.py
@@ -25,7 +25,7 @@ from dispatch.document.models import Document, DocumentRead
 from dispatch.enums import Visibility
 from dispatch.event.models import EventRead
 from dispatch.group.models import Group, GroupRead
-from dispatch.incident.models import IncidentRead
+from dispatch.incident.models import IncidentReadMinimal
 from dispatch.messaging.strings import CASE_RESOLUTION_DEFAULT
 from dispatch.models import DispatchBase, ProjectMixin, TimeStampMixin
 from dispatch.models import NameStr, PrimaryKey
@@ -204,7 +204,6 @@ class CaseRead(CaseBase):
     case_priority: CasePriorityRead
     case_severity: CaseSeverityRead
     case_type: CaseTypeRead
-    signal_instances: Optional[List[SignalInstanceRead]] = []
     closed_at: Optional[datetime] = None
     created_at: Optional[datetime] = None
     documents: Optional[List[DocumentRead]] = []
@@ -212,11 +211,12 @@ class CaseRead(CaseBase):
     escalated_at: Optional[datetime] = None
     events: Optional[List[EventRead]] = []
     groups: Optional[List[GroupRead]] = []
-    incidents: Optional[List[IncidentRead]] = []
+    incidents: Optional[List[IncidentReadMinimal]] = []
     name: Optional[NameStr]
     project: ProjectRead
     related: Optional[List[CaseReadMinimal]] = []
     reported_at: Optional[datetime] = None
+    signal_instances: Optional[List[SignalInstanceRead]] = []
     storage: Optional[StorageRead] = None
     tags: Optional[List[TagRead]] = []
     ticket: Optional[TicketRead] = None
@@ -232,7 +232,7 @@ class CaseUpdate(CaseBase):
     duplicates: Optional[List[CaseRead]] = []
     related: Optional[List[CaseRead]] = []
     escalated_at: Optional[datetime] = None
-    incidents: Optional[List[IncidentRead]] = []
+    incidents: Optional[List[IncidentReadMinimal]] = []
     reported_at: Optional[datetime] = None
     tags: Optional[List[TagRead]] = []
     triage_at: Optional[datetime] = None

--- a/src/dispatch/case/models.py
+++ b/src/dispatch/case/models.py
@@ -183,7 +183,7 @@ class CaseCreate(CaseBase):
     tags: Optional[List[TagRead]] = []
 
 
-class CaseReadReadMinimal(CaseBase):
+class CaseReadMinimal(CaseBase):
     id: PrimaryKey
     assignee: Optional[UserRead]
     case_priority: CasePriorityRead
@@ -208,14 +208,14 @@ class CaseRead(CaseBase):
     closed_at: Optional[datetime] = None
     created_at: Optional[datetime] = None
     documents: Optional[List[DocumentRead]] = []
-    duplicates: Optional[List[CaseReadReadMinimal]] = []
+    duplicates: Optional[List[CaseReadMinimal]] = []
     escalated_at: Optional[datetime] = None
     events: Optional[List[EventRead]] = []
     groups: Optional[List[GroupRead]] = []
     incidents: Optional[List[IncidentRead]] = []
     name: Optional[NameStr]
     project: ProjectRead
-    related: Optional[List[CaseReadReadMinimal]] = []
+    related: Optional[List[CaseReadMinimal]] = []
     reported_at: Optional[datetime] = None
     storage: Optional[StorageRead] = None
     tags: Optional[List[TagRead]] = []
@@ -255,7 +255,7 @@ class CaseUpdate(CaseBase):
 
 
 class CasePagination(DispatchBase):
-    items: List[CaseReadReadMinimal] = []
+    items: List[CaseReadMinimal] = []
     itemsPerPage: int
     page: int
     total: int

--- a/src/dispatch/case/models.py
+++ b/src/dispatch/case/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from collections import defaultdict
-from typing import List, Optional, Any
+from typing import List, Optional, Any, ForwardRef
 
 from pydantic import validator
 from sqlalchemy import (
@@ -183,6 +183,9 @@ class CaseCreate(CaseBase):
     tags: Optional[List[TagRead]] = []
 
 
+CaseReadMinimal = ForwardRef("CaseReadMinimal")
+
+
 class CaseReadMinimal(CaseBase):
     id: PrimaryKey
     assignee: Optional[UserRead]
@@ -196,6 +199,9 @@ class CaseReadMinimal(CaseBase):
     project: ProjectRead
     reported_at: Optional[datetime] = None
     triage_at: Optional[datetime] = None
+
+
+CaseReadMinimal.update_forward_refs()
 
 
 class CaseRead(CaseBase):

--- a/src/dispatch/conference/models.py
+++ b/src/dispatch/conference/models.py
@@ -39,7 +39,3 @@ class ConferenceRead(ConferenceBase):
         return Template(INCIDENT_CONFERENCE_DESCRIPTION).render(
             conference_challenge=values["conference_challenge"]
         )
-
-
-class ConferenceNested(ConferenceBase):
-    pass

--- a/src/dispatch/conversation/models.py
+++ b/src/dispatch/conversation/models.py
@@ -35,7 +35,3 @@ class ConversationRead(ConversationBase):
     def set_description(cls, v):
         """Sets the description"""
         return INCIDENT_CONVERSATION_DESCRIPTION
-
-
-class ConversationNested(ConversationBase):
-    pass

--- a/src/dispatch/data/source/models.py
+++ b/src/dispatch/data/source/models.py
@@ -90,7 +90,7 @@ class Source(Base, TimeStampMixin, ProjectMixin):
     search_vector = Column(TSVectorType("name", regconfig="pg_catalog.simple"))
 
 
-class QueryReadNested(DispatchBase):
+class QueryReadMinimal(DispatchBase):
     id: PrimaryKey
     name: str
     description: str
@@ -119,7 +119,7 @@ class SourceBase(DispatchBase):
     links: Optional[List] = []
     tags: Optional[List[TagRead]] = []
     incidents: Optional[List[IncidentRead]] = []
-    queries: Optional[List[QueryReadNested]] = []
+    queries: Optional[List[QueryReadMinimal]] = []
     alerts: Optional[List[AlertRead]] = []
     cost: Optional[float]
     owner: Optional[ServiceRead] = Field(None, nullable=True)

--- a/src/dispatch/database/core.py
+++ b/src/dispatch/database/core.py
@@ -24,22 +24,24 @@ engine = create_engine(
     max_overflow=config.DATABASE_ENGINE_MAX_OVERFLOW,
 )
 
-logging.basicConfig()
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+
+# Useful for identifying slow or n + 1 queries. But doesn't need to be enabled in production.
+# logging.basicConfig()
+# logger = logging.getLogger(__name__)
+# logger.setLevel(logging.DEBUG)
 
 
-@event.listens_for(Engine, "before_cursor_execute")
-def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
-    conn.info.setdefault("query_start_time", []).append(time.time())
-    logger.debug("Start Query: %s", statement)
+# @event.listens_for(Engine, "before_cursor_execute")
+# def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+#    conn.info.setdefault("query_start_time", []).append(time.time())
+#    logger.debug("Start Query: %s", statement)
 
 
-@event.listens_for(Engine, "after_cursor_execute")
-def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
-    total = time.time() - conn.info["query_start_time"].pop(-1)
-    logger.debug("Query Complete!")
-    logger.debug("Total Time: %f", total)
+# @event.listens_for(Engine, "after_cursor_execute")
+# def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+#    total = time.time() - conn.info["query_start_time"].pop(-1)
+#    logger.debug("Query Complete!")
+#    logger.debug("Total Time: %f", total)
 
 
 SessionLocal = sessionmaker(bind=engine)

--- a/src/dispatch/document/models.py
+++ b/src/dispatch/document/models.py
@@ -73,10 +73,6 @@ class DocumentRead(DocumentBase):
         return v
 
 
-class DocumentNested(DocumentRead):
-    pass
-
-
 class DocumentPagination(DispatchBase):
     total: int
     items: List[DocumentRead] = []

--- a/src/dispatch/event/models.py
+++ b/src/dispatch/event/models.py
@@ -58,7 +58,3 @@ class EventUpdate(EventBase):
 
 class EventRead(EventBase):
     pass
-
-
-class EventNested(EventBase):
-    id: PrimaryKey

--- a/src/dispatch/feedback/models.py
+++ b/src/dispatch/feedback/models.py
@@ -8,7 +8,7 @@ from sqlalchemy_utils import TSVectorType
 
 from dispatch.database.core import Base
 from dispatch.feedback.enums import FeedbackRating
-from dispatch.incident.models import IncidentReadNested
+from dispatch.incident.models import IncidentReadMinimal
 from dispatch.models import DispatchBase, TimeStampMixin, PrimaryKey
 from dispatch.participant.models import ParticipantRead
 from dispatch.project.models import ProjectRead
@@ -42,7 +42,7 @@ class FeedbackBase(DispatchBase):
     created_at: Optional[datetime]
     rating: FeedbackRating = FeedbackRating.very_satisfied
     feedback: Optional[str] = Field(None, nullable=True)
-    incident: Optional[IncidentReadNested]
+    incident: Optional[IncidentReadMinimal]
     participant: Optional[ParticipantRead]
 
 

--- a/src/dispatch/group/models.py
+++ b/src/dispatch/group/models.py
@@ -41,7 +41,3 @@ class GroupRead(GroupBase):
     def set_description(cls, v):
         """Sets the description"""
         return TACTICAL_GROUP_DESCRIPTION
-
-
-class GroupNested(GroupBase):
-    id: PrimaryKey

--- a/src/dispatch/incident/models.py
+++ b/src/dispatch/incident/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from collections import Counter, defaultdict
-from typing import List, Optional, Any
+from typing import List, Optional, ForwardRef
 
 from pydantic import validator
 from sqlalchemy import (
@@ -27,18 +27,15 @@ from dispatch.group.models import Group
 from dispatch.incident.priority.models import (
     IncidentPriorityBase,
     IncidentPriorityCreate,
-    IncidentPriorityRead,
     IncidentPriorityReadMinimal,
 )
 from dispatch.incident.severity.models import (
     IncidentSeverityCreate,
-    IncidentSeverityRead,
     IncidentSeverityReadMinimal,
     IncidentSeverityBase,
 )
 from dispatch.incident.type.models import (
     IncidentTypeCreate,
-    IncidentTypeRead,
     IncidentTypeReadMinimal,
     IncidentTypeBase,
 )
@@ -273,6 +270,9 @@ class IncidentCreate(IncidentBase):
     tags: Optional[List[TagRead]] = []
 
 
+IncidentReadMinimal = ForwardRef("IncidentReadMinimal")
+
+
 class IncidentReadMinimal(IncidentBase):
     id: PrimaryKey
     closed_at: Optional[datetime] = None
@@ -292,8 +292,11 @@ class IncidentReadMinimal(IncidentBase):
     stable_at: Optional[datetime] = None
     tags: Optional[List[TagReadMinimal]] = []
     total_cost: Optional[float]
-    duplicates: Optional[List[Any]] = []
+    duplicates: Optional[List[IncidentReadMinimal]] = []
     incident_costs: Optional[List[IncidentCostRead]] = []
+
+
+IncidentReadMinimal.update_forward_refs()
 
 
 class IncidentUpdate(IncidentBase):

--- a/src/dispatch/incident/models.py
+++ b/src/dispatch/incident/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from collections import Counter, defaultdict
-from typing import List, Optional
+from typing import List, Optional, Any
 
 from pydantic import validator
 from sqlalchemy import (
@@ -28,23 +28,30 @@ from dispatch.incident.priority.models import (
     IncidentPriorityBase,
     IncidentPriorityCreate,
     IncidentPriorityRead,
+    IncidentPriorityReadMinimal,
 )
 from dispatch.incident.severity.models import (
     IncidentSeverityCreate,
     IncidentSeverityRead,
+    IncidentSeverityReadMinimal,
     IncidentSeverityBase,
 )
-from dispatch.incident.type.models import IncidentTypeCreate, IncidentTypeRead, IncidentTypeBase
+from dispatch.incident.type.models import (
+    IncidentTypeCreate,
+    IncidentTypeRead,
+    IncidentTypeReadMinimal,
+    IncidentTypeBase,
+)
 from dispatch.incident_cost.models import IncidentCostRead, IncidentCostUpdate
 from dispatch.messaging.strings import INCIDENT_RESOLUTION_DEFAULT
 from dispatch.models import DispatchBase, ProjectMixin, TimeStampMixin
 from dispatch.models import NameStr, PrimaryKey
 from dispatch.participant.models import Participant
-from dispatch.participant.models import ParticipantRead, ParticipantUpdate
+from dispatch.participant.models import ParticipantRead, ParticipantReadMinimal, ParticipantUpdate
 from dispatch.report.enums import ReportTypes
 from dispatch.report.models import ReportRead
 from dispatch.storage.models import StorageRead
-from dispatch.tag.models import TagRead
+from dispatch.tag.models import TagRead, TagReadMinimal
 from dispatch.term.models import TermRead
 from dispatch.ticket.models import TicketRead
 from dispatch.workflow.models import WorkflowInstanceRead
@@ -341,8 +348,31 @@ class IncidentRead(IncidentReadMinimal):
     workflow_instances: Optional[List[WorkflowInstanceRead]] = []
 
 
+class IncidentReadBulk(DispatchBase):
+    id: PrimaryKey
+    closed_at: Optional[datetime] = None
+    commander: Optional[ParticipantReadMinimal]
+    commanders_location: Optional[str]
+    created_at: Optional[datetime] = None
+    incident_costs: Optional[List[IncidentCostRead]] = []
+    incident_priority: IncidentPriorityReadMinimal
+    incident_severity: IncidentSeverityReadMinimal
+    incident_type: IncidentTypeReadMinimal
+    name: Optional[NameStr]
+    participants_location: Optional[str]
+    participants_team: Optional[str]
+    project: ProjectRead
+    reported_at: Optional[datetime] = None
+    reporter: Optional[ParticipantReadMinimal]
+    reporters_location: Optional[str]
+    stable_at: Optional[datetime] = None
+    tags: Optional[List[TagReadMinimal]] = []
+    total_cost: Optional[float]
+    duplicates: Optional[List[Any]] = []
+
+
 class IncidentPagination(DispatchBase):
     total: int
     itemsPerPage: int
     page: int
-    items: List[IncidentRead] = []
+    items: List[IncidentReadBulk] = []

--- a/src/dispatch/incident/models.py
+++ b/src/dispatch/incident/models.py
@@ -292,7 +292,6 @@ class IncidentReadMinimal(IncidentBase):
     stable_at: Optional[datetime] = None
     tags: Optional[List[TagReadMinimal]] = []
     total_cost: Optional[float]
-    duplicates: Optional[List[IncidentReadMinimal]] = []
     incident_costs: Optional[List[IncidentCostRead]] = []
 
 
@@ -330,9 +329,11 @@ class IncidentUpdate(IncidentBase):
 
 
 class IncidentRead(IncidentReadMinimal):
+    cases: Optional[List[CaseRead]] = []
     conference: Optional[ConferenceRead] = None
     conversation: Optional[ConversationRead] = None
     documents: Optional[List[DocumentRead]] = []
+    duplicates: Optional[List[IncidentReadMinimal]] = []
     events: Optional[List[EventRead]] = []
     last_executive_report: Optional[ReportRead]
     last_tactical_report: Optional[ReportRead]

--- a/src/dispatch/incident/models.py
+++ b/src/dispatch/incident/models.py
@@ -276,7 +276,7 @@ class IncidentCreate(IncidentBase):
 class IncidentReadMinimal(IncidentBase):
     id: PrimaryKey
     closed_at: Optional[datetime] = None
-    commander: ParticipantReadMinimal
+    commander: Optional[ParticipantReadMinimal]
     commanders_location: Optional[str]
     created_at: Optional[datetime] = None
     incident_priority: IncidentPriorityReadMinimal
@@ -287,7 +287,7 @@ class IncidentReadMinimal(IncidentBase):
     participants_team: Optional[str]
     project: ProjectRead
     reported_at: Optional[datetime] = None
-    reporter: ParticipantReadMinimal
+    reporter: Optional[ParticipantReadMinimal]
     reporters_location: Optional[str]
     stable_at: Optional[datetime] = None
     tags: Optional[List[TagReadMinimal]] = []

--- a/src/dispatch/incident/models.py
+++ b/src/dispatch/incident/models.py
@@ -164,6 +164,7 @@ class Incident(Base, TimeStampMixin, ProjectMixin):
         "Participant",
         backref="incident",
         cascade="all, delete-orphan",
+        lazy="joined",
         foreign_keys=[Participant.incident_id],
     )
     reports = relationship("Report", backref="incident", cascade="all, delete-orphan")
@@ -173,6 +174,7 @@ class Incident(Base, TimeStampMixin, ProjectMixin):
     tags = relationship(
         "Tag",
         secondary=assoc_incident_tags,
+        lazy="joined",
         backref="incidents",
     )
     tasks = relationship("Task", backref="incident", cascade="all, delete-orphan")

--- a/src/dispatch/incident/priority/models.py
+++ b/src/dispatch/incident/priority/models.py
@@ -62,6 +62,19 @@ class IncidentPriorityRead(IncidentPriorityBase):
     id: PrimaryKey
 
 
+class IncidentPriorityReadMinimal(DispatchBase):
+    id: PrimaryKey
+    name: NameStr
+    description: Optional[str] = Field(None, nullable=True)
+    page_commander: Optional[StrictBool]
+    tactical_report_reminder: Optional[int]
+    executive_report_reminder: Optional[int]
+    default: Optional[bool]
+    enabled: Optional[bool]
+    view_order: Optional[int]
+    color: Optional[Color] = Field(None, nullable=True)
+
+
 class IncidentPriorityPagination(DispatchBase):
     total: int
     items: List[IncidentPriorityRead] = []

--- a/src/dispatch/incident/priority/models.py
+++ b/src/dispatch/incident/priority/models.py
@@ -77,4 +77,4 @@ class IncidentPriorityReadMinimal(DispatchBase):
 
 class IncidentPriorityPagination(DispatchBase):
     total: int
-    items: List[IncidentPriorityRead] = []
+    items: List[IncidentPriorityReadMinimal] = []

--- a/src/dispatch/incident/severity/models.py
+++ b/src/dispatch/incident/severity/models.py
@@ -71,4 +71,4 @@ class IncidentSeverityReadMinimal(DispatchBase):
 
 class IncidentSeverityPagination(DispatchBase):
     total: int
-    items: List[IncidentSeverityRead] = []
+    items: List[IncidentSeverityReadMinimal] = []

--- a/src/dispatch/incident/severity/models.py
+++ b/src/dispatch/incident/severity/models.py
@@ -60,6 +60,15 @@ class IncidentSeverityRead(IncidentSeverityBase):
     id: PrimaryKey
 
 
+class IncidentSeverityReadMinimal(DispatchBase):
+    id: PrimaryKey
+    color: Optional[Color] = Field(None, nullable=True)
+    default: Optional[bool]
+    description: Optional[str] = Field(None, nullable=True)
+    enabled: Optional[bool]
+    name: NameStr
+
+
 class IncidentSeverityPagination(DispatchBase):
     total: int
     items: List[IncidentSeverityRead] = []

--- a/src/dispatch/incident/type/models.py
+++ b/src/dispatch/incident/type/models.py
@@ -111,6 +111,16 @@ class IncidentTypeRead(IncidentTypeBase):
     id: PrimaryKey
 
 
+class IncidentTypeReadMinimal(DispatchBase):
+    id: PrimaryKey
+    name: NameStr
+    visibility: Optional[str] = Field(None, nullable=True)
+    description: Optional[str] = Field(None, nullable=True)
+    enabled: Optional[bool]
+    exclude_from_metrics: Optional[bool] = False
+    default: Optional[bool] = False
+
+
 class IncidentTypePagination(DispatchBase):
     total: int
     items: List[IncidentTypeRead] = []

--- a/src/dispatch/incident/type/models.py
+++ b/src/dispatch/incident/type/models.py
@@ -123,4 +123,4 @@ class IncidentTypeReadMinimal(DispatchBase):
 
 class IncidentTypePagination(DispatchBase):
     total: int
-    items: List[IncidentTypeRead] = []
+    items: List[IncidentTypeReadMinimal] = []

--- a/src/dispatch/incident_cost/models.py
+++ b/src/dispatch/incident_cost/models.py
@@ -46,10 +46,6 @@ class IncidentCostRead(IncidentCostBase):
     incident_cost_type: IncidentCostTypeRead
 
 
-class IncidentCostNested(IncidentCostBase):
-    id: PrimaryKey
-
-
 class IncidentCostPagination(DispatchBase):
     total: int
     items: List[IncidentCostRead] = []

--- a/src/dispatch/incident_cost_type/models.py
+++ b/src/dispatch/incident_cost_type/models.py
@@ -55,10 +55,6 @@ class IncidentCostTypeRead(IncidentCostTypeBase):
     id: PrimaryKey
 
 
-class IncidentCostTypeNested(IncidentCostTypeBase):
-    id: PrimaryKey
-
-
 class IncidentCostTypePagination(DispatchBase):
     total: int
     items: List[IncidentCostTypeRead] = []

--- a/src/dispatch/individual/models.py
+++ b/src/dispatch/individual/models.py
@@ -77,15 +77,12 @@ class IndividualContactRead(IndividualContactBase):
     updated_at: Optional[datetime] = None
 
 
-class IndividualContactReadMinimal(DispatchBase):
+class IndividualContactReadMinimal(IndividualContactBase):
     id: Optional[PrimaryKey]
-    weblink: Optional[str] = Field(None, nullable=True)
-    mobile_phone: Optional[str] = Field(None, nullable=True)
-    office_phone: Optional[str] = Field(None, nullable=True)
-    title: Optional[str] = Field(None, nullable=True)
-    external_id: Optional[str] = Field(None, nullable=True)
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
 class IndividualContactPagination(DispatchBase):
     total: int
-    items: List[IndividualContactRead] = []
+    items: List[IndividualContactReadMinimal] = []

--- a/src/dispatch/individual/models.py
+++ b/src/dispatch/individual/models.py
@@ -77,6 +77,15 @@ class IndividualContactRead(IndividualContactBase):
     updated_at: Optional[datetime] = None
 
 
+class IndividualContactReadMinimal(DispatchBase):
+    id: Optional[PrimaryKey]
+    weblink: Optional[str] = Field(None, nullable=True)
+    mobile_phone: Optional[str] = Field(None, nullable=True)
+    office_phone: Optional[str] = Field(None, nullable=True)
+    title: Optional[str] = Field(None, nullable=True)
+    external_id: Optional[str] = Field(None, nullable=True)
+
+
 class IndividualContactPagination(DispatchBase):
     total: int
     items: List[IndividualContactRead] = []

--- a/src/dispatch/participant/models.py
+++ b/src/dispatch/participant/models.py
@@ -10,10 +10,11 @@ from dispatch.models import DispatchBase, PrimaryKey
 from dispatch.participant_role.models import (
     ParticipantRoleCreate,
     ParticipantRoleRead,
+    ParticipantRoleReadMinimal,
     ParticipantRole,
 )
 from dispatch.service.models import ServiceRead
-from dispatch.individual.models import IndividualContactRead
+from dispatch.individual.models import IndividualContactRead, IndividualContactReadMinimal
 
 
 class Participant(Base):
@@ -86,6 +87,12 @@ class ParticipantRead(ParticipantBase):
     id: PrimaryKey
     participant_roles: Optional[List[ParticipantRoleRead]] = []
     individual: Optional[IndividualContactRead]
+
+
+class ParticipantReadMinimal(DispatchBase):
+    id: PrimaryKey
+    participant_roles: Optional[List[ParticipantRoleReadMinimal]] = []
+    individual: Optional[IndividualContactReadMinimal]
 
 
 class ParticipantPagination(DispatchBase):

--- a/src/dispatch/participant_role/models.py
+++ b/src/dispatch/participant_role/models.py
@@ -39,6 +39,10 @@ class ParticipantRoleRead(ParticipantRoleBase):
     activity: Optional[int]
 
 
+class ParticipantRoleReadMinimal(ParticipantRoleRead):
+    pass
+
+
 class ParticipantRolePagination(ParticipantRoleBase):
     total: int
     items: List[ParticipantRoleRead] = []

--- a/src/dispatch/participant_role/models.py
+++ b/src/dispatch/participant_role/models.py
@@ -45,4 +45,4 @@ class ParticipantRoleReadMinimal(ParticipantRoleRead):
 
 class ParticipantRolePagination(ParticipantRoleBase):
     total: int
-    items: List[ParticipantRoleRead] = []
+    items: List[ParticipantRoleReadMinimal] = []

--- a/src/dispatch/service/models.py
+++ b/src/dispatch/service/models.py
@@ -64,10 +64,6 @@ class ServiceRead(ServiceBase):
     updated_at: Optional[datetime] = None
 
 
-class ServiceNested(ServiceBase):
-    id: PrimaryKey
-
-
 class ServicePagination(DispatchBase):
     total: int
     items: List[ServiceRead] = []

--- a/src/dispatch/static/dispatch/src/case/store.js
+++ b/src/dispatch/static/dispatch/src/case/store.js
@@ -133,7 +133,11 @@ const actions = {
         ]),
       }).then((response) => {
         if (response.data.items.length) {
-          commit("SET_SELECTED", response.data.items[0])
+          // get the full data set
+          return CaseApi.get(response.data.items[0].id).then((response) => {
+            commit("SET_SELECTED", response.data)
+            commit("SET_SELECTED_LOADING", false)
+          })
         } else {
           commit(
             "notification_backend/addBeNotification",

--- a/src/dispatch/static/dispatch/src/incident/store.js
+++ b/src/dispatch/static/dispatch/src/incident/store.js
@@ -154,7 +154,11 @@ const actions = {
         ]),
       }).then((response) => {
         if (response.data.items.length) {
-          commit("SET_SELECTED", response.data.items[0])
+          // get the full data set
+          return IncidentApi.get(response.data.items[0].id).then((response) => {
+            commit("SET_SELECTED", response.data)
+            commit("SET_SELECTED_LOADING", false)
+          })
         } else {
           commit(
             "notification_backend/addBeNotification",

--- a/src/dispatch/storage/models.py
+++ b/src/dispatch/storage/models.py
@@ -35,7 +35,3 @@ class StorageRead(StorageBase):
     def set_description(cls, v):
         """Sets the description"""
         return STORAGE_DESCRIPTION
-
-
-class StorageNested(StorageBase):
-    pass

--- a/src/dispatch/tag/models.py
+++ b/src/dispatch/tag/models.py
@@ -9,7 +9,7 @@ from sqlalchemy_utils import TSVectorType
 from dispatch.database.core import Base
 from dispatch.models import DispatchBase, TimeStampMixin, ProjectMixin, PrimaryKey
 from dispatch.project.models import ProjectRead
-from dispatch.tag_type.models import TagTypeRead, TagTypeCreate, TagTypeUpdate
+from dispatch.tag_type.models import TagTypeRead, TagTypeCreate, TagTypeUpdate, TagTypeReadMinimal
 
 
 class Tag(Base, TimeStampMixin, ProjectMixin):
@@ -64,8 +64,9 @@ class TagReadMinimal(DispatchBase):
     uri: Optional[str] = Field(None, nullable=True)
     discoverable: Optional[bool] = True
     description: Optional[str] = Field(None, nullable=True)
+    tag_type: Optional[TagTypeReadMinimal]
 
 
 class TagPagination(DispatchBase):
-    items: List[TagRead]
+    items: List[TagReadMinimal]
     total: int

--- a/src/dispatch/tag/models.py
+++ b/src/dispatch/tag/models.py
@@ -57,6 +57,15 @@ class TagRead(TagBase):
     project: ProjectRead
 
 
+class TagReadMinimal(DispatchBase):
+    id: PrimaryKey
+    name: Optional[str] = Field(None, nullable=True)
+    source: Optional[str] = Field(None, nullable=True)
+    uri: Optional[str] = Field(None, nullable=True)
+    discoverable: Optional[bool] = True
+    description: Optional[str] = Field(None, nullable=True)
+
+
 class TagPagination(DispatchBase):
     items: List[TagRead]
     total: int

--- a/src/dispatch/tag_type/models.py
+++ b/src/dispatch/tag_type/models.py
@@ -40,6 +40,13 @@ class TagTypeRead(TagTypeBase):
     project: ProjectRead
 
 
+class TagTypeReadMinimal(DispatchBase):
+    id: PrimaryKey
+    name: NameStr
+    exclusive: Optional[bool] = False
+    description: Optional[str] = Field(None, nullable=True)
+
+
 class TagTypePagination(DispatchBase):
     items: List[TagTypeRead]
     total: int

--- a/src/dispatch/tag_type/models.py
+++ b/src/dispatch/tag_type/models.py
@@ -48,5 +48,5 @@ class TagTypeReadMinimal(DispatchBase):
 
 
 class TagTypePagination(DispatchBase):
-    items: List[TagTypeRead]
+    items: List[TagTypeReadMinimal]
     total: int

--- a/src/dispatch/task/models.py
+++ b/src/dispatch/task/models.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy_utils import TSVectorType
 
 from dispatch.database.core import Base
-from dispatch.incident.models import IncidentReadNested
+from dispatch.incident.models import IncidentReadMinimal
 from dispatch.models import DispatchBase, ResourceBase, ResourceMixin, PrimaryKey
 from dispatch.participant.models import ParticipantRead, ParticipantUpdate
 from dispatch.project.models import ProjectRead
@@ -91,7 +91,7 @@ class TaskBase(ResourceBase):
     created_at: Optional[datetime]
     creator: Optional[ParticipantRead]
     description: Optional[str] = Field(None, nullable=True)
-    incident: IncidentReadNested
+    incident: IncidentReadMinimal
     owner: Optional[ParticipantRead]
     priority: Optional[str] = Field(None, nullable=True)
     resolve_by: Optional[datetime]

--- a/src/dispatch/ticket/models.py
+++ b/src/dispatch/ticket/models.py
@@ -35,7 +35,3 @@ class TicketRead(TicketBase):
     def set_description(cls, v):
         """Sets the description"""
         return TICKET_DESCRIPTION
-
-
-class TicketNested(TicketBase):
-    id: PrimaryKey

--- a/src/dispatch/workflow/models.py
+++ b/src/dispatch/workflow/models.py
@@ -141,10 +141,6 @@ class WorkflowRead(WorkflowBase):
         return v
 
 
-class WorkflowNested(WorkflowRead):
-    pass
-
-
 class WorkflowPagination(DispatchBase):
     total: int
     items: List[WorkflowRead] = []


### PR DESCRIPTION
They query performance for /incidents is quite poor. Via nested pedantic relationships we are loading a cascading set of attributes we don't need. This PR introduced the idea of "minimal" models that try to not load any unnecessary sub-models. This along with modifying some relationships' lazy loading to use subqueries provided a 10x reduction in API response time (loading 500 incidents). 

There are likely similar improvements to be back for cases and other endpoints. Should the need arise. I've removed several "nested" models that were similar to "minimal" but never actually used. 