### PR TITLE
Allow a signal definition to be referenced by it's external id

### DIFF
--- a/src/dispatch/signal/service.py
+++ b/src/dispatch/signal/service.py
@@ -211,7 +211,7 @@ def get(*, db_session: Session, signal_id: int) -> Optional[Signal]:
     """Gets a signal by id or external_id."""
     signal = db_session.query(Signal).filter(Signal.id == signal_id).one_or_none()
     if not signal:
-        signal = db_session(Signal).filter(Signal.external_id == signal_id).one_or_none()
+        signal = db_session.query(Signal).filter(Signal.external_id == signal_id).one_or_none()
     return signal
 
 

--- a/src/dispatch/signal/service.py
+++ b/src/dispatch/signal/service.py
@@ -211,7 +211,7 @@ def get(*, db_session: Session, signal_id: int) -> Optional[Signal]:
     """Gets a signal by id or external_id."""
     signal = db_session.query(Signal).filter(Signal.id == signal_id).one_or_none()
     if not signal:
-        signal = db_session.query(Signal).filter(Signal.external_id == signal_id).one_or_none()
+        signal = db_session.query(Signal).filter(Signal.external_id == str(signal_id)).one_or_none()
     return signal
 
 

--- a/src/dispatch/signal/service.py
+++ b/src/dispatch/signal/service.py
@@ -208,8 +208,11 @@ def get_signal_instance(
 
 
 def get(*, db_session: Session, signal_id: int) -> Optional[Signal]:
-    """Gets a signal by id."""
-    return db_session.query(Signal).filter(Signal.id == signal_id).one_or_none()
+    """Gets a signal by id or external_id."""
+    signal = db_session.query(Signal).filter(Signal.id == signal_id).one_or_none()
+    if not signal:
+        signal = db_session(Signal).filter(Signal.external_id == signal_id).one_or_none()
+    return signal
 
 
 def get_by_variant_or_external_id(


### PR DESCRIPTION
This allows a signal definition referenced directly by its external id. Allows for direct interaction with other integration. 

We already allow signal instances to reference signal definitions by their external id. This just extends that logic to the API as well as the signal instance post body.