### PR TITLE
add lazy error decorator, resolve tuple unpack exception, and minor type changes

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/bolt.py
+++ b/src/dispatch/plugins/dispatch_slack/bolt.py
@@ -14,6 +14,7 @@ from .middleware import (
     configuration_middleware,
     db_middleware,
     message_context_middleware,
+    user_middleware,
 )
 
 app = AsyncApp(
@@ -25,7 +26,7 @@ app = AsyncApp(
 logging.basicConfig(level=logging.DEBUG)
 
 
-# @app.error
+@app.error
 async def app_error_handler(
     error: Any,
     client: AsyncWebClient,
@@ -61,6 +62,7 @@ async def app_error_handler(
     middleware=[
         message_context_middleware,
         db_middleware,
+        user_middleware,
         configuration_middleware,
     ],
 )

--- a/src/dispatch/plugins/dispatch_slack/bolt.py
+++ b/src/dispatch/plugins/dispatch_slack/bolt.py
@@ -3,7 +3,7 @@ import logging
 from http import HTTPStatus
 from typing import Any
 
-from blockkit import Modal, Section
+from blockkit import Modal, MarkdownText, Context
 from slack_bolt.app.async_app import AsyncApp
 from slack_bolt.async_app import AsyncRespond
 from slack_bolt.response import BoltResponse
@@ -43,7 +43,17 @@ async def app_error_handler(
 
     # the user is within a modal flow
     if body.get("view"):
-        modal = Modal(title="Error", close="Close", blocks=[Section(text=str(error))]).build()
+        modal = Modal(
+            title="Error",
+            close="Close",
+            blocks=[
+                Context(
+                    elements=[
+                        MarkdownText(text=f"❌ An internal error occured:\n ```{str(error)}```")
+                    ]
+                )
+            ],
+        ).build()
 
         await client.views_update(
             view_id=body["view"]["id"],

--- a/src/dispatch/plugins/dispatch_slack/decorators.py
+++ b/src/dispatch/plugins/dispatch_slack/decorators.py
@@ -1,7 +1,14 @@
 import logging
 import inspect
+from functools import wraps
+from typing import Callable, TypeVar
+from typing_extensions import ParamSpec
+
 
 log = logging.getLogger(__file__)
+
+T = TypeVar("T")
+P = ParamSpec("P")
 
 
 class MessageDispatcher:
@@ -37,3 +44,15 @@ class MessageDispatcher:
 
 
 message_dispatcher = MessageDispatcher()
+
+
+def handle_lazy_error(func: Callable[P, T]):
+    @wraps(func)
+    async def handle(*args: P.args, **kwargs: P.kwargs) -> None:
+        try:
+            await func(*args, **kwargs)
+        except Exception as e:
+            log.debug(f"Failed to run a lazy listener function {func.__name__}")
+            log.exception(f"{func.__name__}: {e}")
+
+    return handle

--- a/src/dispatch/plugins/dispatch_slack/endpoints.py
+++ b/src/dispatch/plugins/dispatch_slack/endpoints.py
@@ -30,7 +30,7 @@ async def is_current_configuration(request: Request, plugin_instance: PluginInst
 async def get_request_handler(request: Request, organization: str) -> AsyncSlackRequestHandler:
     """Creates a slack request handler for use by the api."""
     session = get_organization_scope_from_slug(organization)
-    plugin_instances = (
+    plugin_instances: list[PluginInstance] = (
         session.query(PluginInstance)
         .join(Plugin)
         .filter(PluginInstance.enabled == true(), Plugin.slug == "slack-conversation")

--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -986,6 +986,7 @@ async def ack_add_timeline_submission_event(ack: AsyncAck) -> None:
     await ack(response_action="update", view=modal)
 
 
+@handle_lazy_error
 async def handle_add_timeline_submission_event(
     body: dict,
     user: DispatchUser,
@@ -1101,6 +1102,7 @@ async def ack_update_participant_submission_event(ack):
     await ack(response_action="update", view=modal)
 
 
+@handle_lazy_error
 async def handle_update_participant_submission_event(
     body: dict,
     client: AsyncWebClient,
@@ -1219,6 +1221,7 @@ async def ack_update_notifications_group_submission_event(ack):
     await ack(response_action="update", view=modal)
 
 
+@handle_lazy_error
 async def handle_update_notifications_group_submission_event(
     body: dict,
     client: AsyncWebClient,
@@ -1442,6 +1445,7 @@ async def ack_engage_oncall_submission_event(ack: AsyncAck) -> None:
     await ack(response_action="update", view=modal)
 
 
+@handle_lazy_error
 async def handle_engage_oncall_submission_event(
     client: AsyncWebClient,
     body: dict,
@@ -1561,6 +1565,7 @@ async def ack_report_tactical_submission_event(ack: AsyncAck) -> None:
     await ack(response_action="update", view=modal)
 
 
+@handle_lazy_error
 async def handle_report_tactical_submission_event(
     client: AsyncWebClient,
     body: dict,
@@ -1679,6 +1684,7 @@ async def ack_report_executive_submission_event(ack: AsyncAck) -> None:
     await ack(response_action="update", view=modal)
 
 
+@handle_lazy_error
 async def handle_report_executive_submission_event(
     client: AsyncWebClient,
     body: dict,
@@ -1798,6 +1804,7 @@ async def ack_incident_update_submission_event(ack: AsyncAck) -> None:
     await ack(response_action="update", view=modal)
 
 
+@handle_lazy_error
 async def handle_update_incident_submission_event(
     body: dict,
     client: AsyncWebClient,
@@ -1920,6 +1927,7 @@ async def ack_report_incident_submission_event(ack: AsyncAck) -> None:
     await ack(response_action="update", view=modal)
 
 
+@handle_lazy_error
 async def handle_report_incident_submission_event(
     user: DispatchUser,
     context: AsyncBoltContext,

--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -48,7 +48,7 @@ from dispatch.participant_role.enums import ParticipantRoleType
 from dispatch.plugin import service as plugin_service
 from dispatch.plugins.dispatch_slack import service as dispatch_slack_service
 from dispatch.plugins.dispatch_slack.bolt import app
-from dispatch.plugins.dispatch_slack.decorators import message_dispatcher
+from dispatch.plugins.dispatch_slack.decorators import message_dispatcher, handle_lazy_error
 from dispatch.plugins.dispatch_slack.fields import (
     DefaultActionIds,
     DefaultBlockIds,
@@ -1318,6 +1318,7 @@ async def ack_assign_role_submission_event(ack: AsyncAck):
     await ack(response_action="update", view=modal)
 
 
+@handle_lazy_error
 async def handle_assign_role_submission_event(
     body: dict,
     user: DispatchUser,

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 
 import slack_sdk
 from slack_sdk.web.async_client import AsyncWebClient
+from sqlalchemy.orm import Session
 from tenacity import TryAgain, retry, retry_if_exception_type, stop_after_attempt
 
 from dispatch.conversation import service as conversation_service
@@ -20,7 +21,7 @@ log = logging.getLogger(__name__)
 # we need a way to determine which organization to use for a given
 # event, we use the unique channel id to determine which organization the
 # event belongs to.
-def get_organization_scope_from_channel_id(channel_id: str) -> SessionLocal:
+def get_organization_scope_from_channel_id(channel_id: str) -> Optional[Session]:
     """Iterate all organizations looking for a relevant channel_id."""
     db_session = SessionLocal()
     organization_slugs = [o.slug for o in organization_service.get_all(db_session=db_session)]
@@ -43,7 +44,7 @@ def get_organization_scope_from_channel_id(channel_id: str) -> SessionLocal:
         scoped_db_session.close()
 
 
-def get_organization_scope_from_slug(slug: str) -> SessionLocal:
+def get_organization_scope_from_slug(slug: str) -> Session:
     """Iterate all organizations looking for a matching slug."""
     schema_engine = engine.execution_options(
         schema_translate_map={


### PR DESCRIPTION
### Tuple Unpacking Exception

`resolve_context_from_conversation` sometimes returns `None` if no `conversation` is found (command is ran from #general or a DM) and results in:

```bash
ERROR:Failed to run a middleware function (error: cannot unpack non-iterable NoneType object)
```

`NamedTuple` seemed like a nice solve here.

### Lazy Error Decorator

`@handle_lazy_error` results in:

```bash
DEBUG:Failed to run a lazy listener function handle_assign_role_submission_event:/Users/wshel/Projects/dispatch/src/dispatch/plugins/dispatch_slack/decorators.py:handle:55
ERROR:handle_assign_role_submission_event: There was an error!:/Users/wshel/Projects/dispatch/src/dispatch/plugins/dispatch_slack/decorators.py:handle:56
Traceback (most recent call last):
  File "/Users/wshel/Projects/dispatch/src/dispatch/plugins/dispatch_slack/decorators.py", line 53, in handle
    await func(*args, **kwargs)
  File "/Users/wshel/Projects/dispatch/src/dispatch/plugins/dispatch_slack/incident/interactive.py", line 1325, in handle_assign_role_submission_event
    raise Exception("There was an error!")
Exception: There was an error!
```

as opposed to:

```bash
ERROR:Failed to run an internal function (Lol!):/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/slack_bolt/lazy_listener/async_internals.py:request_wired_wrapper:30
```

It should be possible to extend this to also surface these issues to the user in a nice way.

Update: surfaces issues to user similarly to global error handler.

![Screenshot 2023-01-12 at 11 14 06 AM](https://user-images.githubusercontent.com/114631109/212159988-36488bbe-73ad-4f9b-8083-d87ff6d40c4a.png)

