### PR TITLE
CLI drop database modified to address in case the database doesn't exist

### DIFF
--- a/src/dispatch/cli.py
+++ b/src/dispatch/cli.py
@@ -308,17 +308,22 @@ def dump_database(dump_file):
 @click.option("--yes", is_flag=True, help="Silences all confirmation prompts.")
 def drop_database(yes):
     """Drops all data in database."""
-    from sqlalchemy_utils import drop_database
+    from sqlalchemy_utils import drop_database, database_exists
 
-    if yes:
-        drop_database(str(config.SQLALCHEMY_DATABASE_URI))
-        click.secho("Success.", fg="green")
+    if database_exists(str(config.SQLALCHEMY_DATABASE_URI)):
+        if yes:
+            drop_database(str(config.SQLALCHEMY_DATABASE_URI))
+            click.secho("Success.", fg="green")
 
-    if click.confirm(
-        f"Are you sure you want to drop: '{config.DATABASE_HOSTNAME}:{config.DATABASE_NAME}'?"
-    ):
-        drop_database(str(config.SQLALCHEMY_DATABASE_URI))
-        click.secho("Success.", fg="green")
+        if click.confirm(
+            f"Are you sure you want to drop: '{config.DATABASE_HOSTNAME}:{config.DATABASE_NAME}'?"
+        ):
+            drop_database(str(config.SQLALCHEMY_DATABASE_URI))
+            click.secho("Success.", fg="green")
+    else:
+        click.secho(
+            f"'{config.DATABASE_HOSTNAME}:{config.DATABASE_NAME}' does not exist!!!", fg="red"
+        )
 
 
 @dispatch_database.command("upgrade")


### PR DESCRIPTION
If you run `vms database drop` when the database is not existing, it results in `sqlalchemy.exc.ProgrammingError`. This is just a minor fix to give a better CLI experience.