### PR TITLE
Shows version in help dialog and toast for full version info

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,13 @@ ARG VITE_SENTRY_DSN
 ARG VITE_SENTRY_APP_KEY
 ARG VITE_SENTRY_ENABLED
 
+# Should be replaced in your build process script
+ARG VITE_DISPATCH_COMMIT_HASH
+ENV VITE_DISPATCH_COMMIT_HASH="Unknown"
+
+ARG VITE_DISPATCH_COMMIT_MESSAGE
+ENV VITE_DISPATCH_COMMIT_MESSAGE="Unknown"
+
 COPY . /usr/src/dispatch/
 RUN export YARN_CACHE_FOLDER="$(mktemp -d)" \
     && cd /usr/src/dispatch \

--- a/src/dispatch/static/dispatch/src/app/store.js
+++ b/src/dispatch/static/dispatch/src/app/store.js
@@ -39,7 +39,7 @@ const actions = {
     commit(
       "notification_backend/addBeNotification",
       {
-        text: `Hash: ${latest_commit_hash} | Message: ${latest_commit_message}`,
+        text: `Hash: ${latestCommitHash} | Message: ${latestCommitMessage}`,
         type: "success",
       },
       { root: true }

--- a/src/dispatch/static/dispatch/src/app/store.js
+++ b/src/dispatch/static/dispatch/src/app/store.js
@@ -17,7 +17,7 @@ const state = {
     ...getDefaultRefreshState(),
   },
   loading: false,
-  current_version: latest_commit_hash,
+  currentVersion: latestCommitHash,
 }
 
 const getters = {

--- a/src/dispatch/static/dispatch/src/app/store.js
+++ b/src/dispatch/static/dispatch/src/app/store.js
@@ -8,12 +8,16 @@ const getDefaultRefreshState = () => {
   }
 }
 
+const latest_commit_hash = import.meta.env.VITE_DISPATCH_COMMIT_MESSAGE
+const latest_commit_message = import.meta.env.VITE_DISPATCH_COMMIT_MESSAGE
+
 const state = {
   toggleDrawer: true,
   refresh: {
     ...getDefaultRefreshState(),
   },
   loading: false,
+  current_version: latest_commit_hash,
 }
 
 const getters = {
@@ -30,6 +34,16 @@ const actions = {
   },
   setLoading({ commit }, value) {
     commit("SET_LOADING", value)
+  },
+  showCommitMessage({ commit }) {
+    commit(
+      "notification_backend/addBeNotification",
+      {
+        text: `Hash: ${latest_commit_hash} | Message: ${latest_commit_message}`,
+        type: "success",
+      },
+      { root: true }
+    )
   },
 }
 

--- a/src/dispatch/static/dispatch/src/app/store.js
+++ b/src/dispatch/static/dispatch/src/app/store.js
@@ -8,8 +8,8 @@ const getDefaultRefreshState = () => {
   }
 }
 
-const latest_commit_hash = import.meta.env.VITE_DISPATCH_COMMIT_MESSAGE
-const latest_commit_message = import.meta.env.VITE_DISPATCH_COMMIT_MESSAGE
+const latestCommitHash = import.meta.env.VITE_DISPATCH_COMMIT_MESSAGE
+const latestCommitMessage = import.meta.env.VITE_DISPATCH_COMMIT_MESSAGE
 
 const state = {
   toggleDrawer: true,

--- a/src/dispatch/static/dispatch/src/auth/store.js
+++ b/src/dispatch/static/dispatch/src/auth/store.js
@@ -203,7 +203,7 @@ const mutations = {
 
 const getters = {
   getField,
-  userAvatarURL: (state) => {
+  userAvatarUrl: (state) => {
     if (state.currentUser.userId) {
       return `${window.location.protocol}//${window.location.host}/avatar/${state.currentUser.userId}/${state.currentUser.userId}.json`
     }

--- a/src/dispatch/static/dispatch/src/components/AppToolbar.vue
+++ b/src/dispatch/static/dispatch/src/components/AppToolbar.vue
@@ -192,7 +192,7 @@ export default {
       })
     },
     ...mapState("auth", ["currentUser", "userAvatarUrl"]),
-    ...mapState("app", ["current_version"]),
+    ...mapState("app", ["currentVersion"]),
     ...mapActions("auth", ["logout"]),
     ...mapActions("search", ["setQuery"]),
     ...mapActions("organization", ["showCreateEditDialog"]),

--- a/src/dispatch/static/dispatch/src/components/AppToolbar.vue
+++ b/src/dispatch/static/dispatch/src/components/AppToolbar.vue
@@ -64,7 +64,7 @@
               </v-list-item-icon>
             </v-list-item-action>
           </v-list-item>
-          <v-list-item v-if="current_version()" @click="showCommitMessage">
+          <v-list-item v-if="currentVersion()" @click="showCommitMessage">
             <v-list-item-title>
               Current version: {{ current_version() | formatHash }}
             </v-list-item-title>

--- a/src/dispatch/static/dispatch/src/components/AppToolbar.vue
+++ b/src/dispatch/static/dispatch/src/components/AppToolbar.vue
@@ -64,6 +64,16 @@
               </v-list-item-icon>
             </v-list-item-action>
           </v-list-item>
+          <v-list-item v-if="current_version()" @click="showCommitMessage">
+            <v-list-item-title>
+              Current version: {{ current_version() | formatHash }}
+            </v-list-item-title>
+            <v-list-item-action>
+              <v-list-item-icon>
+                <v-icon small>read_more</v-icon>
+              </v-list-item-icon>
+            </v-list-item-action>
+          </v-list-item>
         </v-list>
       </v-menu>
       <v-menu offset-y>
@@ -182,9 +192,11 @@ export default {
       })
     },
     ...mapState("auth", ["currentUser", "userAvatarUrl"]),
+    ...mapState("app", ["current_version"]),
     ...mapActions("auth", ["logout"]),
     ...mapActions("search", ["setQuery"]),
     ...mapActions("organization", ["showCreateEditDialog"]),
+    ...mapActions("app", ["showCommitMessage"]),
     ...mapMutations("search", ["SET_QUERY"]),
   },
 

--- a/src/dispatch/static/dispatch/src/components/AppToolbar.vue
+++ b/src/dispatch/static/dispatch/src/components/AppToolbar.vue
@@ -66,7 +66,7 @@
           </v-list-item>
           <v-list-item v-if="currentVersion()" @click="showCommitMessage">
             <v-list-item-title>
-              Current version: {{ current_version() | formatHash }}
+              Current version: {{ currentVersion() | formatHash }}
             </v-list-item-title>
             <v-list-item-action>
               <v-list-item-icon>

--- a/src/dispatch/static/dispatch/src/filters.js
+++ b/src/dispatch/static/dispatch/src/filters.js
@@ -5,6 +5,12 @@ import moment from "moment-timezone"
 const time_format = "YYYY-MM-DD HH:mm:ss"
 const zones_to_show = ["America/Los_Angeles", "America/New_York"]
 
+Vue.filter("formatHash", function (value) {
+  if (value) {
+    return value.slice(0, 7)
+  }
+})
+
 Vue.filter("formatDate", function (value) {
   if (value) {
     return formatISO(parseISO(value))


### PR DESCRIPTION
This shows the version information (i.e., the latest commit hash) in the help dialog. If none is available, the row is skipped. Clicking on the hash shows a snackbar with the full hash and commit message. 

Note: requires pushing the commit hash and message to the environment during the build process. 