### PR TITLE
Updates dashboard filters

### DIFF
--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
@@ -130,7 +130,7 @@ export default {
     update(data) {
       this.items = data.filter(function (item) {
         return (
-          !item.incident_type.exclude_from_metrics &&
+          !item.case_type.exclude_from_metrics &&
           !item.duplicates.filter((d) => data.includes(d)).length
         )
       })

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
@@ -128,8 +128,11 @@ export default {
 
   methods: {
     update(data) {
-      this.items = filter(data, function (item) {
-        return !item.case_type.exclude_from_metrics && !item.duplicates.length
+      this.items = data.filter(function (item) {
+        return (
+          !item.incident_type.exclude_from_metrics &&
+          !item.duplicates.filter((d) => data.includes(d)).length
+        )
       })
     },
     detailsSelected(event) {

--- a/src/dispatch/static/dispatch/src/dashboard/incident/IncidentOverview.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/incident/IncidentOverview.vue
@@ -177,8 +177,11 @@ export default {
 
   methods: {
     update(data) {
-      this.items = filter(data, function (item) {
-        return !item.incident_type.exclude_from_metrics && !item.duplicates.length
+      this.items = data.filter(function (item) {
+        return (
+          !item.incident_type.exclude_from_metrics &&
+          !item.duplicates.filter((d) => data.includes(d)).length
+        )
       })
     },
     detailsSelected(event) {


### PR DESCRIPTION
Previously, the dashboard filtered out all duplicate incidents and cases.

This change updates the dashboard filters to include items marked as duplicates as long as the originals are not part of the same returned data set. This allows new/reopened issues to be reflected on the dashboard metrics but still prevents double counting.