### PR TITLE
Allow customizing notification templates per project

### DIFF
--- a/docs/docs/administration/settings/messaging.mdx
+++ b/docs/docs/administration/settings/messaging.mdx
@@ -1,0 +1,50 @@
+# Messaging
+
+Dispatch supports sending email notifications to participants of, for example, an incident.
+
+## Notification templates
+
+Templates for emails are [part](https://github.com/Netflix/dispatch/tree/master/src/dispatch/messaging/email/templates) of Dispatch
+and are [Jinja](https://jinja.palletsprojects.com/) templates that during runtime are compiled into [MJML](https://mjml.io/) format.
+
+There is a way to customize these templates. To do this, if you run Dispatch with [Docker Compose](https://github.com/Netflix/dispatch-docker/),
+mount a volume with a customized templates dir as part of the docker compose:
+
+```
+  web:
+    image: dispatch-local
+    ...
+    volumes:
+      - "../dispatch-templates/messaging-email-templates:/usr/local/lib/python3.11/site-packages/dispatch/messaging/email/templates"
+```
+
+Such approach allows you to customize the common template for *all projects*.
+
+You can also "patch" the templates *per project*. Create a folder per project (identified by project id):
+
+```
+dispatch/messaging/email/templates/project_id/<project_id>/base.mjml
+```
+
+This will be used at the first place if exists,
+otherwise the resolution process will gracefully fall back to the default template:
+
+```
+dispatch/messaging/email/templates/base.mjml
+```
+
+
+## Markdown in the notifications
+
+:::warning
+Watch out for security implications related to unescaped HTML that may propagate through the system.
+:::
+
+By default, notification text is just a plain text with special characters and HTML escaped.
+
+It is possible, however, to enable Markdown syntax with a server setting:
+
+```
+DISPATCH_MARKDOWN_IN_INCIDENT_DESC=True
+DISPATCH_ESCAPE_HTML=False
+```

--- a/src/dispatch/messaging/email/utils.py
+++ b/src/dispatch/messaging/email/utils.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import tempfile
 
+import jinja2.exceptions
 from dispatch.config import MJML_PATH
 
 
@@ -53,7 +54,7 @@ def get_template(message_type: MessageType, project_id: int):
     template_path = os.path.join("templates", "project_id", f"{project_id}", template_key)
     try:
         template = env.get_template(template_path)
-    except FileNotFoundError:
+    except jinja2.exceptions.TemplateNotFound:
         template_path = os.path.join("templates", template_key)
         template = env.get_template(template_path)
 

--- a/src/dispatch/messaging/email/utils.py
+++ b/src/dispatch/messaging/email/utils.py
@@ -54,7 +54,7 @@ def get_template(message_type: MessageType, project_id: int):
     template_path = os.path.join("templates", "project_id", f"{project_id}", template_key)
     try:
         template = env.get_template(template_path)
-    except jinja2.exceptions.TemplateNotFound:
+    except Exception:
         template_path = os.path.join("templates", template_key)
         template = env.get_template(template_path)
 

--- a/src/dispatch/messaging/email/utils.py
+++ b/src/dispatch/messaging/email/utils.py
@@ -4,7 +4,6 @@ import subprocess
 import tempfile
 
 from dispatch.config import MJML_PATH
-from dispatch.project.models import Project
 
 
 from dispatch.messaging.strings import (
@@ -21,7 +20,7 @@ from .filters import env
 log = logging.getLogger(__name__)
 
 
-def get_template(message_type: MessageType, project: Project):
+def get_template(message_type: MessageType, project_id: int):
     """Fetches the correct template based on the message type."""
     template_map = {
         MessageType.incident_executive_report: ("executive_report.mjml", None),
@@ -51,7 +50,7 @@ def get_template(message_type: MessageType, project: Project):
     if not template_key:
         raise Exception(f"Unable to determine template. MessageType: {message_type}")
 
-    template_path = os.path.join("templates", "project_id", f"{project.id}", template_key)
+    template_path = os.path.join("templates", "project_id", f"{project_id}", template_key)
     try:
         template = env.get_template(template_path)
     except FileNotFoundError:
@@ -62,10 +61,10 @@ def get_template(message_type: MessageType, project: Project):
 
 
 def create_multi_message_body(
-        message_template: dict, message_type: MessageType, items: list, project: Project, **kwargs
+        message_template: dict, message_type: MessageType, items: list, project_id: int, **kwargs
 ):
     """Creates a multi message message body based on message type."""
-    template, description = get_template(message_type, project)
+    template, description = get_template(message_type, project_id)
 
     master_map = []
     for item in items:
@@ -75,9 +74,9 @@ def create_multi_message_body(
     return render_html(template.render(**kwargs))
 
 
-def create_message_body(message_template: dict, message_type: MessageType, project: Project, **kwargs):
+def create_message_body(message_template: dict, message_type: MessageType, project_id: int, **kwargs):
     """Creates the correct message body based on message type."""
-    template, description = get_template(message_type, project)
+    template, description = get_template(message_type, project_id)
 
     items_grouped_rendered = []
     if kwargs.get("items_grouped"):

--- a/src/dispatch/messaging/email/utils.py
+++ b/src/dispatch/messaging/email/utils.py
@@ -51,10 +51,10 @@ def get_template(message_type: MessageType, project_id: int):
     if not template_key:
         raise Exception(f"Unable to determine template. MessageType: {message_type}")
 
-    template_path = os.path.join("templates", "project_id", f"{project_id}", template_key)
     try:
+        template_path = os.path.join("templates", "project_id", f"{project_id}", template_key)
         template = env.get_template(template_path)
-    except Exception:
+    except jinja2.exceptions.TemplateNotFound:
         template_path = os.path.join("templates", template_key)
         template = env.get_template(template_path)
 

--- a/src/dispatch/messaging/email/utils.py
+++ b/src/dispatch/messaging/email/utils.py
@@ -62,7 +62,7 @@ def get_template(message_type: MessageType, project_id: int):
 
 
 def create_multi_message_body(
-        message_template: dict, message_type: MessageType, items: list, project_id: int, **kwargs
+    message_template: dict, message_type: MessageType, items: list, project_id: int, **kwargs
 ):
     """Creates a multi message message body based on message type."""
     template, description = get_template(message_type, project_id)
@@ -75,7 +75,9 @@ def create_multi_message_body(
     return render_html(template.render(**kwargs))
 
 
-def create_message_body(message_template: dict, message_type: MessageType, project_id: int, **kwargs):
+def create_message_body(
+    message_template: dict, message_type: MessageType, project_id: int, **kwargs
+):
     """Creates the correct message body based on message type."""
     template, description = get_template(message_type, project_id)
 

--- a/src/dispatch/messaging/email/utils.py
+++ b/src/dispatch/messaging/email/utils.py
@@ -57,6 +57,7 @@ def get_template(message_type: MessageType, project_id: int):
     except jinja2.exceptions.TemplateNotFound:
         template_path = os.path.join("templates", template_key)
         template = env.get_template(template_path)
+    log.debug("Resolved template path: %s", template_path)
 
     return template, description
 

--- a/src/dispatch/plugins/dispatch_google/gmail/plugin.py
+++ b/src/dispatch/plugins/dispatch_google/gmail/plugin.py
@@ -103,10 +103,10 @@ class GoogleGmailEmailPlugin(EmailPlugin):
             cc = kwargs["cc"]
 
         if not items:
-            message_body = create_message_body(notification_template, notification_type, **kwargs)
+            message_body = create_message_body(notification_template, notification_type, self.project, **kwargs)
         else:
             message_body = create_multi_message_body(
-                notification_template, notification_type, items, **kwargs
+                notification_template, notification_type, items, self.project, **kwargs
             )
 
         html_message = create_html_message(

--- a/src/dispatch/plugins/dispatch_google/gmail/plugin.py
+++ b/src/dispatch/plugins/dispatch_google/gmail/plugin.py
@@ -103,7 +103,9 @@ class GoogleGmailEmailPlugin(EmailPlugin):
             cc = kwargs["cc"]
 
         if not items:
-            message_body = create_message_body(notification_template, notification_type, self.project_id, **kwargs)
+            message_body = create_message_body(
+                notification_template, notification_type, self.project_id, **kwargs
+            )
         else:
             message_body = create_multi_message_body(
                 notification_template, notification_type, items, self.project_id, **kwargs

--- a/src/dispatch/plugins/dispatch_google/gmail/plugin.py
+++ b/src/dispatch/plugins/dispatch_google/gmail/plugin.py
@@ -103,10 +103,10 @@ class GoogleGmailEmailPlugin(EmailPlugin):
             cc = kwargs["cc"]
 
         if not items:
-            message_body = create_message_body(notification_template, notification_type, self.project, **kwargs)
+            message_body = create_message_body(notification_template, notification_type, self.project_id, **kwargs)
         else:
             message_body = create_multi_message_body(
-                notification_template, notification_type, items, self.project, **kwargs
+                notification_template, notification_type, items, self.project_id, **kwargs
             )
 
         html_message = create_html_message(


### PR DESCRIPTION
There is a way to have customizable templates for dispatch today, by mounting a volume with a customized templates dir as part of the docker compose:

```
  web:
    image: dispatch-local
    ...
    volumes:
      - "../dispatch-templates/messaging-email-templates:/usr/local/lib/python3.11/site-packages/dispatch/messaging/email/templates"
```

This approach does allow to customize the templates "deployment"-wide.

In this PR I suggest a small extension of this functionality. You can create a folder per project (identified by project id):

```
dispatch/messaging/email/templates/project_id/<project_id>/base.mjml
```

This will be used at the first place if exists, otherwise will gracefully fall back to the default template like "/templates/base.mjml".

I was a bit afraid to use "slug" of the project name, because this requires more careful work on escaping system paths and making sure we don't expose something by engineering a weird project name. This can be expanded  in future though, by introducing another subdir "templates/project_slug/<project_slug>".