### PR TITLE
Propose the adoption of lightweight architecture decision records

### DIFF
--- a/docs/architecture/decisions/0001-record-architecture-decisions.md
+++ b/docs/architecture/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,20 @@
+# 1. Record architecture decisions
+
+Date: 2023-02-07
+
+## Status
+
+Proposed
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard in
+[documenting architecture decisions](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see [Nat Pryce's adr-tools](https://github.com/npryce/adr-tools)


### PR DESCRIPTION
Storing these in `git` is useful in my experience -- they work best when kept near the code they pertain to because developers will find them in the course of working, and they can be created as part of the PR introducing a change—all ensuring the pertinent context is available with minimal searching.  You can see an example of this in use by the [UK government](https://github.com/alphagov/govuk-aws/tree/master/doc/architecture/decisions).