### PR TITLE
Allows users to conduct global search via the URL

### DIFF
--- a/src/dispatch/static/dispatch/src/components/AppToolbar.vue
+++ b/src/dispatch/static/dispatch/src/components/AppToolbar.vue
@@ -182,9 +182,8 @@ export default {
     },
     performSearch() {
       let query = this.query
-      //alert("The query is" + JSON.stringify(query))
       this.$store.dispatch("search/getResults", this.$store.state.query)
-      this.$router.push({ name: "ResultListWithQuery", params: { name: query } })
+      this.$router.push({ name: "ResultList", query: { q: query } })
     },
     toggleDarkTheme() {
       this.$vuetify.theme.dark = !this.$vuetify.theme.dark

--- a/src/dispatch/static/dispatch/src/components/AppToolbar.vue
+++ b/src/dispatch/static/dispatch/src/components/AppToolbar.vue
@@ -157,6 +157,7 @@ export default {
   name: "AppToolbar",
   data: () => ({
     organizations: [],
+    query: "",
   }),
   components: {
     OrganizationCreateEditDialog,
@@ -165,6 +166,7 @@ export default {
     queryString: {
       set(query) {
         this.$store.dispatch("search/setQuery", query)
+        this.query = query
       },
       get() {
         return this.$store.state.query.q
@@ -179,8 +181,10 @@ export default {
       Util.toggleFullScreen()
     },
     performSearch() {
+      let query = this.query
+      //alert("The query is" + JSON.stringify(query))
       this.$store.dispatch("search/getResults", this.$store.state.query)
-      this.$router.push({ name: "GlobalSearch" })
+      this.$router.push({ name: "ResultListWithQuery", params: { name: query } })
     },
     toggleDarkTheme() {
       this.$vuetify.theme.dark = !this.$vuetify.theme.dark

--- a/src/dispatch/static/dispatch/src/router/config.js
+++ b/src/dispatch/static/dispatch/src/router/config.js
@@ -524,17 +524,10 @@ export const protectedRoute = [
       children: [
         {
           path: "results",
-          name: "ResultList",
           meta: { name: "Results" },
           component: () => import("@/search/ResultList.vue"),
-          children: [
-            {
-              path: "/:organization/search/results/:name",
-              name: "ResultListWithQuery",
-              component: () => import("@/search/ResultList.vue"),
-              props: true,
-            },
-          ],
+          name: "ResultList",
+          props: true,
         },
       ],
     },

--- a/src/dispatch/static/dispatch/src/router/config.js
+++ b/src/dispatch/static/dispatch/src/router/config.js
@@ -527,6 +527,14 @@ export const protectedRoute = [
           name: "ResultList",
           meta: { name: "Results" },
           component: () => import("@/search/ResultList.vue"),
+          children: [
+            {
+              path: "/:organization/search/results/:name",
+              name: "ResultListWithQuery",
+              component: () => import("@/search/ResultList.vue"),
+              props: true,
+            },
+          ],
         },
       ],
     },

--- a/src/dispatch/static/dispatch/src/search/ResultList.vue
+++ b/src/dispatch/static/dispatch/src/search/ResultList.vue
@@ -54,6 +54,7 @@
 
 <script>
 import { mapState } from "vuex"
+import { mapActions } from "vuex"
 import IncidentSummaryTable from "@/incident/IncidentSummaryTable.vue"
 import CaseSummaryTable from "@/case/CaseSummaryTable.vue"
 import TaskSummaryTable from "@/task/TaskSummaryTable.vue"
@@ -76,9 +77,25 @@ export default {
   data() {
     return {}
   },
+  created() {
+    console.log("Searching for " + this.$route.params.name)
+    this.fetchDetails()
+  },
+  watch: {
+    "$route.params.name": function () {
+      console.log("Searching for " + this.$route.params.name)
+    },
+  },
 
   computed: {
     ...mapState("search", ["results", "query", "loading"]),
+  },
+  methods: {
+    fetchDetails() {
+      this.setQuery(this.$route.params.name)
+      this.getResults()
+    },
+    ...mapActions("search", ["setQuery", "getResults"]),
   },
 }
 </script>

--- a/src/dispatch/static/dispatch/src/search/ResultList.vue
+++ b/src/dispatch/static/dispatch/src/search/ResultList.vue
@@ -78,12 +78,11 @@ export default {
     return {}
   },
   created() {
-    console.log("Searching for " + this.$route.params.name)
     this.fetchDetails()
   },
   watch: {
     "$route.params.name": function () {
-      console.log("Searching for " + this.$route.params.name)
+      this.fetchDetails()
     },
   },
 

--- a/src/dispatch/static/dispatch/src/search/ResultList.vue
+++ b/src/dispatch/static/dispatch/src/search/ResultList.vue
@@ -81,8 +81,11 @@ export default {
     this.fetchDetails()
   },
   watch: {
-    "$route.params.name": function () {
-      this.fetchDetails()
+    query: function (q) {
+      // update URL in browser and search for new query
+      this.$router.push({ name: "ResultList", query: { q: q } })
+      this.setQuery(q)
+      this.getResults()
     },
   },
 
@@ -91,7 +94,7 @@ export default {
   },
   methods: {
     fetchDetails() {
-      this.setQuery(this.$route.params.name)
+      this.setQuery(this.$route.query.q)
       this.getResults()
     },
     ...mapActions("search", ["setQuery", "getResults"]),

--- a/src/dispatch/static/dispatch/src/search/store.js
+++ b/src/dispatch/static/dispatch/src/search/store.js
@@ -105,8 +105,10 @@ const actions = {
   },
   getResults({ commit, state }) {
     commit("SET_LOADING", true)
+    console.log("Got query " + JSON.stringify(state.query))
     return SearchApi.search(state.query, state.type)
       .then((response) => {
+        console.log("HERE")
         commit("SET_RESULTS", response.data.results)
         commit("SET_LOADING", false)
       })

--- a/src/dispatch/static/dispatch/src/search/store.js
+++ b/src/dispatch/static/dispatch/src/search/store.js
@@ -105,10 +105,8 @@ const actions = {
   },
   getResults({ commit, state }) {
     commit("SET_LOADING", true)
-    console.log("Got query " + JSON.stringify(state.query))
     return SearchApi.search(state.query, state.type)
       .then((response) => {
-        console.log("HERE")
         commit("SET_RESULTS", response.data.results)
         commit("SET_LOADING", false)
       })


### PR DESCRIPTION
This PR adds the global search query to the URL, providing a way to copy & paste the search query, and allowing direct access to search results via URL. For instance, `https://dispatch.com/org/search/results?q=281` will show the search results for the query "281".