### PR TITLE
the engaged_user should be used in the updated message

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -1568,7 +1568,7 @@ def handle_engagement_submission_event(
                 channel_id=case.conversation.channel_id,
                 engagement=engagement,
                 signal_instance=signal_instance,
-                user=user,
+                user=engaged_user,
                 engagement_status=engagement_status,
             )
             client.chat_update(


### PR DESCRIPTION
In the event a Dispatch admin approves an engagement we should not update the initial message with the user who clicked the button, but rather the original engaged user. 