### PR TITLE
remove entities from signal instance table

### DIFF
--- a/src/dispatch/static/dispatch/src/signal/TableInstance.vue
+++ b/src/dispatch/static/dispatch/src/signal/TableInstance.vue
@@ -72,7 +72,6 @@ export default {
         { text: "Case", value: "case", sortable: false },
         { text: "Signal", value: "signal", sortable: false },
         { text: "Project", value: "project.name", sortable: true },
-        { text: "Entities", value: "entities", sortable: false },
         { text: "Created At", value: "created_at" },
         { text: "", value: "data-table-actions", sortable: false, align: "end" },
       ],


### PR DESCRIPTION
@kevgliss removing for now, will explore popover that we can reuse across the app, and here.