### PR TITLE
Fixes issue where tags list expected a project field

### DIFF
--- a/src/dispatch/database/service.py
+++ b/src/dispatch/database/service.py
@@ -1,21 +1,18 @@
 import json
 import logging
-
 from collections import namedtuple
 from collections.abc import Iterable
 from inspect import signature
 from itertools import chain
-from six import string_types
-from sortedcontainers import SortedSet
-
 from typing import List
-from pydantic.error_wrappers import ErrorWrapper, ValidationError
-from pydantic import BaseModel
-from pydantic.types import Json, constr
 
 from fastapi import Depends, Query
-
-from sqlalchemy import and_, not_, or_, orm, func, desc
+from pydantic import BaseModel
+from pydantic.error_wrappers import ErrorWrapper, ValidationError
+from pydantic.types import Json, constr
+from six import string_types
+from sortedcontainers import SortedSet
+from sqlalchemy import and_, desc, func, not_, or_, orm
 from sqlalchemy.exc import InvalidRequestError, ProgrammingError
 from sqlalchemy.orm.mapper import Mapper
 from sqlalchemy_filters import apply_pagination, apply_sort
@@ -23,7 +20,8 @@ from sqlalchemy_filters.exceptions import BadFilterFormat, FieldNotFound
 from sqlalchemy_filters.models import Field, get_model_from_spec
 
 from dispatch.auth.models import DispatchUser
-from dispatch.auth.service import get_current_user, get_current_role
+from dispatch.auth.service import get_current_role, get_current_user
+from dispatch.case.models import Case
 from dispatch.data.query.models import Query as QueryModel
 from dispatch.data.source.models import Source
 from dispatch.enums import UserRoles, Visibility
@@ -37,13 +35,7 @@ from dispatch.plugin.models import Plugin, PluginInstance
 from dispatch.search.fulltext.composite_search import CompositeSearch
 from dispatch.task.models import Task
 
-from .core import (
-    Base,
-    get_class_by_tablename,
-    get_model_name_by_tablename,
-    get_db,
-)
-
+from .core import Base, get_class_by_tablename, get_db, get_model_name_by_tablename
 
 log = logging.getLogger(__file__)
 
@@ -352,6 +344,7 @@ def apply_filter_specific_joins(model: Base, filter_spec: dict, query: orm.query
         (Incident, "Tag"): (Incident.tags, True),
         (Incident, "TagType"): (Incident.tags, True),
         (Incident, "Term"): (Incident.terms, True),
+        (Case, "Tag"): (Case.tags, True),
     }
     filters = build_filters(filter_spec)
     filter_models = get_named_models(filters)[0]

--- a/src/dispatch/static/dispatch/src/incident/DetailsTab.vue
+++ b/src/dispatch/static/dispatch/src/incident/DetailsTab.vue
@@ -106,7 +106,13 @@
         </v-row>
       </v-flex>
       <v-flex xs12>
-        <tag-filter-auto-complete label="Tags" v-model="tags" model="incident" :model-id="id" />
+        <tag-filter-auto-complete
+          label="Tags"
+          v-model="tags"
+          :project="project"
+          model="incident"
+          :model-id="id"
+        />
       </v-flex>
       <v-flex xs12>
         <incident-filter-combobox label="Duplicates" v-model="duplicates" :project="project" />

--- a/src/dispatch/static/dispatch/src/tag/TagFilterAutoComplete.vue
+++ b/src/dispatch/static/dispatch/src/tag/TagFilterAutoComplete.vue
@@ -27,9 +27,7 @@
     </template>
     <template v-slot:selection="{ item, index }">
       <v-chip close @click:close="value.splice(index, 1)">
-        <span v-if="item.tag_type">
-          <span v-if="!project">{{ item.project.name }}/</span>{{ item.tag_type.name }}/
-        </span>
+        <span v-if="item.tag_type"> {{ item.tag_type.name }}/ </span>
         <a :href="item.uri" target="_blank" :title="item.description">
           {{ item.name }}
         </a>
@@ -37,11 +35,7 @@
     </template>
     <template v-slot:item="data">
       <v-list-item-content>
-        <v-list-item-title>
-          <span v-if="!project">{{ data.item.project.name }}/</span>{{ data.item.tag_type.name }}/{{
-            data.item.name
-          }}
-        </v-list-item-title>
+        <v-list-item-title> {{ data.item.tag_type.name }}/{{ data.item.name }} </v-list-item-title>
         <v-list-item-subtitle style="width: 200px" class="text-truncate">
           {{ data.item.description }}
         </v-list-item-subtitle>

--- a/src/dispatch/static/dispatch/src/tag_type/TagTypeFilterCombobox.vue
+++ b/src/dispatch/static/dispatch/src/tag_type/TagTypeFilterCombobox.vue
@@ -32,7 +32,7 @@
     </template>
     <template v-slot:item="data">
       <v-list-item-content>
-        <v-list-item-title> {{ data.item.project.name }}/{{ data.item.name }} </v-list-item-title>
+        <v-list-item-title> {{ data.item.name }} </v-list-item-title>
         <v-list-item-subtitle style="width: 200px" class="text-truncate">
           {{ data.item.description }}
         </v-list-item-subtitle>


### PR DESCRIPTION
With the switch to the minimalist tag model, this is no longer included. We should consider making tag names exclusive across projects if we expect a user to be able to determine which tag they wish to filter on.