### PR TITLE
bugfix/handle-slash-command-timeouts-and-error-handling

### DIFF
--- a/src/dispatch/database/core.py
+++ b/src/dispatch/database/core.py
@@ -6,10 +6,9 @@ import logging
 
 from pydantic import BaseModel
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
-from sqlalchemy import create_engine, event, inspect
-from sqlalchemy.engine import Engine
+from sqlalchemy import create_engine, inspect
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
-from sqlalchemy.orm import object_session, sessionmaker
+from sqlalchemy.orm import object_session, sessionmaker, Session
 from sqlalchemy.sql.expression import true
 from sqlalchemy_utils import get_mapper
 from starlette.requests import Request
@@ -188,3 +187,13 @@ def ensure_unique_default_per_project(target, value, oldvalue, initiator):
             if previous_default.id != target.id:
                 previous_default.default = False
                 session.commit()
+
+
+def refetch_db_session(organization_slug: str) -> Session:
+    schema_engine = engine.execution_options(
+        schema_translate_map={
+            None: f"dispatch_organization_{organization_slug}",
+        }
+    )
+    db_session = sessionmaker(bind=schema_engine)()
+    return db_session

--- a/src/dispatch/plugins/dispatch_slack/bolt.py
+++ b/src/dispatch/plugins/dispatch_slack/bolt.py
@@ -19,7 +19,7 @@ from .middleware import (
 
 app = AsyncApp(
     token="xoxb-valid",
-    raise_error_for_unhandled_request=True,
+    raise_error_for_unhandled_request=False,
     process_before_response=True,
     request_verification_enabled=False,  # NOTE this is only safe because we do additional verification in order to determine which plugin configuration we are using
 )

--- a/src/dispatch/plugins/dispatch_slack/exceptions.py
+++ b/src/dispatch/plugins/dispatch_slack/exceptions.py
@@ -19,3 +19,8 @@ class ContextError(DispatchException):
 class RoleError(DispatchException):
     code = "role"
     msg_template = "{msg}"
+
+
+class BotNotPresentError(DispatchException):
+    code = "bot_not_present"
+    msg_template = "{msg}"

--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -424,15 +424,14 @@ async def handle_list_incidents_command(
 
 @handle_lazy_error
 async def handle_list_participants_command(
-    ack: AsyncAck,
     respond: AsyncRespond,
     client: AsyncWebClient,
-    db_session: Session,
     context: AsyncBoltContext,
 ) -> None:
     """Handles list participants command."""
-    await ack()
     blocks = [Section(text="*Incident Participants*")]
+    db_session = refetch_db_session(context["subject"].organization_slug)
+
     participants = participant_service.get_all_by_incident_id(
         db_session=db_session, incident_id=context["subject"].id
     ).all()
@@ -516,17 +515,16 @@ def filter_tasks_by_assignee_and_creator(
 
 @handle_lazy_error
 async def handle_list_tasks_command(
-    ack: AsyncAck,
     body: dict,
     payload: dict,
     client: AsyncWebClient,
     context: AsyncBoltContext,
-    db_session: Session,
     respond: AsyncRespond,
 ) -> None:
     """Handles the list tasks command."""
-    await ack()
     blocks = []
+
+    db_session = refetch_db_session(context["subject"].organization_slug)
 
     caller_only = False
     if body["command"] == context["config"].slack_command_list_my_tasks:
@@ -586,11 +584,10 @@ async def handle_list_tasks_command(
 
 
 @handle_lazy_error
-async def handle_list_resources_command(
-    ack: AsyncAck, respond: AsyncRespond, db_session: Session, context: AsyncBoltContext
-) -> None:
+async def handle_list_resources_command(respond: AsyncRespond, context: AsyncBoltContext) -> None:
     """Handles the list resources command."""
-    await ack()
+
+    db_session = refetch_db_session(context["subject"].organization_slug)
 
     incident = incident_service.get(db_session=db_session, incident_id=context["subject"].id)
 

--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -141,28 +141,38 @@ def configure(config):
     ]
 
     # don't need an incident context
+    app.command(config.slack_command_report_incident, middleware=[db_middleware])(
+        handle_report_incident_command
+    )
+
+    # non-sensitive-commands
     app.command(
         config.slack_command_list_incidents,
         middleware=middleware,
     )(ack=ack_command, lazy=[handle_list_incidents_command])
 
-    app.command(config.slack_command_report_incident, middleware=middleware)(
-        handle_report_incident_command
-    )
+    app.command(
+        config.slack_command_list_tasks,
+        middleware=middleware,
+    )(ack=ack_command, lazy=[handle_list_tasks_command])
 
-    # non-sensitive-commands
-    app.command(config.slack_command_list_tasks, middleware=middleware)(handle_list_tasks_command)
-    app.command(config.slack_command_list_my_tasks, middleware=middleware)(
-        handle_list_tasks_command
-    )
-    app.command(config.slack_command_list_participants, middleware=middleware)(
-        handle_list_participants_command
-    )
+    app.command(
+        config.slack_command_list_my_tasks,
+        middleware=middleware,
+    )(ack=ack_command, lazy=[handle_list_tasks_command])
+
+    app.command(
+        config.slack_command_list_participants,
+        middleware=middleware,
+    )(ack=ack_command, lazy=[handle_list_participants_command])
+
+    app.command(
+        config.slack_command_list_resources,
+        middleware=middleware,
+    )(ack=ack_command, lazy=[handle_list_resources_command])
+
     app.command(config.slack_command_update_participant, middleware=middleware)(
         handle_update_participant_command
-    )
-    app.command(config.slack_command_list_resources, middleware=middleware)(
-        handle_list_resources_command
     )
     app.command(config.slack_command_engage_oncall, middleware=middleware)(
         handle_engage_oncall_command
@@ -412,6 +422,7 @@ async def handle_list_incidents_command(
         await respond(text="Incident List", blocks=blocks, response_type="ephemeral")
 
 
+@handle_lazy_error
 async def handle_list_participants_command(
     ack: AsyncAck,
     respond: AsyncRespond,
@@ -503,6 +514,7 @@ def filter_tasks_by_assignee_and_creator(
     return filtered_tasks
 
 
+@handle_lazy_error
 async def handle_list_tasks_command(
     ack: AsyncAck,
     body: dict,
@@ -573,6 +585,7 @@ async def handle_list_tasks_command(
     await respond(text="Incident Task List", blocks=message, response_type="ephermeral")
 
 
+@handle_lazy_error
 async def handle_list_resources_command(
     ack: AsyncAck, respond: AsyncRespond, db_session: Session, context: AsyncBoltContext
 ) -> None:

--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -100,6 +100,7 @@ from dispatch.plugins.dispatch_slack.middleware import (
     db_middleware,
     message_context_middleware,
     modal_submit_middleware,
+    non_incident_command_middlware,
     restricted_command_middleware,
     subject_middleware,
     user_middleware,
@@ -141,6 +142,8 @@ def configure(config):
     ]
 
     # don't need an incident context
+    middleware.extend([non_incident_command_middlware])
+
     app.command(config.slack_command_report_incident, middleware=middleware)(
         ack=ack_command, lazy=[handle_report_incident_command]
     )
@@ -149,6 +152,7 @@ def configure(config):
     )
 
     # non-sensitive-commands
+    middleware.remove(non_incident_command_middlware)
     middleware.extend([command_context_middleware])
 
     app.command(config.slack_command_list_tasks, middleware=middleware)(

--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -2032,6 +2032,7 @@ async def handle_report_incident_submission_event(
 
     result = await client.views_update(
         view_id=result["view"]["id"],
+        hash=body["view"]["hash"],
         trigger_id=result["trigger_id"],
         view=modal,
     )
@@ -2094,6 +2095,7 @@ async def handle_report_incident_project_select_action(
 
     await client.views_update(
         view_id=body["view"]["id"],
+        hash=body["view"]["hash"],
         trigger_id=body["trigger_id"],
         view=modal,
     )

--- a/src/dispatch/plugins/dispatch_slack/messaging.py
+++ b/src/dispatch/plugins/dispatch_slack/messaging.py
@@ -17,6 +17,7 @@ from dispatch.messaging.strings import (
     MessageType,
     render_message_template,
 )
+from dispatch.plugins.dispatch_slack.config import SlackConfiguration
 
 log = logging.getLogger(__name__)
 
@@ -40,6 +41,77 @@ def get_template(message_type: MessageType):
     }
 
     return template_map.get(message_type, (default_notification, None))
+
+
+def get_incident_conversation_command_message(config: SlackConfiguration, command_string: str):
+    command_messages = {
+        config.slack_command_run_workflow: {
+            "response_type": "ephemeral",
+            "text": "Opening a modal to run a workflow...",
+        },
+        config.slack_command_report_tactical: {
+            "response_type": "ephemeral",
+            "text": "Opening a dialog to write a tactical report...",
+        },
+        config.slack_command_list_tasks: {
+            "response_type": "ephemeral",
+            "text": "Fetching the list of incident tasks...",
+        },
+        config.slack_command_list_my_tasks: {
+            "response_type": "ephemeral",
+            "text": "Fetching your incident tasks...",
+        },
+        config.slack_command_list_participants: {
+            "response_type": "ephemeral",
+            "text": "Fetching the list of incident participants...",
+        },
+        config.slack_command_assign_role: {
+            "response_type": "ephemeral",
+            "text": "Opening a dialog to assign a role to a participant...",
+        },
+        config.slack_command_update_incident: {
+            "response_type": "ephemeral",
+            "text": "Opening a dialog to update incident information...",
+        },
+        config.slack_command_update_participant: {
+            "response_type": "ephemeral",
+            "text": "Opening a dialog to update participant information...",
+        },
+        config.slack_command_engage_oncall: {
+            "response_type": "ephemeral",
+            "text": "Opening a dialog to engage an oncall person...",
+        },
+        config.slack_command_list_resources: {
+            "response_type": "ephemeral",
+            "text": "Fetching the list of incident resources...",
+        },
+        config.slack_command_report_incident: {
+            "response_type": "ephemeral",
+            "text": "Opening a dialog to report an incident...",
+        },
+        config.slack_command_report_executive: {
+            "response_type": "ephemeral",
+            "text": "Opening a dialog to write an executive report...",
+        },
+        config.slack_command_update_notifications_group: {
+            "response_type": "ephemeral",
+            "text": "Opening a dialog to update the membership of the notifications group...",
+        },
+        config.slack_command_add_timeline_event: {
+            "response_type": "ephemeral",
+            "text": "Opening a dialog to add an event to the incident timeline...",
+        },
+        config.slack_command_list_incidents: {
+            "response_type": "ephemeral",
+            "text": "Fetching the list of incidents...",
+        },
+        config.slack_command_list_workflows: {
+            "response_type": "ephemeral",
+            "text": "Fetching the list of workflows...",
+        },
+    }
+
+    return command_messages.get(command_string, f"Running command... {command_string}")
 
 
 def format_default_text(item: dict):

--- a/src/dispatch/plugins/dispatch_slack/messaging.py
+++ b/src/dispatch/plugins/dispatch_slack/messaging.py
@@ -43,7 +43,19 @@ def get_template(message_type: MessageType):
     return template_map.get(message_type, (default_notification, None))
 
 
-def get_incident_conversation_command_message(config: SlackConfiguration, command_string: str):
+def get_incident_conversation_command_message(
+    command_string: str, config: Optional[SlackConfiguration] = None
+) -> dict[str, str]:
+    """Fetches a custom message and response type for each respective slash command."""
+
+    default = {
+        "response_type": "ephemeral",
+        "text": f"Running command... `{command_string}`",
+    }
+
+    if not config:
+        return default
+
     command_messages = {
         config.slack_command_run_workflow: {
             "response_type": "ephemeral",
@@ -111,7 +123,7 @@ def get_incident_conversation_command_message(config: SlackConfiguration, comman
         },
     }
 
-    return command_messages.get(command_string, f"Running command... {command_string}")
+    return command_messages.get(command_string, default)
 
 
 def format_default_text(item: dict):

--- a/src/dispatch/plugins/dispatch_slack/middleware.py
+++ b/src/dispatch/plugins/dispatch_slack/middleware.py
@@ -305,12 +305,11 @@ async def non_incident_command_middlware(
 ):
     """Attempts to resolve a conversation based on the channel id or message_ts."""
     # We get the list of public and private conversations the Dispatch bot is a member of
-    (
-        public_conversations,
-        private_conversations,
-    ) = await dispatch_slack_service.get_conversations_by_user_id_async(
-        client,
-        context["config"].app_user_slug,  # dependency
+    public_conversations = await dispatch_slack_service.get_public_conversations_by_user_id_async(
+        client, context["config"].app_user_slug
+    )
+    private_conversations = await dispatch_slack_service.get_private_conversations_by_user_id_async(
+        client, context["config"].app_user_slug
     )
 
     public_conversation_names = [c["name"] for c in public_conversations]


### PR DESCRIPTION
The slash commands are not bolt [lazy listeners](https://slack.dev/bolt-python/concepts#lazy-listeners) like the modal functions and as a result can raise `operation_timeout` errors in Slack to the user if they take longer than 3 seconds.

```
/dispatch-list-incidents failed with the error "operation_timeout"
```

One approach is to make everything a lazy listener. One known downside to lazy listeners is they swallow errors/exceptions and are hard to debug. We have the `@handle_lazy_error` decorator as a workaround. For context, we used to [acknowledge](https://github.com/Netflix/dispatch/blob/2390cc161f1b767e686ca5a68593fe5fca44fc7e/src/dispatch/plugins/dispatch_slack/events.py#L148) each request from Slack in the [handle_slack_event](https://github.com/Netflix/dispatch/blob/2390cc161f1b767e686ca5a68593fe5fca44fc7e/src/dispatch/plugins/dispatch_slack/events.py#L113) function that [would run immediately upon](https://github.com/Netflix/dispatch/blob/2390cc161f1b767e686ca5a68593fe5fca44fc7e/src/dispatch/plugins/dispatch_slack/views.py#L119) receiving a request from Slack.

I tested that this works by running `time.sleep(4)` within the `handle_list_incidents_command` function.

If we're good with this approach, I'll update the PR to do this for all slash commands.