### PR TITLE
removes user_middleware from global message event dispatcher

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/bolt.py
+++ b/src/dispatch/plugins/dispatch_slack/bolt.py
@@ -17,7 +17,6 @@ from .decorators import message_dispatcher
 from .middleware import (
     message_context_middleware,
     db_middleware,
-    user_middleware,
     configuration_middleware,
 )
 
@@ -66,7 +65,6 @@ async def app_error_handler(
     middleware=[
         message_context_middleware,
         db_middleware,
-        user_middleware,
         configuration_middleware,
     ],
 )


### PR DESCRIPTION
the `user_middleware` is not currently utilized in any of the `message_dispatcher` functions.