### PR TITLE
Adds ability to expand case attributes via the api

### DIFF
--- a/src/dispatch/case/models.py
+++ b/src/dispatch/case/models.py
@@ -315,3 +315,7 @@ class CaseUpdate(CaseBase):
 
 class CasePagination(Pagination):
     items: List[CaseReadMinimal] = []
+
+
+class CaseExpandedPagination(Pagination):
+    items: List[CaseRead] = []

--- a/src/dispatch/case/views.py
+++ b/src/dispatch/case/views.py
@@ -35,7 +35,7 @@ from .flows import (
     case_triage_create_flow,
     case_update_flow,
 )
-from .models import Case, CaseCreate, CasePagination, CaseRead, CaseUpdate
+from .models import Case, CaseCreate, CasePagination, CaseRead, CaseUpdate, CaseExpandedPagination
 from .service import create, delete, get, update
 
 
@@ -74,9 +74,16 @@ def get_case(
 
 
 @router.get("", summary="Retrieves a list of cases.")
-def get_cases(common: CommonParameters, include: List[str] = Query([], alias="include[]")):
+def get_cases(
+    common: CommonParameters,
+    include: List[str] = Query([], alias="include[]"),
+    expand: bool = Query(default=False),
+):
     """Retrieves all cases."""
     pagination = search_filter_sort_paginate(model="Case", **common)
+
+    if expand:
+        return json.loads(CaseExpandedPagination(**pagination).json())
 
     if include:
         # only allow two levels for now


### PR DESCRIPTION
This was dropped from a previous PR by accident. It allows for the full data object, specifically which signals were associated with the case.