### PR TITLE
Optimize ORM usage, db_session instantiation, and tuning

### DIFF
--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -191,7 +191,6 @@ def update_conversation(case: Case, db_session: SessionLocal):
     )
 
 
-@background_task
 def case_new_create_flow(
     *,
     case_id: int,

--- a/src/dispatch/decorators.py
+++ b/src/dispatch/decorators.py
@@ -1,8 +1,12 @@
+from contextlib import _GeneratorContextManager, contextmanager
 from functools import wraps
-from typing import Any, List
+from typing import Any, Callable, List
 import inspect
 import logging
 import time
+
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import scoped_session, Session
 
 from dispatch.metrics import provider as metrics_provider
 from dispatch.organization import service as organization_service
@@ -19,7 +23,75 @@ def fullname(o):
     return f"{module.__name__}.{o.__qualname__}"
 
 
-def scheduled_project_task(func):
+@contextmanager
+def _session(
+    engine: Engine,
+    is_scoped: bool = False,
+) -> None:
+    """Provide a transactional scope around a series of operations."""
+    session = (
+        sessionmaker(bind=engine)()
+        if not is_scoped
+        else scoped_session(sessionmaker(bind=engine))()
+    )
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise Exception from None
+    finally:
+        session.close()
+
+
+def _execute_task_in_project_context(
+    func: Callable,
+    is_scoped: bool = False,
+    *args,
+    **kwargs,
+) -> None:
+    db_session = SessionLocal()
+    metrics_provider.counter("function.call.counter", tags={"function": fullname(func)})
+    start = time.perf_counter()
+
+    def __execute_task_within_session_context(
+        schema_session: _GeneratorContextManager[Session],
+    ) -> None:
+        kwargs["db_session"] = schema_session
+        for project in project_service.get_all(db_session=schema_session):
+            project = schema_session.merge(project)
+            kwargs["project"] = project
+            try:
+                func(*args, **kwargs)
+            except Exception as e:
+                log.exception(e)
+
+    # iterate for all schema
+    for organization in organization_service.get_all(db_session=db_session):
+        schema_engine = engine.execution_options(
+            schema_translate_map={None: f"dispatch_organization_{organization.slug}"}
+        )
+        if not is_scoped:
+            with _session(
+                engine=schema_engine,
+                is_scoped=False,
+            ) as __session:
+                __execute_task_within_session_context(__session)
+        else:
+            with _session(
+                engine=schema_engine,
+                is_scoped=True,
+            ) as __session:
+                __execute_task_within_session_context(__session)
+
+    elapsed_time = time.perf_counter() - start
+    metrics_provider.timer(
+        "function.elapsed.time", value=elapsed_time, tags={"function": fullname(func)}
+    )
+    db_session.close()
+
+
+def scheduled_project_task(func: Callable):
     """Decorator that sets up a background task function with
     a database session and exception tracking.
 
@@ -28,29 +100,31 @@ def scheduled_project_task(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        db_session = SessionLocal()
-        metrics_provider.counter("function.call.counter", tags={"function": fullname(func)})
-        start = time.perf_counter()
-
-        # iterate for all schema
-        for organization in organization_service.get_all(db_session=db_session):
-            schema_engine = engine.execution_options(
-                schema_translate_map={None: f"dispatch_organization_{organization.slug}"}
-            )
-            schema_session = sessionmaker(bind=schema_engine)()
-            kwargs["db_session"] = schema_session
-            for project in project_service.get_all(db_session=schema_session):
-                kwargs["project"] = project
-                try:
-                    func(*args, **kwargs)
-                except Exception as e:
-                    log.exception(e)
-            schema_session.close()
-        elapsed_time = time.perf_counter() - start
-        metrics_provider.timer(
-            "function.elapsed.time", value=elapsed_time, tags={"function": fullname(func)}
+        _execute_task_in_project_context(
+            func,
+            *args,
+            **kwargs,
+            is_scoped=False,
         )
-        db_session.close()
+
+    return wrapper
+
+
+def scoped_scheduled_project_task(func: Callable):
+    """Decorator that sets up a background task function with
+    a scoped database session and exception tracking.
+
+    Each task is executed in a specific project context.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        _execute_task_in_project_context(
+            func,
+            *args,
+            **kwargs,
+            is_scoped=True,
+        )
 
     return wrapper
 

--- a/src/dispatch/entity/service.py
+++ b/src/dispatch/entity/service.py
@@ -162,7 +162,6 @@ def get_cases_with_entity(db_session: Session, entity_id: int, days_back: int) -
     # Calculate the datetime for the start of the search window
     start_date = datetime.utcnow() - timedelta(days=days_back)
 
-    # Query for signal instances containing the entity within the search window
     cases = (
         db_session.query(Case)
         .join(Case.signal_instances)
@@ -171,6 +170,21 @@ def get_cases_with_entity(db_session: Session, entity_id: int, days_back: int) -
         .all()
     )
     return cases
+
+
+def get_case_count_with_entity(db_session: Session, entity_id: int, days_back: int) -> int:
+    """Calculate the count of cases with a given Entity by it's ID."""
+    # Calculate the datetime for the start of the search window
+    start_date = datetime.utcnow() - timedelta(days=days_back)
+
+    count = (
+        db_session.query(Case)
+        .join(Case.signal_instances)
+        .join(SignalInstance.entities)
+        .filter(Entity.id == entity_id, SignalInstance.created_at >= start_date)
+        .count()
+    )
+    return count
 
 
 def get_signal_instances_with_entity(

--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -85,7 +85,7 @@ class SlackConversationPlugin(ConversationPlugin):
         )
         if case.signal_instances:
             message = create_signal_messages(
-                case=case, channel_id=conversation_id, db_session=db_session
+                case_id=case.id, channel_id=conversation_id, db_session=db_session
             )
             signal_response = send_message(
                 client=client,
@@ -129,7 +129,7 @@ class SlackConversationPlugin(ConversationPlugin):
 
     def update_signal_message(
         self,
-        case: Case,
+        case_id: int,
         conversation_id: str,
         db_session: Session,
         thread_id: str,
@@ -137,7 +137,7 @@ class SlackConversationPlugin(ConversationPlugin):
         """Updates the signal message."""
         client = create_slack_client(self.configuration)
         blocks = create_signal_messages(
-            case=case, channel_id=conversation_id, db_session=db_session
+            case_id=case_id, channel_id=conversation_id, db_session=db_session
         )
         return update_message(
             client=client, conversation_id=conversation_id, blocks=blocks, ts=thread_id

--- a/src/dispatch/signal/flows.py
+++ b/src/dispatch/signal/flows.py
@@ -33,13 +33,14 @@ def signal_instance_create_flow(
         db_session=db_session, signal_instance_id=signal_instance_id
     )
 
-    entities = entity_service.find_entities(
-        db_session=db_session,
-        signal_instance=signal_instance,
-        entity_types=signal_instance.signal.entity_types,
-    )
-    signal_instance.entities = entities
-    db_session.commit()
+    if signal_instance.signal.entity_types:
+        entities = entity_service.find_entities(
+            db_session=db_session,
+            signal_instance=signal_instance,
+            entity_types=signal_instance.signal.entity_types,
+        )
+        signal_instance.entities = entities
+        db_session.commit()
 
     # we don't need to continue if a filter action took place
     if signal_service.filter_signal(
@@ -223,7 +224,7 @@ def update_signal_message(db_session: Session, signal_instance: SignalInstance) 
         return
 
     plugin.instance.update_signal_message(
-        case=signal_instance.case,
+        case_id=signal_instance.case_id,
         conversation_id=signal_instance.case.conversation.channel_id,
         db_session=db_session,
         thread_id=signal_instance.case.signal_thread_ts,


### PR DESCRIPTION
This change introduces performance improvements for deduplicated Signal instances that are ingested. By optimizing the ORM usage across the flow (primarily by removing loads of unnecessary relationships, columns, and rows) this path is about 4x faster. To process 500 deduplicated instances, it takes roughly 10 seconds. 

The `create_signal_messages` had the most room for improvement, because it unnecessarily was loading all signal_instances and their associated raw data. It previously took about 3 seconds (and exponentially more as more and more signals are ingested). It is about 5-6x faster.

Before:
`DEBUG:function.elapsed.time.dispatch.plugins.dispatch_slack.case.messages.create_signal_messages: 3.1490371670006425`

After:
`DEBUG:function.elapsed.time.dispatch.plugins.dispatch_slack.case.messages.create_signal_messages: 0.056947083001432475:/Users/wshel/Projects/dispatch/src/dispatch/decorators.py:wrapper:185`

This implementation takes 10-15 seconds to process (deduplicated) 500 instances. Creating a new case from scratch (non-deduped) now takes about 6 seconds. It previously took roughly 30 seconds. 

`DEBUG:function.elapsed.time.dispatch.signal.scheduled.process_signal_instance: 29.435003541992046`

This is primarily due to the [removal of external resources](https://github.com/Netflix/dispatch/pull/3331) such as Google docs, drive, etc. 

The default dedupe filter is also first by fetching one row to determine if we dedupe instead of all of them in the time frame and only fetching the necessary column (case_id).

Based on these stats I think it makes sense to increase the duration the scheduler runs to every 20 seconds. This gives some buffer for net new case creation and makes the most efficient use of each run instead of waiting when it could be processing new signals. 

I also moved scoped database connection instantiation outside of the process signal function and into its own decorator, so that it's scoped on each scheduled task run, which saves us database connections.

On my M1 MBP I was able to send 25k signal instances across 10 threads and keep up with 25 max db connections.

![Screenshot 2023-05-05 at 10 04 21 AM](https://user-images.githubusercontent.com/114631109/236521724-b941bcf2-e4ee-40f8-871a-1d33ec9329cc.png)

**Testing**
`pytest -v`
```
174 passed, 3 skipped in 7.85s
```
