### PR TITLE
individual name is wrongly resolved

### DIFF
--- a/src/dispatch/individual/service.py
+++ b/src/dispatch/individual/service.py
@@ -89,12 +89,10 @@ def get_or_create(
 
     individual_info = {}
     if contact_plugin:
-        individual_info = contact_plugin.instance.get(email,
-                                                      project_id=contact_plugin.project_id,
-                                                      db_session=db_session)
+        individual_info = contact_plugin.instance.get(email, db_session=db_session)
 
     kwargs["email"] = individual_info.get("email", email)
-    kwargs["name"] = individual_info.get("name", "Unknown")
+    kwargs["name"] = individual_info.get("fullname", "Unknown")
     kwargs["weblink"] = individual_info.get("weblink", "")
 
     if not individual_contact:

--- a/src/dispatch/individual/service.py
+++ b/src/dispatch/individual/service.py
@@ -89,10 +89,12 @@ def get_or_create(
 
     individual_info = {}
     if contact_plugin:
-        individual_info = contact_plugin.instance.get(email, db_session=db_session)
+        individual_info = contact_plugin.instance.get(email,
+                                                      project_id=contact_plugin.project_id,
+                                                      db_session=db_session)
 
     kwargs["email"] = individual_info.get("email", email)
-    kwargs["name"] = individual_info.get("fullname", "Unknown")
+    kwargs["name"] = individual_info.get("name", "Unknown")
     kwargs["weblink"] = individual_info.get("weblink", "")
 
     if not individual_contact:

--- a/src/dispatch/plugin/models.py
+++ b/src/dispatch/plugin/models.py
@@ -72,6 +72,7 @@ class PluginInstance(Base, ProjectMixin):
         """Fetches a plugin instance that matches this record."""
         plugin = plugins.get(self.plugin.slug)
         plugin.configuration = self.configuration
+        plugin.project_id = self.project_id
         return plugin
 
     @property

--- a/src/dispatch/plugins/base/v1.py
+++ b/src/dispatch/plugins/base/v1.py
@@ -56,6 +56,7 @@ class IPlugin(local):
     author: Optional[str] = None
     author_url: Optional[str] = None
     configuration: Optional[dict] = None
+    project_id: Optional[int] = None
     resource_links = ()
 
     schema: PluginConfiguration

--- a/src/dispatch/plugins/dispatch_core/plugin.py
+++ b/src/dispatch/plugins/dispatch_core/plugin.py
@@ -272,14 +272,16 @@ class DispatchContactPlugin(ContactPlugin):
     author = "Netflix"
     author_url = "https://github.com/netflix/dispatch.git"
 
-    def get(self, email, project_id=None, db_session=None):
-        return getattr(
-            individual_service.get_by_email_and_project(
-                db_session=db_session, email=email, project_id=project_id
-            ),
-            "__dict__",
-            {"email": email, "fullname": email},
+    def get(self, email, db_session=None):
+        individual = individual_service.get_by_email_and_project(
+            db_session=db_session, email=email, project_id=self.project_id
         )
+        if individual is None:
+            return {"email": email, "fullname": email}
+
+        data = individual.dict()
+        data["fullname"] = data["name"]
+        return data
 
 
 class DispatchParticipantResolverPlugin(ParticipantPlugin):


### PR DESCRIPTION
when an incident is created, reporter's name is reset to their "email".

reasons:
1. project_id is not provided to `get` method of the contact plugin
2. `individual.service` checks for a `fullname` field while `name` is actual field of the IndividualContact table

