### PR TITLE
bugfix/bolt-unhandled-exception-and-httpstatus-literals

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/bolt.py
+++ b/src/dispatch/plugins/dispatch_slack/bolt.py
@@ -19,7 +19,7 @@ from .middleware import (
 
 app = AsyncApp(
     token="xoxb-valid",
-    raise_error_for_unhandled_request=True,
+    raise_error_for_unhandled_request=False,
     process_before_response=True,
     request_verification_enabled=False,  # NOTE this is only safe because we do additional verification in order to determine which plugin configuration we are using
 )

--- a/src/dispatch/plugins/dispatch_slack/endpoints.py
+++ b/src/dispatch/plugins/dispatch_slack/endpoints.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from fastapi import APIRouter, HTTPException
 from slack_bolt.adapter.starlette.async_handler import AsyncSlackRequestHandler
 from slack_sdk.signature import SignatureVerifier
@@ -46,7 +48,9 @@ async def get_request_handler(request: Request, organization: str) -> AsyncSlack
             return AsyncSlackRequestHandler(app)
 
     session.close()
-    raise HTTPException(status_code=403, detail=[{"msg": "Invalid request signature"}])
+    raise HTTPException(
+        status_code=HTTPStatus.FORBIDDEN.value, detail=[{"msg": "Invalid request signature"}]
+    )
 
 
 @router.post(


### PR DESCRIPTION
Setting `raise_error_for_unhandled_request` to `False` appears to have better exceptions for unhandled bolt requests:


with `raise_error_for_unhandled_request=True`:

```bash
ERROR:Error: :/Users/wshel/Projects/dispatch/src/dispatch/plugins/dispatch_slack/bolt.py:app_error_handler:42
NoneType: None
```

vs with `raise_error_for_unhandled_request=False`:

```bash
WARNING:Unhandled request ({'type': 'block_actions', 'block_id': 'eKk', 'action_id': 'provide-feedback'})
---
[Suggestion] You can handle this type of event with the following listener function:

@app.action("provide-feedback")
async def handle_some_action(ack, body, logger):
    await ack()
    logger.info(body)
:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/slack_bolt/app/async_app.py:_handle_unmatched_requests:585
INFO:Unsuccessful Bolt execution result (status: 404, body: {"error": "unhandled request"}):/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/slack_bolt/adapter/socket_mode/async_internals.py:send_async_response:45
```

When the `raise_error_*` parameter is set to False, all unhandled requests enter the `warning_unhandled_request` function [0], which generates and logs the rich error message you see above. Otherwise, the request is packaged into a `BoltUnhandledRequestError` and sent to your global error handler (which can be the default or your custom one) [1]. It seems to be a net benefit to just use the builtin logger here (we should test if these exceptions still make their way into Radar). Unless we have a specific use case for handling this error that `warning_unhandled_request` does not provide, I believe `raise_error_for_unhandled_request` should be set to `False`.

Note that this only affects `unhandled request` errors and does not have an effect on uncaught exceptions within functions and similar.

[0] - https://github.com/slackapi/bolt-python/blob/f0ef1c382d96c3d5c159289ad1c53a4a630d9640/slack_bolt/logger/messages.py#L177
[1] - https://github.com/slackapi/bolt-python/blob/f0ef1c382d96c3d5c159289ad1c53a4a630d9640/slack_bolt/app/async_app.py#L564-L572