### PR TITLE
Allows pre-population of the incident title, description, and tags in the incident intake form by including them in the URL path.

### DIFF
--- a/tests/static/e2e/pages/report-incident-page.ts
+++ b/tests/static/e2e/pages/report-incident-page.ts
@@ -91,7 +91,7 @@ export class ReportIncidentPage {
     await this.tagsDropdown.click()
     for (const tag of tags) {
       if (!(await this.page.getByText("No tags matching").isVisible())) {
-        await this.page.getByText(tag, { exact: true }).click()
+        await this.page.getByText(tag).first().click()
       }
     }
   }

--- a/tests/static/e2e/report-submission.spec.ts
+++ b/tests/static/e2e/report-submission.spec.ts
@@ -14,7 +14,7 @@ test.describe("Authenticated Dispatch App", () => {
       const project = "default"
       const type = "Denial of Service"
       const priority = "Low"
-      const tags = ["default/ExampleTag"]
+      const tags = ["ExampleTag"]
 
       await reportIncidentPage.reportIncident(title, description, project, type, priority, tags)
       // Soft validate that we get redirected to the incident submission form
@@ -22,7 +22,7 @@ test.describe("Authenticated Dispatch App", () => {
         .soft(page)
         .toHaveURL(
           encodeURI(
-            `./default/incidents/report?project=${project}&incident_priority=${priority}&incident_type=${type}`
+            `./default/incidents/report?project=${project}&incident_priority=${priority}&incident_type=${type}&title=${title}&description=${description}` + tags.map((tag) => "&tag=" + tag).join("")
           )
         )
 


### PR DESCRIPTION
Adds the following query params for the incident intake form:
- title
- description
- tag (tag name)

Example: <hostname>:<port>/default/incidents/report?project=default&title=ExampleTitle&description=ExampleDescription&tag=ExampleTag