### PR TITLE
Updates documentation about prerequisites

### DIFF
--- a/docs/docs/administration/contributing/environment.mdx
+++ b/docs/docs/administration/contributing/environment.mdx
@@ -40,11 +40,11 @@ Once we have python installed, let's ensure it's a new enough version:
 
 ```bash
 > python --version
-Python 3.7.3
+Python 3.10.11
 ```
 
 :::info
-Dispatch uses async functionality and requires `python 3.7.3+`.
+Dispatch requires `python 3.10+`.
 
 Create a new virtualenv just for Dispatch:
 


### PR DESCRIPTION
Dispatch uses the `|` operator and requires python 3.10+.