### PR TITLE
lower all case priorities to standardize

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -43,7 +43,7 @@ from dispatch.signal.enums import SignalEngagementStatus
 def create_case_message(case: Case, channel_id: str) -> list[Block]:
     # TODO we should probably restrict the possible colors to make this work
     priority_color_mapping = {
-        "9e9e9e": "⚪",
+        "#9e9e9e": "⚪",
         "#8bc34a": "🟢",
         "#ffeb3b": "🟡",
         "#ff9800": "🟠",

--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -43,14 +43,14 @@ from dispatch.signal.enums import SignalEngagementStatus
 def create_case_message(case: Case, channel_id: str) -> list[Block]:
     # TODO we should probably restrict the possible colors to make this work
     priority_color_mapping = {
-        "9E9E9E": "⚪",
-        "#8BC34A": "🟢",
-        "#FFEB3B": "🟡",
-        "#FF9800": "🟠",
-        "#F44336": "🔴",
-        "#9C27B0": "🟣",
+        "9e9e9e": "⚪",
+        "#8bc34a": "🟢",
+        "#ffeb3b": "🟡",
+        "#ff9800": "🟠",
+        "#f44336": "🔴",
+        "#9c27b0": "🟣",
     }
-    priority_field = f"*Priority* \n {case.case_priority.name} {priority_color_mapping.get(case.case_priority.color,'')}"
+    priority_field = f"*Priority* \n {priority_color_mapping.get(case.case_priority.color.lower(),'')} {case.case_priority.name}"
 
     fields = [
         f"*Assignee* \n {case.assignee.individual.email}",


### PR DESCRIPTION
![Screenshot 2023-07-14 at 10 18 35 AM](https://github.com/Netflix/dispatch/assets/114631109/81a8cf8b-cd34-482a-a793-4a07d9418d04)

Case pri color appears to default to caps when setting in UI, somehow mine was lowered, and it appears to be the same in production. Standardizing to lower in the `create_case_message`.