### PR TITLE
set explicit build dir in Vite to resolve `Expected a JavaScript module on rebuild` error

### DIFF
--- a/src/dispatch/static/dispatch/package.json
+++ b/src/dispatch/static/dispatch/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "cross-env NODE_ENV=dev NODE_OPTIONS='--max-http-header-size=100000' vite",
-    "build": "vite build --out-dir dist",
+    "build": "vite build --base=./ --out-dir dist",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "preview": "vite preview --open --port 8080"

--- a/src/dispatch/static/dispatch/vite.config.js
+++ b/src/dispatch/static/dispatch/vite.config.js
@@ -8,6 +8,7 @@ import Components from "unplugin-vue-components/vite"
 import path from "path"
 
 export default defineConfig({
+  base: "./",
   plugins: [
     vue2(),
     monacoEditorPlugin({ languageWorkers: ["json"] }),


### PR DESCRIPTION
Resolves:

```
Expected a JavaScript module script but the server responded with a MIME type of "text/html" in Vue with Vite
```

https://vitejs.dev/guide/build.html#public-base-path
https://axellarsson.com/blog/expected-javascript-module-script-server-response-mimetype-text-html/