### PR TITLE
Adds validation to permission dependencies

### DIFF
--- a/src/dispatch/auth/permissions.py
+++ b/src/dispatch/auth/permissions.py
@@ -6,13 +6,13 @@ from starlette.requests import Request
 from starlette.status import HTTP_403_FORBIDDEN, HTTP_404_NOT_FOUND
 
 from dispatch.auth.service import get_current_user
-from dispatch.enums import UserRoles, Visibility
 from dispatch.case import service as case_service
 from dispatch.case.models import Case
+from dispatch.enums import UserRoles, Visibility
 from dispatch.incident import service as incident_service
+from dispatch.models import PrimaryKeyModel
 from dispatch.organization import service as organization_service
 from dispatch.organization.models import OrganizationRead
-
 
 log = logging.getLogger(__name__)
 
@@ -222,9 +222,8 @@ class IncidentJoinOrSubscribePermission(BasePermission):
         self,
         request: Request,
     ) -> bool:
-        current_incident = incident_service.get(
-            db_session=request.state.db, incident_id=request.path_params["incident_id"]
-        )
+        pk = PrimaryKeyModel(id=request.path_params["incident_id"])
+        current_incident = incident_service.get(db_session=request.state.db, incident_id=pk.id)
 
         if current_incident.visibility == Visibility.restricted:
             return OrganizationAdminPermission(request=request)
@@ -237,9 +236,8 @@ class IncidentViewPermission(BasePermission):
         self,
         request: Request,
     ) -> bool:
-        current_incident = incident_service.get(
-            db_session=request.state.db, incident_id=request.path_params["incident_id"]
-        )
+        pk = PrimaryKeyModel(id=request.path_params["incident_id"])
+        current_incident = incident_service.get(db_session=request.state.db, incident_id=pk.id)
 
         if not current_incident:
             return False
@@ -277,9 +275,8 @@ class IncidentReporterPermission(BasePermission):
         request: Request,
     ) -> bool:
         current_user = get_current_user(request=request)
-        current_incident = incident_service.get(
-            db_session=request.state.db, incident_id=request.path_params["incident_id"]
-        )
+        pk = PrimaryKeyModel(id=request.path_params["incident_id"])
+        current_incident = incident_service.get(db_session=request.state.db, incident_id=pk.id)
 
         if not current_incident:
             return False
@@ -295,9 +292,8 @@ class IncidentCommanderPermission(BasePermission):
         request: Request,
     ) -> bool:
         current_user = get_current_user(request=request)
-        current_incident = incident_service.get(
-            db_session=request.state.db, incident_id=request.path_params["incident_id"]
-        )
+        pk = PrimaryKeyModel(id=request.path_params["incident_id"])
+        current_incident = incident_service.get(db_session=request.state.db, incident_id=pk.id)
         if not current_incident:
             return False
 
@@ -314,9 +310,9 @@ class CaseViewPermission(BasePermission):
         self,
         request: Request,
     ) -> bool:
-        current_case = case_service.get(
-            db_session=request.state.db, case_id=request.path_params["case_id"]
-        )
+        pk = PrimaryKeyModel(id=request.path_params["case_id"])
+
+        current_case = case_service.get(db_session=request.state.db, case_id=pk.id)
 
         if not current_case:
             return False
@@ -352,9 +348,8 @@ class CaseParticipantPermission(BasePermission):
         request: Request,
     ) -> bool:
         current_user = get_current_user(request=request)
-        current_case: Case = case_service.get(
-            db_session=request.state.db, case_id=request.path_params["case_id"]
-        )
+        pk = PrimaryKeyModel(id=request.path_params["incident_id"])
+        current_case: Case = case_service.get(db_session=request.state.db, case_id=pk.id)
         participant_emails: list[str] = [
             participant.individual.email for participant in current_case.participants
         ]

--- a/src/dispatch/models.py
+++ b/src/dispatch/models.py
@@ -109,6 +109,10 @@ class DispatchBase(BaseModel):
         }
 
 
+class PrimaryKeyModel(BaseModel):
+    id: PrimaryKey
+
+
 class EvergreenBase(DispatchBase):
     evergreen: Optional[bool] = False
     evergreen_owner: Optional[EmailStr]


### PR DESCRIPTION
This addresses an issue where path parameters are not validated directly in their dependencies because of the way we use the request object. This adds that validate such that `/incident/foo` no longer throws a `500` but a `422` informing the user that the path parameters should be an conint.