### PR TITLE
Fixes issue with case escalation dialog

### DIFF
--- a/src/dispatch/static/dispatch/src/case/EscalateDialog.vue
+++ b/src/dispatch/static/dispatch/src/case/EscalateDialog.vue
@@ -87,7 +87,7 @@ export default {
         this.incidentDescription = this.caseDescription
         this.incidentTitle = this.caseTitle
         this.incidentProject = this.caseProject ? this.caseProject : null
-        this.incidentType = this.caseType.incident_type ? this.caseType : null
+        this.incidentType = this.caseType.incident_type ? this.caseType.incident_type : null
       }
     )
   },


### PR DESCRIPTION
This PR fixes an issue with the case escalation dialog where case type was being used in the incident type field rather than the incident type mapped to the case type.