### PR TITLE
Enhancement/adding case resolution to thread

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -1189,7 +1189,9 @@ def resolve_button_click(
 
     reason = case.resolution_reason
     blocks = [
-        case_resolution_reason_select(initial_option={"text": reason, "value": reason}) if reason else case_resolution_reason_select(),
+        case_resolution_reason_select(initial_option={"text": reason, "value": reason})
+        if reason
+        else case_resolution_reason_select(),
         resolution_input(initial_value=case.resolution),
     ]
 

--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -1187,8 +1187,9 @@ def resolve_button_click(
     ack()
     case = case_service.get(db_session=db_session, case_id=context["subject"].id)
 
+    reason = case.resolution_reason
     blocks = [
-        case_resolution_reason_select(),
+        case_resolution_reason_select(initial_option={"text": reason, "value": reason}) if reason else case_resolution_reason_select(),
         resolution_input(initial_value=case.resolution),
     ]
 
@@ -1242,6 +1243,7 @@ def handle_resolve_submission_event(
     # we update the case with the new resolution and status
     case_in = CaseUpdate(
         title=case.title,
+        resolution_reason=form_data[DefaultBlockIds.case_resolution_reason_select]["value"],
         resolution=form_data[DefaultBlockIds.resolution_input],
         visibility=case.visibility,
         status=CaseStatus.closed,

--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -111,6 +111,8 @@ def create_case_message(case: Case, channel_id: str) -> list[Block]:
     elif case.status == CaseStatus.closed:
         blocks.extend(
             [
+                Section(text=f"*Resolution reason* \n {case.resolution_reason}"),
+                Section(text=f"*Resolution description* \n {case.resolution}"),
                 Actions(
                     elements=[
                         Button(
@@ -120,7 +122,7 @@ def create_case_message(case: Case, channel_id: str) -> list[Block]:
                             value=button_metadata,
                         )
                     ]
-                )
+                ),
             ]
         )
     else:


### PR DESCRIPTION
This PR adds the case resolution reason and description to the Slack thread. Also fixes a bug that wasn't storing the selected resolution reason when the user selects "Resolve" directly in the Slack thread.

![Screenshot 2023-08-14 at 1 35 21 PM](https://github.com/Netflix/dispatch/assets/84562015/8150f7cc-5219-4b8f-9bf6-056e737f705a)
