### PR TITLE
wait for selected signal data for rendering signal tab

### DIFF
--- a/src/dispatch/static/dispatch/src/case/EditSheet.vue
+++ b/src/dispatch/static/dispatch/src/case/EditSheet.vue
@@ -63,7 +63,7 @@
           <entities-tab :selected="selected" v-model="signal_instances" />
         </v-tab-item>
         <v-tab-item key="signal_instances">
-          <signal-instance-tab v-model="signal_instances" />
+          <signal-instance-tab v-model="signal_instances" v-if="selected.signal_instances" />
         </v-tab-item>
       </v-tabs-items>
     </v-navigation-drawer>


### PR DESCRIPTION
Same bug as https://github.com/Netflix/dispatch/pull/3068/files -- If you switch the `Signal` tab very quick after you open the `CaseEditSheet` (before `selected.signal_instances` has been fetched), the Signal data will say there's no data/signals but there is.