### PR TITLE
instantly acknowledge /command and /event requests from slack

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/endpoints.py
+++ b/src/dispatch/plugins/dispatch_slack/endpoints.py
@@ -85,7 +85,7 @@ async def slack_events(request: Request, organization: str, body: bytes = Depend
     task = BackgroundTask(handler.handle, req=request, body=body)
     return JSONResponse(
         background=task,
-        content={"ok": ""},
+        content=HTTPStatus.OK.phrase,
         status_code=HTTPStatus.OK,
     )
 

--- a/src/dispatch/plugins/dispatch_slack/endpoints.py
+++ b/src/dispatch/plugins/dispatch_slack/endpoints.py
@@ -1,7 +1,10 @@
 from http import HTTPStatus
+import json
+import time
 
 from fastapi import APIRouter, HTTPException, Depends
-from slack_bolt.adapter.starlette.handler import SlackRequestHandler
+from starlette.background import BackgroundTask
+from starlette.responses import JSONResponse
 from slack_sdk.signature import SignatureVerifier
 from sqlalchemy import true
 from starlette.requests import Request, Headers
@@ -10,10 +13,12 @@ from dispatch.database.core import refetch_db_session
 from dispatch.plugin.models import Plugin, PluginInstance
 
 from .bolt import app
+from .case.interactive import configure as case_configure
+from .handler import SlackRequestHandler
 from .incident.interactive import configure as incident_configure
 from .feedback.interactive import configure as feedback_configure
 from .workflow import configure as workflow_configure
-from .case.interactive import configure as case_configure
+from .messaging import get_incident_conversation_command_message
 
 
 router = APIRouter()
@@ -21,6 +26,15 @@ router = APIRouter()
 
 async def get_body(request: Request):
     return await request.body()
+
+
+async def parse_request(request: Request):
+    request_body_form = await request.form()
+    try:
+        request = json.loads(request_body_form.get("payload"))
+    except Exception:
+        raise HTTPException(status_code=400, detail=[{"msg": "Bad Request"}])
+    return request
 
 
 def is_current_configuration(
@@ -46,10 +60,11 @@ def get_request_handler(request: Request, body: bytes, organization: str) -> Sla
     )
     for p in plugin_instances:
         if is_current_configuration(body=body, headers=request.headers, plugin_instance=p):
-            incident_configure(p.configuration)
-            workflow_configure(p.configuration)
             case_configure(p.configuration)
             feedback_configure(p.configuration)
+            incident_configure(p.configuration)
+            workflow_configure(p.configuration)
+            app._configuration = p.configuration
             app._token = p.configuration.api_bot_token.get_secret_value()
             app._signing_secret = p.configuration.signing_secret.get_secret_value()
             session.close()
@@ -67,7 +82,12 @@ def get_request_handler(request: Request, body: bytes, organization: str) -> Sla
 async def slack_events(request: Request, organization: str, body: bytes = Depends(get_body)):
     """Handle all incoming Slack events."""
     handler = get_request_handler(request=request, body=body, organization=organization)
-    return await handler.handle(request)
+    task = BackgroundTask(handler.handle, req=request, body=body)
+    return JSONResponse(
+        background=task,
+        content={"ok": ""},
+        status_code=HTTPStatus.OK,
+    )
 
 
 @router.post(
@@ -75,8 +95,27 @@ async def slack_events(request: Request, organization: str, body: bytes = Depend
 )
 async def slack_commands(organization: str, request: Request, body: bytes = Depends(get_body)):
     """Handle all incoming Slack commands."""
+    # We build the background task
+    context_properties = {"start_time": time.perf_counter()}
     handler = get_request_handler(request=request, body=body, organization=organization)
-    return await handler.handle(request)
+    task = BackgroundTask(
+        handler.handle,
+        req=request,
+        body=body,
+        addition_context_properties=context_properties,
+    )
+
+    # We get the name of command that was run
+    request_body_form = await request.form()
+    command = request_body_form._dict.get("command")
+    message = get_incident_conversation_command_message(
+        config=app._configuration, command_string=command
+    )
+    return JSONResponse(
+        background=task,
+        content=message,
+        status_code=HTTPStatus.OK,
+    )
 
 
 @router.post(
@@ -85,7 +124,7 @@ async def slack_commands(organization: str, request: Request, body: bytes = Depe
 async def slack_actions(request: Request, organization: str, body: bytes = Depends(get_body)):
     """Handle all incoming Slack actions."""
     handler = get_request_handler(request=request, body=body, organization=organization)
-    return await handler.handle(request)
+    return handler.handle(req=request, body=body)
 
 
 @router.post(
@@ -94,4 +133,4 @@ async def slack_actions(request: Request, organization: str, body: bytes = Depen
 async def slack_menus(request: Request, organization: str, body: bytes = Depends(get_body)):
     """Handle all incoming Slack actions."""
     handler = get_request_handler(request=request, body=body, organization=organization)
-    return await handler.handle(request)
+    return handler.handle(req=request, body=body)

--- a/src/dispatch/plugins/dispatch_slack/endpoints.py
+++ b/src/dispatch/plugins/dispatch_slack/endpoints.py
@@ -33,7 +33,7 @@ async def parse_request(request: Request):
     try:
         request = json.loads(request_body_form.get("payload"))
     except Exception:
-        raise HTTPException(status_code=400, detail=[{"msg": "Bad Request"}])
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=[{"msg": "Bad Request"}])
     return request
 
 

--- a/src/dispatch/plugins/dispatch_slack/handler.py
+++ b/src/dispatch/plugins/dispatch_slack/handler.py
@@ -3,7 +3,7 @@ https://github.com/slackapi/bolt-python/blob/c99c23fd056d26f8b1e39436bd1fcd2c83a
 
 Fork of the built-in Bolt Starlette adapater. Removes async to allow instant acknowledgment of interactivity payloads from Slack.
 """
-
+from http import HTTPStatus
 from typing import Dict, Any, Optional
 
 from starlette.requests import Request
@@ -78,6 +78,6 @@ class SlackRequestHandler:
             return to_starlette_response(bolt_resp)
 
         return Response(
-            status_code=404,
+            status_code=HTTPStatus.NOT_FOUND,
             content="Not found",
         )

--- a/src/dispatch/plugins/dispatch_slack/handler.py
+++ b/src/dispatch/plugins/dispatch_slack/handler.py
@@ -78,6 +78,6 @@ class SlackRequestHandler:
             return to_starlette_response(bolt_resp)
 
         return Response(
-            status_code=HTTPStatus.NOT_FOUND,
-            content="Not found",
+            status_code=HTTPStatus.NOT_FOUND.value,
+            content=HTTPStatus.NOT_FOUND.phrase,
         )

--- a/src/dispatch/plugins/dispatch_slack/handler.py
+++ b/src/dispatch/plugins/dispatch_slack/handler.py
@@ -1,0 +1,83 @@
+"""
+https://github.com/slackapi/bolt-python/blob/c99c23fd056d26f8b1e39436bd1fcd2c83a3e1bd/slack_bolt/adapter/starlette/handler.py
+
+Fork of the built-in Bolt Starlette adapater. Removes async to allow instant acknowledgment of interactivity payloads from Slack.
+"""
+
+from typing import Dict, Any, Optional
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+from slack_bolt import BoltRequest, App, BoltResponse
+from slack_bolt.oauth import OAuthFlow
+
+
+def to_bolt_request(
+    req: Request,
+    body: bytes,
+    addition_context_properties: Optional[Dict[str, Any]] = None,
+) -> BoltRequest:
+    request = BoltRequest(
+        body=body.decode("utf-8"),
+        query=req.query_params,
+        headers=req.headers,
+    )
+    if addition_context_properties is not None:
+        for k, v in addition_context_properties.items():
+            request.context[k] = v
+    return request
+
+
+def to_starlette_response(bolt_resp: BoltResponse) -> Response:
+    resp = Response(
+        status_code=bolt_resp.status,
+        content=bolt_resp.body,
+        headers=bolt_resp.first_headers_without_set_cookie(),
+    )
+    for cookie in bolt_resp.cookies():
+        for name, c in cookie.items():
+            resp.set_cookie(
+                key=name,
+                value=c.value,
+                max_age=c.get("max-age"),
+                expires=c.get("expires"),
+                path=c.get("path"),
+                domain=c.get("domain"),
+                secure=True,
+                httponly=True,
+            )
+    return resp
+
+
+class SlackRequestHandler:
+    def __init__(self, app: App):  # type: ignore
+        self.app = app
+
+    def handle(
+        self,
+        req: Request,
+        body: bytes,
+        addition_context_properties: Optional[Dict[str, Any]] = None,
+    ) -> Response:
+        if req.method == "GET":
+            if self.app.oauth_flow is not None:
+                oauth_flow: OAuthFlow = self.app.oauth_flow
+                if req.url.path == oauth_flow.install_path:
+                    bolt_resp = oauth_flow.handle_installation(
+                        to_bolt_request(req, body, addition_context_properties)
+                    )
+                    return to_starlette_response(bolt_resp)
+                elif req.url.path == oauth_flow.redirect_uri_path:
+                    bolt_resp = oauth_flow.handle_callback(
+                        to_bolt_request(req, body, addition_context_properties)
+                    )
+                    return to_starlette_response(bolt_resp)
+        elif req.method == "POST":
+            bolt_resp = self.app.dispatch(to_bolt_request(req, body, addition_context_properties))
+            return to_starlette_response(bolt_resp)
+
+        return Response(
+            status_code=404,
+            content="Not found",
+        )

--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -1936,8 +1936,6 @@ def handle_report_incident_command(
         private_metadata=context["subject"].json(),
     ).build()
 
-    elapsed_time = time.perf_counter() - context["start_time"]
-    log.debug(f"It has been {elapsed_time} since we got a trigger_id")
     client.views_open(trigger_id=body["trigger_id"], view=modal)
 
 

--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import datetime
+import inspect
 from typing import Any
+import time
 
 import pytz
 from blockkit import (
@@ -97,9 +99,7 @@ from dispatch.plugins.dispatch_slack.messaging import create_message_blocks
 from dispatch.plugins.dispatch_slack.middleware import (
     action_context_middleware,
     button_context_middleware,
-    command_acknowledge_middleware,
     command_context_middleware,
-    command_reply_middleware,
     configuration_middleware,
     db_middleware,
     is_bot,
@@ -131,10 +131,8 @@ log = logging.getLogger(__file__)
 def configure(config):
     """Maps commands/events to their functions."""
     middleware = [
-        command_acknowledge_middleware,
         subject_middleware,
         configuration_middleware,
-        command_reply_middleware,
     ]
 
     # don't need an incident context
@@ -147,10 +145,8 @@ def configure(config):
 
     # non-sensitive-commands
     middleware = [
-        command_acknowledge_middleware,
         subject_middleware,
         configuration_middleware,
-        command_reply_middleware,
         command_context_middleware,
     ]
 
@@ -159,10 +155,8 @@ def configure(config):
     )
 
     middleware = [
-        command_acknowledge_middleware,
         subject_middleware,
         configuration_middleware,
-        command_reply_middleware,
         command_context_middleware,
     ]
 
@@ -182,10 +176,8 @@ def configure(config):
 
     # sensitive commands
     middleware = [
-        command_acknowledge_middleware,
         subject_middleware,
         configuration_middleware,
-        command_reply_middleware,
         command_context_middleware,
         user_middleware,
         restricted_command_middleware,
@@ -337,9 +329,16 @@ def handle_update_incident_project_select_action(
 
 # COMMANDS
 def handle_list_incidents_command(
-    body: dict, payload: dict, db_session: Session, context: BoltContext, client: WebClient
+    ack: Ack,
+    body: dict,
+    payload: dict,
+    db_session: Session,
+    context: BoltContext,
+    client: WebClient,
 ) -> None:
     """Handles the list incidents command."""
+    ack()
+
     projects = []
 
     if context["subject"].type == "incident":
@@ -435,12 +434,18 @@ def handle_list_incidents_command(
 
 
 def handle_list_participants_command(
+    ack: Ack,
     body: dict,
     client: WebClient,
     context: BoltContext,
     db_session: Session,
 ) -> None:
     """Handles list participants command."""
+    ack()
+    log.debug(
+        f"Begin {inspect.currentframe().f_code.co_name}: {time.perf_counter() - context['start_time']} seconds have elapsed since recieving trigger_id: {body['trigger_id']}"
+    )
+
     blocks = []
 
     participants = participant_service.get_all_by_incident_id(
@@ -506,6 +511,9 @@ def handle_list_participants_command(
         close="Close",
     ).build()
 
+    log.debug(
+        f"End {inspect.currentframe().f_code.co_name}: {time.perf_counter() - context['start_time']} seconds have elapsed since recieving trigger_id: {body['trigger_id']}"
+    )
     client.views_open(trigger_id=body["trigger_id"], view=modal)
 
 
@@ -531,6 +539,7 @@ def filter_tasks_by_assignee_and_creator(
 
 
 def handle_list_tasks_command(
+    ack: Ack,
     body: dict,
     payload: dict,
     client: WebClient,
@@ -538,6 +547,8 @@ def handle_list_tasks_command(
     db_session: Session,
 ) -> None:
     """Handles the list tasks command."""
+    ack()
+
     tasks = task_service.get_all_by_incident_id(
         db_session=db_session,
         incident_id=context["subject"].id,
@@ -683,9 +694,11 @@ def handle_list_resources_command(
 
 
 def handle_timeline_added_event(
-    client: Any, context: BoltContext, payload: Any, db_session: Session
+    ack: Ack, client: Any, context: BoltContext, payload: Any, db_session: Session
 ) -> None:
     """Handles an event where a reaction is added to a message."""
+    ack()
+
     conversation_id = context["channel_id"]
     message_ts = payload["item"]["ts"]
     message_ts_utc = datetime.utcfromtimestamp(float(message_ts))
@@ -812,9 +825,11 @@ def handle_after_hours_message(
 
 @message_dispatcher.add()
 def handle_thread_creation(
-    client: WebClient, payload: dict, context: BoltContext, request: BoltRequest
+    ack: Ack, client: WebClient, payload: dict, context: BoltContext, request: BoltRequest
 ) -> None:
     """Sends the user an ephemeral message if they use threads."""
+    ack()
+
     if not context["config"].ban_threads:
         return
 
@@ -830,8 +845,12 @@ def handle_thread_creation(
 
 
 @message_dispatcher.add()
-def handle_message_tagging(db_session: Session, payload: dict, context: BoltContext) -> None:
+def handle_message_tagging(
+    ack: Ack, db_session: Session, payload: dict, context: BoltContext
+) -> None:
     """Looks for incident tags in incident messages."""
+    ack()
+
     # TODO: (wshel) handle case tagging
     if context["subject"].type == "incident":
         text = payload["text"]
@@ -1004,8 +1023,12 @@ def handle_member_left_channel(
 # MODALS
 
 
-def handle_add_timeline_event_command(body: dict, client: WebClient, context: BoltContext) -> None:
+def handle_add_timeline_event_command(
+    ack: Ack, body: dict, client: WebClient, context: BoltContext
+) -> None:
     """Handles the add timeline event command."""
+    ack()
+
     blocks = [
         Context(
             elements=[
@@ -1094,11 +1117,13 @@ def handle_add_timeline_submission_event(
 
 
 def handle_update_participant_command(
+    ack: Ack,
     body: dict,
     context: BoltContext,
     client: WebClient,
 ) -> None:
     """Handles the update participant command."""
+    ack()
 
     if context["subject"].type == "case":
         raise CommandError("Command is not currently available for cases.")
@@ -1183,9 +1208,10 @@ def handle_update_participant_submission_event(
 
 
 def handle_update_notifications_group_command(
-    body: dict, context: BoltContext, client: WebClient, db_session: Session
+    ack: Ack, body: dict, context: BoltContext, client: WebClient, db_session: Session
 ) -> None:
     """Handles the update notification group command."""
+    ack()
 
     # TODO handle cases
     if context["subject"].type == "case":
@@ -1293,8 +1319,12 @@ def handle_update_notifications_group_submission_event(
     )
 
 
-def handle_assign_role_command(body: dict, context: BoltContext, client: WebClient) -> None:
+def handle_assign_role_command(
+    ack: Ack, body: dict, context: BoltContext, client: WebClient
+) -> None:
     """Handles the assign role command."""
+    ack()
+
     roles = [
         {"text": r.value, "value": r.value}
         for r in ParticipantRoleType
@@ -1382,12 +1412,15 @@ def handle_assign_role_submission_event(
 
 
 def handle_engage_oncall_command(
+    ack: Ack,
     body: dict,
     client: WebClient,
     context: BoltContext,
     db_session: Session,
 ) -> None:
     """Handles the engage oncall command."""
+    ack()
+
     # TODO: handle cases
     if context["subject"].type == "case":
         raise CommandError("Command is not currently available for cases.")
@@ -1486,12 +1519,15 @@ def handle_engage_oncall_submission_event(
 
 
 def handle_report_tactical_command(
+    ack: Ack,
     body: dict,
     client: WebClient,
     context: BoltContext,
     db_session: Session,
 ) -> None:
     """Handles the report tactical command."""
+    ack()
+
     if context["subject"].type == "case":
         raise CommandError("Command is not available outside of incident channels.")
 
@@ -1591,12 +1627,14 @@ def handle_report_tactical_submission_event(
 
 
 def handle_report_executive_command(
+    ack: Ack,
     body: dict,
     client: WebClient,
     context: BoltContext,
     db_session: Session,
 ) -> None:
     """Handles executive report command."""
+    ack()
 
     if context["subject"].type == "case":
         raise CommandError("Command is not available outside of incident channels.")
@@ -1721,9 +1759,11 @@ def handle_report_executive_submission_event(
 
 
 def handle_update_incident_command(
-    body: dict, client: WebClient, context: BoltContext, db_session: Session
+    ack: Ack, body: dict, client: WebClient, context: BoltContext, db_session: Session
 ) -> None:
     """Creates the incident update modal."""
+    ack()
+
     incident = incident_service.get(db_session=db_session, incident_id=context["subject"].id)
 
     blocks = [
@@ -1861,12 +1901,15 @@ def handle_update_incident_submission_event(
 
 
 def handle_report_incident_command(
+    ack: Ack,
     body: dict,
     context: BoltContext,
     client: WebClient,
     db_session: Session,
 ) -> None:
     """Handles the report incident command."""
+    ack()
+
     blocks = [
         Context(
             elements=[
@@ -1893,6 +1936,8 @@ def handle_report_incident_command(
         private_metadata=context["subject"].json(),
     ).build()
 
+    elapsed_time = time.perf_counter() - context["start_time"]
+    log.debug(f"It has been {elapsed_time} since we got a trigger_id")
     client.views_open(trigger_id=body["trigger_id"], view=modal)
 
 

--- a/src/dispatch/plugins/dispatch_slack/workflow.py
+++ b/src/dispatch/plugins/dispatch_slack/workflow.py
@@ -14,9 +14,7 @@ from dispatch.plugins.dispatch_slack.bolt import app
 from dispatch.plugins.dispatch_slack.fields import static_select_block
 from dispatch.plugins.dispatch_slack.middleware import (
     action_context_middleware,
-    command_acknowledge_middleware,
     command_context_middleware,
-    command_reply_middleware,
     configuration_middleware,
     db_middleware,
     modal_submit_middleware,
@@ -47,11 +45,9 @@ class RunWorkflowActions(DispatchEnum):
 def configure(config):
     """Maps commands/events to their functions."""
     middleware = [
-        command_acknowledge_middleware,
         command_context_middleware,
         db_middleware,
         configuration_middleware,
-        command_reply_middleware,
     ]
     app.command(config.slack_command_list_workflows, middleware=middleware)(
         handle_workflow_list_command


### PR DESCRIPTION
We still receive occasional command timeouts after running Slash commands or handling message events. 

This PR leverages Starlette background task to *instantly* return a `200` `OK` to Slack upon receipt of a `/command` or `/event` interactivity payload. This change ensures that the first thing we do is acknowledge the request and aren't waiting on Bolt at all.

In my tests, I discovered that calling `ack()` at the beginning of our middleware function does not *actually* send a `200` back to Slack *at that point*. The way bolt works, it doesn't matter when you call `ack()`, as long you call it at the beginning of your listener function ([like this](https://github.com/Netflix/dispatch/pull/2907/files#diff-d2495d41fbf8f5c5500a410dc9fdcbcb271af34de0a447a84c0ec7b7a200b67bR444)). If you call it before then, like in a middleware function, it will function exactly the same as if you had called it at beginning of the listener function:

```bash
DEBUG:0.0009812499999988233:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/slack_bolt/app/app.py:dispatch:525
DEBUG:function.elapsed.time.dispatch.plugins.dispatch_slack.middleware.resolve_context_from_conversation: 0.08142970899999824:/Users/wshel/Projects/dispatch/src/dispatch/decorators.py:wrapper:111
DEBUG:Got middleware response None:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/slack_bolt/app/app.py:dispatch:530
DEBUG:Running listener: handle_list_participants_command ...:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/slack_bolt/app/app.py:dispatch:549
DEBUG:Begin if not request.lazy_only conditional:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/slack_bolt/listener/thread_runner.py:run:112
DEBUG:Enter run_ack_function_asynchronously:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/slack_bolt/listener/thread_runner.py:run:153
DEBUG:Start handler:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/slack_bolt/listener/thread_runner.py:run_ack_function_asynchronously:117
DEBUG:Waiting while response is None and it's been less than 3 seconds:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/slack_bolt/listener/thread_runner.py:run:172
DEBUG:Begin run_ack_function:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/slack_bolt/listener/thread_runner.py:run_ack_function_asynchronously:122
DEBUG:begin handle_list_participants_command: 1.013716875 seconds have elapsed since recieving trigger_id: 4722662541473.4543933691524.8025f946588c09b10ef50b7d7ebe20f3:/Users/wshel/Projects/dispatch/src/dispatch/plugins/dispatch_slack/incident/interactive.py:handle_list_participants_command:473
```

This flow has been annotated below:

[bolt-python/blob/main/slack_bolt/listener/thread_runner.py#L59-L109](https://github.com/slackapi/bolt-python/blob/c99c23fd056d26f8b1e39436bd1fcd2c83a3e1bd/slack_bolt/listener/thread_runner.py#L59-L109)
```python
    def run(  # type: ignore
        self,
        request: BoltRequest,
        response: BoltResponse,
        listener_name: str,
        listener: Listener,
        starting_time: Optional[float] = None,
    ) -> Optional[BoltResponse]:
    
           ...snip
          
            if not request.lazy_only:
                self.logger.debug("Begin if not request.lazy_only conditional")
                # start the listener function asynchronously
                def run_ack_function_asynchronously():
                    nonlocal ack, request, response
                    try:
                        self.logger.debug("Start handler")
                        self.listener_start_handler.handle(
                            request=request,
                            response=response,
                        )
                        self.logger.debug("Begin run_ack_function")
                        # 1. (wshel) This is when we finally start running our command logic (this is async)
                        listener.run_ack_function(request=request, response=response)
                        self.logger.debug("Done with run_ack_function")
                    except Exception as e:
                        ...snip
                    finally:
                        self.listener_completion_handler.handle(
                            request=request,
                            response=response,
                        )

                self.logger.debug("Enter run_ack_function_asynchronously")
                self.listener_executor.submit(run_ack_function_asynchronously)
```

Note that the code above (`run` function) begins [here](https://github.com/slackapi/bolt-python/blob/c99c23fd056d26f8b1e39436bd1fcd2c83a3e1bd/slack_bolt/app/app.py#L523), within the [dispatch function](https://github.com/slackapi/bolt-python/blob/c99c23fd056d26f8b1e39436bd1fcd2c83a3e1bd/slack_bolt/app/app.py#L454), strictly after all middleware has been called. Middleware [inherently cannot return a response](https://github.com/slackapi/bolt-python/blob/main/slack_bolt/app/app.py#L479), if it does, the listener will never be executed.


### Tests

Slash commands sends custom ephemeral message without middleware:

![Screenshot 2023-01-27 at 7 59 14 AM](https://user-images.githubusercontent.com/114631109/215131201-d751acca-2220-4699-85e9-9e2330359e93.png)

Modal submission:

![Screenshot 2023-01-27 at 7 59 35 AM](https://user-images.githubusercontent.com/114631109/215131305-44bae15e-12fc-4c8f-83cd-bc244f3b42bd.png)

Message event:

![Screenshot 2023-01-27 at 8 00 21 AM](https://user-images.githubusercontent.com/114631109/215131592-ef5334ff-98b0-48ff-b145-f8a8fa7ce0ec.png)
