### PR TITLE
Allows searching by incident number for Jira-created incident names

### DIFF
--- a/src/dispatch/database/service.py
+++ b/src/dispatch/database/service.py
@@ -391,9 +391,14 @@ def search(*, query_str: str, query: Query, model: str, sort=False):
 
     # determine if we have a name and use it for exact matching
     # TODO we could make the exact match field configurable in the future
+    # Also include searches formatted as "-xxxx" for Jira-created ticket names
     if hasattr(search_model, "name"):
         query = query.filter(
-            or_(vector.op("@@")(func.tsq_parse(query_str)), search_model.name == query_str)
+            or_(
+                vector.op("@@")(func.tsq_parse(query_str)),
+                search_model.name == query_str,
+                vector.op("@@")(f"-{query_str}"),
+            )
         )
     else:
         query = query.filter(vector.op("@@")(func.tsq_parse(query_str)))


### PR DESCRIPTION
Determined that the Jira plug-in was adding the name in the search_vector as "-xxxx" instead of just "xxxx", causing the search to not find incidents when users search just for "xxxx"