### PR TITLE
Revert "Adds the Slack domain to the conversation weblink URL."

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/enums.py
+++ b/src/dispatch/plugins/dispatch_slack/enums.py
@@ -2,10 +2,8 @@ from dispatch.enums import DispatchEnum
 
 
 class SlackAPIGetEndpoints(DispatchEnum):
-    chat_permalink = "chat.getPermalink"
     conversations_history = "conversations.history"
     conversations_info = "conversations.info"
-    team_info = "team.info"
     users_conversations = "users.conversations"
     users_info = "users.info"
     users_lookup_by_email = "users.lookupByEmail"

--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -931,11 +931,6 @@ def handle_member_joined_channel(
     participant = incident_flows.incident_add_or_reactivate_participant_flow(
         user_email=user.email, incident_id=context["subject"].id, db_session=db_session
     )
-
-    if not participant:
-        # Participant is already in the incident channel.
-        return
-
     participant.user_conversation_id = context["user_id"]
 
     incident = incident_service.get(db_session=db_session, incident_id=context["subject"].id)

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -87,12 +87,6 @@ def list_conversation_messages(client: WebClient, conversation_id: str, **kwargs
 
 
 @functools.lru_cache()
-def get_domain(client: WebClient) -> str:
-    """Gets the team's Slack domain."""
-    return make_call(client, SlackAPIGetEndpoints.team_info)["team"]["domain"]
-
-
-@functools.lru_cache()
 def get_user_info_by_id(client: WebClient, user_id: str) -> dict:
     """Gets profile information about a user by id."""
     return make_call(client, SlackAPIGetEndpoints.users_info, user=user_id)["user"]
@@ -201,7 +195,7 @@ def create_conversation(client: WebClient, name: str, is_private: bool = False) 
     return {
         "id": response["id"],
         "name": response["name"],
-        "weblink": f"https://{get_domain(client)}.slack.com/app_redirect?channel={response['id']}",
+        "weblink": f"https://slack.com/app_redirect?channel={response['id']}",
     }
 
 
@@ -276,15 +270,6 @@ def add_users_to_conversation(
                 pass
 
 
-def get_message_permalink(client: WebClient, conversation_id: str, ts: str) -> str:
-    return make_call(
-        client,
-        SlackAPIGetEndpoints.chat_permalink,
-        channel=conversation_id,
-        message_ts=ts,
-    )
-
-
 def send_message(
     client: WebClient,
     conversation_id: str,
@@ -309,7 +294,7 @@ def send_message(
     return {
         "id": response["channel"],
         "timestamp": response["ts"],
-        "weblink": get_message_permalink(client, response["channel"], response["ts"]),
+        "weblink": f"https://slack.com/app_redirect?channel={response['id']}",  # TODO should we fetch the permalink?
     }
 
 
@@ -333,7 +318,7 @@ def update_message(
     return {
         "id": response["channel"],
         "timestamp": response["ts"],
-        "weblink": get_message_permalink(client, response["channel"], response["ts"]),
+        "weblink": f"https://slack.com/app_redirect?channel={response['id']}",  # TODO should we fetch the permalink?
     }
 
 


### PR DESCRIPTION
`send_message` returns a `SlackResponse` object instead of the weblink `str` that's expected.

This causes downstream issues when the weblink is used in Slack Blockkit.