### PR TITLE
Adds triage button

### DIFF
--- a/src/dispatch/conversation/service.py
+++ b/src/dispatch/conversation/service.py
@@ -8,17 +8,27 @@ def get(*, db_session, conversation_id: int) -> Optional[Conversation]:
     return db_session.query(Conversation).filter(Conversation.id == conversation_id).one_or_none()
 
 
-def get_by_channel_id_ignoring_channel_type(db_session, channel_id: str) -> Optional[Conversation]:
+def get_by_channel_id_ignoring_channel_type(
+    db_session, channel_id: str, thread_id: str = None
+) -> Optional[Conversation]:
     """
     Gets a conversation by its id ignoring the channel type, and updates the
     channel id in the database if the channel type has changed.
     """
     channel_id_without_type = channel_id[1:]
-    conversation = (
-        db_session.query(Conversation)
-        .filter(Conversation.channel_id.contains(channel_id_without_type))
-        .one_or_none()
-    )
+    if thread_id:
+        conversation = (
+            db_session.query(Conversation)
+            .filter(Conversation.channel_id.contains(channel_id_without_type))
+            .filter(Conversation.thread_id == thread_id)
+            .one_or_none()
+        )
+    else:
+        conversation = (
+            db_session.query(Conversation)
+            .filter(Conversation.channel_id.contains(channel_id_without_type))
+            .one_or_none()
+        )
 
     if conversation:
         if channel_id[0] != conversation.channel_id[0]:

--- a/src/dispatch/plugins/dispatch_slack/case/enums.py
+++ b/src/dispatch/plugins/dispatch_slack/case/enums.py
@@ -7,6 +7,7 @@ class CaseNotificationActions(DispatchEnum):
     join_incident = "case-notification-join-incident"
     reopen = "case-notification-reopen"
     resolve = "case-notification-resolve"
+    triage = "case-notification-triage"
 
 
 class CasePaginateActions(DispatchEnum):

--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -823,7 +823,12 @@ def handle_case_participant_role_activity(
             case_id=context["subject"].id, user_email=user.email, db_session=db_session
         )
         participant.user_conversation_id = context["user_id"]
+
+    # if a participant is active mark the case as being in the triaged state
+    case = case_service.get(db_session=db_session, case_id=context["subject"].id)
+    case.status = CaseStatus.triage
     db_session.commit()
+    case_flows.update_conversation(case, db_session)
 
 
 @message_dispatcher.add(
@@ -1205,6 +1210,17 @@ def resolve_button_click(
         private_metadata=context["subject"].json(),
     ).build()
     client.views_open(trigger_id=body["trigger_id"], view=modal)
+
+
+@app.action(CaseNotificationActions.triage, middleware=[button_context_middleware, db_middleware])
+def triage_button_click(
+    ack: Ack, body: dict, db_session: Session, context: BoltContext, client: WebClient
+):
+    ack()
+    case = case_service.get(db_session=db_session, case_id=context["subject"].id)
+    case.status = CaseStatus.triage
+    db_session.commit()
+    case_flows.update_conversation(case, db_session)
 
 
 @app.view(

--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -826,7 +826,8 @@ def handle_case_participant_role_activity(
 
     # if a participant is active mark the case as being in the triaged state
     case = case_service.get(db_session=db_session, case_id=context["subject"].id)
-    case.status = CaseStatus.triage
+    if case.status == CaseStatus.new:
+        case.status = CaseStatus.triage
     db_session.commit()
     case_flows.update_conversation(case, db_session)
 

--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -124,32 +124,37 @@ def create_case_message(case: Case, channel_id: str) -> list[Block]:
             ]
         )
     else:
-        blocks.extend(
-            [
-                Actions(
-                    elements=[
-                        Button(
-                            text="Edit",
-                            action_id=CaseNotificationActions.edit,
-                            style="primary",
-                            value=button_metadata,
-                        ),
-                        Button(
-                            text="Resolve",
-                            action_id=CaseNotificationActions.resolve,
-                            style="primary",
-                            value=button_metadata,
-                        ),
-                        Button(
-                            text="Escalate",
-                            action_id=CaseNotificationActions.escalate,
-                            style="danger",
-                            value=button_metadata,
-                        ),
-                    ]
-                )
-            ]
-        )
+        action_buttons = [
+            Button(
+                text="Resolve",
+                action_id=CaseNotificationActions.resolve,
+                style="primary",
+                value=button_metadata,
+            ),
+            Button(
+                text="Edit",
+                action_id=CaseNotificationActions.edit,
+                style="primary",
+                value=button_metadata,
+            ),
+            Button(
+                text="Escalate",
+                action_id=CaseNotificationActions.escalate,
+                style="danger",
+                value=button_metadata,
+            ),
+        ]
+        if case.status == CaseStatus.new:
+            action_buttons.insert(
+                0,
+                Button(
+                    text="Triage",
+                    action_id=CaseNotificationActions.triage,
+                    style="primary",
+                    value=button_metadata,
+                ),
+            )
+        blocks.extend([Actions(elements=action_buttons)])
 
     return Message(blocks=blocks).build()["blocks"]
 

--- a/src/dispatch/plugins/dispatch_slack/middleware.py
+++ b/src/dispatch/plugins/dispatch_slack/middleware.py
@@ -27,8 +27,8 @@ Subject = NamedTuple("Subject", subject=SubjectMetadata, db_session=Session)
 
 
 @timer
-def resolve_context_from_conversation(channel_id: str) -> Optional[Subject]:
-    """Attempts to resolve a conversation based on the channel id."""
+def resolve_context_from_conversation(channel_id: str, thread_id: str = None) -> Optional[Subject]:
+    """Attempts to resolve a conversation based on the channel id and thread_id."""
     db_session = SessionLocal()
     organization_slugs = [o.slug for o in organization_service.get_all(db_session=db_session)]
     db_session.close()
@@ -37,7 +37,7 @@ def resolve_context_from_conversation(channel_id: str) -> Optional[Subject]:
         scoped_db_session = refetch_db_session(slug)
 
         conversation = conversation_service.get_by_channel_id_ignoring_channel_type(
-            db_session=scoped_db_session, channel_id=channel_id
+            db_session=scoped_db_session, channel_id=channel_id, thread_id=thread_id
         )
 
         if conversation:
@@ -146,7 +146,9 @@ def message_context_middleware(
     if is_bot(request):
         return context.ack()
 
-    if subject := resolve_context_from_conversation(channel_id=context.channel_id):
+    if subject := resolve_context_from_conversation(
+        channel_id=context.channel_id, thread_id=payload.get("thread_ts")
+    ):
         context.update(subject._asdict())
     else:
         raise ContextError("Unable to determine context for message.")
@@ -154,6 +156,7 @@ def message_context_middleware(
     next()
 
 
+# TODO should we support reactions for cases?
 def reaction_context_middleware(context: BoltContext, next: Callable) -> None:
     """Attemps to determine the current context of a reaction event."""
     if subject := resolve_context_from_conversation(channel_id=context.channel_id):


### PR DESCRIPTION
This PR adds a triage button that is only shown then the case is in the "New" state. Click it simple moves the case to "triage" state. 

Additionally, this PR adds support for processing case messages (this wasn't working before apparently) by modifying the way we look up conversation context to allow for specifying thread_id together with conversation_id. 

With these case messages now being properly processed, a message listener moves the case to triage on the first non-bot message. 

Dispatch won't currently allow for participant conversation and the case to stay in the "New state". I'm not sure if there is a use case for such a scenario.

![Screenshot 2023-07-28 at 2 37 54 PM](https://github.com/Netflix/dispatch/assets/2262214/27737706-54bf-4616-9d47-a3ac4e74b77f)
![Screenshot 2023-07-28 at 2 54 54 PM](https://github.com/Netflix/dispatch/assets/2262214/878f2798-0a61-4bac-8b86-04021fae6b95)