### PR TITLE
consolidate get_conversations service method and resolve cache issue

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/middleware.py
+++ b/src/dispatch/plugins/dispatch_slack/middleware.py
@@ -310,11 +310,11 @@ async def non_incident_command_middlware(
 ):
     """Attempts to resolve a conversation based on the channel id or message_ts."""
     # We get the list of public and private conversations the Dispatch bot is a member of
-    public_conversations = await dispatch_slack_service.get_public_conversations_by_user_id_async(
-        client, context["config"].app_user_slug
+    public_conversations = await dispatch_slack_service.get_conversations_by_user_id_async(
+        client, context["config"].app_user_slug, type="public"
     )
-    private_conversations = await dispatch_slack_service.get_private_conversations_by_user_id_async(
-        client, context["config"].app_user_slug
+    private_conversations = await dispatch_slack_service.get_conversations_by_user_id_async(
+        client, context["config"].app_user_slug, type="private"
     )
 
     public_conversation_names = [c["name"] for c in public_conversations]

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -308,7 +308,7 @@ async def get_conversations_by_user_id_async(client: Any, user_id: str, type: st
             types=f"{type}_channel",
             exclude_archived="true",
         )
-        await cache.set(user_id + f"-{type}", result)
+        await cache.set(f"{user_id}-{type}", result)
 
     conversations = []
     for channel in result["channels"]:

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -305,7 +305,7 @@ async def get_conversations_by_user_id_async(client: Any, user_id: str, type: st
             client,
             "users.conversations",
             user=user_id,
-            types=type + "_channel",
+            types=f"{type}_channel",
             exclude_archived="true",
         )
         await cache.set(user_id + f"-{type}", result)

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -298,46 +298,23 @@ async def get_user_avatar_url_async(client: Any, email: str):
 Conversations = list[dict[str, str]]
 
 
-async def get_private_conversations_by_user_id_async(client: Any, user_id: str) -> Conversations:
-    private_result = await cache.get(user_id)
-    if not private_result:
-        private_result = await make_call_async(
+async def get_conversations_by_user_id_async(client: Any, user_id: str, type: str) -> Conversations:
+    result = await cache.get(user_id)
+    if not result:
+        result = await make_call_async(
             client,
             "users.conversations",
             user=user_id,
-            types="private_channel",
+            types=type + "_channel",
             exclude_archived="true",
         )
-        await cache.set(user_id, private_result)
+        await cache.set(user_id + f"-{type}", result)
 
-    private_conversations = []
-    for channel in private_result["channels"]:
-        private_conversations.append(
-            {k: v for (k, v) in channel.items() if k == "id" or k == "name"}
-        )
+    conversations = []
+    for channel in result["channels"]:
+        conversations.append({k: v for (k, v) in channel.items() if k == "id" or k == "name"})
 
-    return private_conversations
-
-
-async def get_public_conversations_by_user_id_async(client: Any, user_id: str) -> Conversations:
-    public_result = await cache.get(user_id)
-    if not public_result:
-        public_result = await make_call_async(
-            client,
-            "users.conversations",
-            user=user_id,
-            types="public_channel",
-            exclude_archived="true",
-        )
-        await cache.set(user_id, public_result)
-
-    public_conversations = []
-    for channel in public_result["channels"]:
-        public_conversations.append(
-            {k: v for (k, v) in channel.items() if k == "id" or k == "name"}
-        )
-
-    return public_conversations
+    return conversations
 
 
 # note this will get slower over time, we might exclude archived to make it sane


### PR DESCRIPTION
This resolves a bug where non-incident commands incorrectly reported that the bot was not present in private channels. Consolidates `get_public/private_conversations_by_user_id_async` into a single function that accepts a `type` param and generates a unique cache key for public / private channels, which is the root cause of the bug.