### PR TITLE
Reverts unneeded changes to PagerDuty plugin

### DIFF
--- a/src/dispatch/plugins/dispatch_pagerduty/plugin.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/plugin.py
@@ -51,11 +51,11 @@ class PagerDutyOncallPlugin(OncallPlugin):
     def __init__(self):
         self.configuration_schema = PagerdutyConfiguration
 
-    def get(self, service_id: str, type: Literal["current", "next"] = "current", **kwargs) -> str:
-        """Gets the current or next oncall person's email."""
+    def get(self, service_id: str, **kwargs) -> str:
+        """Gets the current oncall person's email."""
         client = APISession(self.configuration.api_key.get_secret_value())
         client.url = self.configuration.pagerduty_api_url
-        return get_oncall(client=client, service_id=service_id, type=type)
+        return get_oncall(client=client, service_id=service_id)
 
     def page(
         self,

--- a/src/dispatch/plugins/dispatch_pagerduty/plugin.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/plugin.py
@@ -14,7 +14,13 @@ from dispatch.decorators import apply, counter, timer
 from dispatch.plugins import dispatch_pagerduty as pagerduty_oncall_plugin
 from dispatch.plugins.bases import OncallPlugin
 
-from .service import get_oncall_email, page_oncall, oncall_shift_check, get_escalation_policy, get_service
+from .service import (
+    get_oncall_email,
+    page_oncall,
+    oncall_shift_check,
+    get_escalation_policy,
+    get_service,
+)
 
 
 log = logging.getLogger(__name__)

--- a/src/dispatch/plugins/dispatch_pagerduty/plugin.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/plugin.py
@@ -14,7 +14,7 @@ from dispatch.decorators import apply, counter, timer
 from dispatch.plugins import dispatch_pagerduty as pagerduty_oncall_plugin
 from dispatch.plugins.bases import OncallPlugin
 
-from .service import get_oncall, page_oncall, oncall_shift_check, get_escalation_policy, get_service
+from .service import get_oncall_email, page_oncall, oncall_shift_check, get_escalation_policy, get_service
 
 
 log = logging.getLogger(__name__)
@@ -51,11 +51,11 @@ class PagerDutyOncallPlugin(OncallPlugin):
     def __init__(self):
         self.configuration_schema = PagerdutyConfiguration
 
-    def get(self, service_id: str, **kwargs) -> str:
+    def get(self, service_id: str) -> str:
         """Gets the current oncall person's email."""
         client = APISession(self.configuration.api_key.get_secret_value())
         client.url = self.configuration.pagerduty_api_url
-        return get_oncall(client=client, service_id=service_id)
+        return get_oncall_email(client=client, service_id=service_id)
 
     def page(
         self,

--- a/src/dispatch/plugins/dispatch_pagerduty/plugin.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/plugin.py
@@ -6,7 +6,7 @@
 """
 from pdpyras import APISession
 from pydantic import Field, SecretStr, EmailStr
-from typing import Literal, Optional
+from typing import Optional
 import logging
 
 from dispatch.config import BaseConfigurationModel

--- a/src/dispatch/plugins/dispatch_pagerduty/service.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/service.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from http import HTTPStatus
-from typing import Literal, Optional
+from typing import Optional
 import logging
 
 from pdpyras import APISession, PDHTTPError, PDClientError

--- a/src/dispatch/plugins/dispatch_pagerduty/service.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/service.py
@@ -83,7 +83,9 @@ def get_oncall_email(client: APISession, service_id: str) -> str:
     """Fetches the oncall's email for a given service."""
     service = get_service(client=client, service_id=service_id)
     escalation_policy_id = service["escalation_policy"]["id"]
-    escalation_policy = get_escalation_policy(client=client, escalation_policy_id=escalation_policy_id)
+    escalation_policy = get_escalation_policy(
+        client=client, escalation_policy_id=escalation_policy_id
+    )
     filter_name = (
         f"{escalation_policy['escalation_rules'][0]['targets'][0]['type'].split('_')[0]}_ids[]"
     )

--- a/src/dispatch/plugins/dispatch_pagerduty/service.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/service.py
@@ -79,10 +79,11 @@ def create_incident(client: APISession, headers: dict, data: dict) -> dict:
     return incident
 
 
-def get_oncall_email(client, service: dict) -> str:
+def get_oncall_email(client: APISession, service_id: str) -> str:
     """Fetches the oncall's email for a given service."""
+    service = get_service(client=client, service_id=service_id)
     escalation_policy_id = service["escalation_policy"]["id"]
-    escalation_policy = client.rget(f"/escalation_policies/{escalation_policy_id}")
+    escalation_policy = get_escalation_policy(client=client, escalation_policy_id=escalation_policy_id)
     filter_name = (
         f"{escalation_policy['escalation_rules'][0]['targets'][0]['type'].split('_')[0]}_ids[]"
     )
@@ -104,15 +105,9 @@ def get_oncall_email(client, service: dict) -> str:
         raise Exception(
             f"No users could be found for this pagerduty escalation policy ({escalation_policy_id}). Is there a schedule associated?"
         )
-    user = client.rget(f"/users/{user_id}")
+    user = get_user(client=client, user_id=user_id)
 
     return user["email"]
-
-
-def get_oncall(client: APISession, service_id: str) -> str:
-    """Gets the email of the current oncall for a given service id."""
-    service = get_service(client, service_id)
-    return get_oncall_email(client, service)
 
 
 def page_oncall(


### PR DESCRIPTION
This PR reverts some of the unneeded changes to the PagerDuty plugin which caused the `get()` to return a `dict` instead of the expected oncall email as a `str`.