### PR TITLE
fix exclude logic in message dispatch decorator

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/decorators.py
+++ b/src/dispatch/plugins/dispatch_slack/decorators.py
@@ -31,8 +31,10 @@ class MessageDispatcher:
             func_args = inspect.getfullargspec(inspect.unwrap(f["func"])).args
             injected_args = (kwargs[a] for a in func_args)
 
-            if kwargs.get("body"):
-                if kwargs["body"].get("event", {}).get("subtype", "") in f["exclude"]:
+            if exclude := f["exclude"]:
+                subtype: str = kwargs.get("body", {}).get("event", {}).get("subtype", "")
+                if subtype in exclude.get("subtype", []):
+                    log.debug(f"Skipping a dispatched function ({f['name']})")
                     continue
 
             try:


### PR DESCRIPTION
### Resolves

Incorrectly attempting to send `after_hours_notification` for new participants, `channel_join` should be filtered in `exclude` statement within `message_dispatcher` decorator. For example:

```python
@message_dispatcher.add(
    exclude={"subtype": ["channel_join", "group_join"]}
)
```

This is ignored, which results in:

```
'NoneType' object has no attribute 'after_hours_notification'
```

### Tested

```
DEBUG:Skipping a dispatched function handle_participant_role_activity:/Users/wshel/Projects/dispatch/src/dispatch/plugins/dispatch_slack/decorators.py:dispatch:37
DEBUG:Skipping a dispatched function handle_after_hours_message:/Users/wshel/Projects/dispatch/src/dispatch/plugins/dispatch_slack/decorators.py:dispatch:37
```