### PR TITLE
Migrate case assignees to participants who aren't individuals

### DIFF
--- a/src/dispatch/database/revisions/tenant/versions/2023-01-30_e4b4991dddcd.py
+++ b/src/dispatch/database/revisions/tenant/versions/2023-01-30_e4b4991dddcd.py
@@ -6,10 +6,13 @@ Create Date: 2023-01-30 10:52:31.676368
 
 """
 from alembic import op
+
 from enum import Enum
 from pydantic import BaseModel
 import sqlalchemy as sa
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, relationship
+from sqlalchemy.sql.expression import true
+from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.declarative import declarative_base
 from typing import Optional
 
@@ -28,6 +31,13 @@ class DispatchUser(Base):
     __table_args__ = {"schema": "dispatch_core"}
     id = sa.Column(sa.Integer, primary_key=True)
     email = sa.Column(sa.String)
+
+
+class Project(Base):
+    __tablename__ = "project"
+    id = sa.Column(sa.Integer, primary_key=True)
+    name = sa.Column(sa.String)
+    default = sa.Column(sa.Boolean, default=False)
 
 
 class Case(Base):
@@ -71,11 +81,25 @@ class ParticipantRoleCreate(ParticipantRoleBase):
     role: Optional[ParticipantRoleType]
 
 
-class IndividualContact(Base):
+class ProjectMixin(object):
+    """Project mixin"""
+
+    @declared_attr
+    def project_id(cls):  # noqa
+        return sa.Column(sa.Integer, sa.ForeignKey("project.id", ondelete="CASCADE"))
+
+    @declared_attr
+    def project(cls):  # noqa
+        return relationship("Project")
+
+
+class IndividualContact(Base, ProjectMixin):
     __tablename__ = "individual_contact"
 
     id = sa.Column(sa.Integer, primary_key=True)
     email = sa.Column(sa.String)
+    name = sa.Column(sa.String)
+    weblink = sa.Column(sa.String)
 
 
 class Participant(Base):
@@ -129,6 +153,19 @@ def upgrade():
                 .filter(IndividualContact.email == current_user.email)
                 .first()
             )
+            if individual is None:
+                i = {}
+                i["email"] = current_user.email
+                i["name"] = current_user.email
+                i["weblink"] = ""
+                default_project = (
+                    db_session.query(Project).filter(Project.default == true()).one_or_none()
+                )
+                individual = IndividualContact(
+                    **i,
+                    project=default_project if default_project else "default",
+                )
+                db_session.add(individual)
 
             participant = Participant(
                 individual_contact_id=individual.id,


### PR DESCRIPTION
Resolves an issue where Assignee's that have never participated in an incident fail to be migrated to the Participant model.

Tested using, where `12460` is not an individual:

```sql
dispatch=# INSERT INTO dispatch_organization_default.case (id, name, assignee_id, title, description, resolution, status, visibility, case_priority_id, case_severity_id, case_type_id, project_id)
VALUES (37, 'TICKET-37', 12460, 'test', 'test', 'done', 'Triage', 'Open', 3, 4, 2, 1);
INSERT 0 1
```

Output:

```bash
(dispatch) wshel@Wills-MacBook-Pro dispatch % dispatch database upgrade                                            
DEBUG:Configuring extensions...:/Users/wshel/Projects/dispatch/src/dispatch/extensions.py:configure_extensions:25
INFO:Migrating dispatch core schema...:/Users/wshel/Projects/dispatch/src/dispatch/database/revisions/core/env.py:run_migrations_online:51
INFO:Context impl PostgresqlImpl.:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:__init__:204
INFO:Will assume transactional DDL.:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:__init__:207
INFO:Migrating dispatch_organization_default...:/Users/wshel/Projects/dispatch/src/dispatch/database/revisions/tenant/env.py:run_migrations_online:60
INFO:Context impl PostgresqlImpl.:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:__init__:204
INFO:Will assume transactional DDL.:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:__init__:207
INFO:Running upgrade 6e53722fa1f2 -> e23c468440c9, Sets a default search filter creator:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:run_migrations:618
DEBUG:update 6e53722fa1f2 to e23c468440c9:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:update_to_step:853
INFO:Running upgrade e23c468440c9 -> 956eb8f8987e, empty message:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:run_migrations:618
DEBUG:update e23c468440c9 to 956eb8f8987e:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:update_to_step:853
INFO:Running upgrade 956eb8f8987e -> e4b4991dddcd, empty message:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:run_migrations:618
Migrating case assignees to Participant from DispatchUser..
Processing Case 36...
Processing Case 24...
Processing Case 21...
Processing Case 22...
Processing Case 35...
Processing Case 37...
DEBUG:update 956eb8f8987e to e4b4991dddcd:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:update_to_step:853
INFO:Migrating dispatch_organization_training...:/Users/wshel/Projects/dispatch/src/dispatch/database/revisions/tenant/env.py:run_migrations_online:60
INFO:Context impl PostgresqlImpl.:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:__init__:204
INFO:Will assume transactional DDL.:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:__init__:207
INFO:Running upgrade 6e53722fa1f2 -> e23c468440c9, Sets a default search filter creator:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:run_migrations:618
DEBUG:update 6e53722fa1f2 to e23c468440c9:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:update_to_step:853
INFO:Running upgrade e23c468440c9 -> 956eb8f8987e, empty message:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:run_migrations:618
DEBUG:update e23c468440c9 to 956eb8f8987e:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:update_to_step:853
INFO:Running upgrade 956eb8f8987e -> e4b4991dddcd, empty message:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:run_migrations:618
Migrating case assignees to Participant from DispatchUser..
DEBUG:update 956eb8f8987e to e4b4991dddcd:/Users/wshel/.pyenv/versions/3.9.7/envs/dispatch/lib/python3.9/site-packages/alembic/runtime/migration.py:update_to_step:853
Success.
```

Migrated user:

![Screenshot 2023-02-07 at 8 55 31 AM](https://user-images.githubusercontent.com/114631109/217311505-748b9210-9f3d-40bb-9587-66f27c5babd8.png)

