### PR TITLE
Converts timestamps to strings before passing them to the document plugin

### DIFF
--- a/src/dispatch/incident/flows.py
+++ b/src/dispatch/incident/flows.py
@@ -493,8 +493,8 @@ def update_document(document_resource_id: str, incident: Incident, db_session: S
         ticket_weblink=resolve_attr(incident, "ticket.weblink"),
         title=incident.title,
         type=incident.incident_type.name,
-        stable_at_time=incident.stable_at,
-        reported_at_time=incident.reported_at,
+        reported_at_time=incident.reported_at.strftime("%m/%d/%Y %H:%M:%S"),
+        stable_at_time=incident.stable_at.strftime("%m/%d/%Y %H:%M:%S"),
     )
 
 


### PR DESCRIPTION
This PR fixes a `TypeError: Object of type datetime is not JSON serializable` exception when the `reported_at` and `stable_at` timestamps were getting passed to the Google document plugin as datetime objects.

cc @Cinojose 