### PR TITLE
add support for errors in threads

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/bolt.py
+++ b/src/dispatch/plugins/dispatch_slack/bolt.py
@@ -79,11 +79,12 @@ def app_error_handler(
     # the user is in a message flow
     if body.get("response_url"):
         # the user is in a thread
-        if body.get("thread_ts"):
+        thread = body.get("container", {}).get("thread_ts")
+        if thread:
             client.chat_postEphemeral(
-                channel=body["channel_id"],
+                channel=context["channel_id"],
                 text=message,
-                thread_ts=body["thread_ts"],
+                thread_ts=thread,
                 user=context["user_id"],
             )
         else:

--- a/src/dispatch/plugins/dispatch_slack/bolt.py
+++ b/src/dispatch/plugins/dispatch_slack/bolt.py
@@ -78,7 +78,16 @@ def app_error_handler(
 
     # the user is in a message flow
     if body.get("response_url"):
-        respond(text=message, response_type="ephemeral", replace_original=False)
+        # the user is in a thread
+        if body.get("thread_ts"):
+            client.chat_postEphemeral(
+                channel=body["channel_id"],
+                text=message,
+                thread_ts=body["thread_ts"],
+                user=context["user_id"],
+            )
+        else:
+            respond(text=message, response_type="ephemeral", replace_original=False)
 
     if not isinstance(error, DispatchException):
         return BoltResponse(body=body, status=HTTPStatus.INTERNAL_SERVER_ERROR.value)

--- a/src/dispatch/plugins/dispatch_slack/bolt.py
+++ b/src/dispatch/plugins/dispatch_slack/bolt.py
@@ -79,8 +79,7 @@ def app_error_handler(
     # the user is in a message flow
     if body.get("response_url"):
         # the user is in a thread
-        thread = body.get("container", {}).get("thread_ts")
-        if thread:
+        if thread := body.get("container", {}).get("thread_ts"):
             client.chat_postEphemeral(
                 channel=context["channel_id"],
                 text=message,


### PR DESCRIPTION
Error messages that occurred in a thread context (for example, clicking the `Snooze` button) went to the main channel, which is a poor user experience. This PR sends the error message to the thread as an ephemeral message.

![Screenshot 2023-03-23 at 11 33 46 AM](https://user-images.githubusercontent.com/114631109/227314003-24086faf-3ec3-40da-9a98-c36d03d6881b.png)
