### PR TITLE
Support incident date in storage

### DIFF
--- a/src/dispatch/incident/flows.py
+++ b/src/dispatch/incident/flows.py
@@ -493,8 +493,8 @@ def update_document(document_resource_id: str, incident: Incident, db_session: S
         ticket_weblink=resolve_attr(incident, "ticket.weblink"),
         title=incident.title,
         type=incident.incident_type.name,
-        incident_stable_time=incident.stable_at,
-        incident_reported_time=incident.reported_at,
+        stable_at_time=incident.stable_at,
+        reported_at_time=incident.reported_at,
     )
 
 

--- a/src/dispatch/incident/flows.py
+++ b/src/dispatch/incident/flows.py
@@ -493,6 +493,8 @@ def update_document(document_resource_id: str, incident: Incident, db_session: S
         ticket_weblink=resolve_attr(incident, "ticket.weblink"),
         title=incident.title,
         type=incident.incident_type.name,
+        incident_stable_time=incident.stable_at,
+        incident_reported_time=incident.reported_at,
     )
 
 


### PR DESCRIPTION
Support Incident date in storage plugins to make the document event richer.  This would enable plugins to calculate recovery time ( Reported-stable).

Document plugins will now support the following in the update.
```
{{incident_stable_time}}
{{incident_reported_time}}
```