### PR TITLE
Filters health metrics for given project

### DIFF
--- a/src/dispatch/feedback/service/scheduled.py
+++ b/src/dispatch/feedback/service/scheduled.py
@@ -60,8 +60,6 @@ def find_schedule_and_send(
     )
 
 
-@timer
-@scheduled_project_task
 def oncall_shift_feedback(db_session: SessionLocal, project: Project):
     """
     Experimental: collects feedback from individuals participating in an oncall service that has health metrics enabled
@@ -77,9 +75,12 @@ def oncall_shift_feedback(db_session: SessionLocal, project: Project):
         )
         return
 
-    # Get all oncall services marked for health metrics
+    # Get all oncall services marked for health metrics for this project
     oncall_services = service_service.get_all_by_health_metrics(
-        db_session=db_session, service_type=oncall_plugin.instance.slug, health_metrics=True
+        db_session=db_session,
+        service_type=oncall_plugin.instance.slug,
+        health_metrics=True,
+        project_id=project.id,
     )
 
     for oncall_service in oncall_services:

--- a/src/dispatch/service/service.py
+++ b/src/dispatch/service/service.py
@@ -148,10 +148,15 @@ def get_all_by_project_id_and_status(
 
 
 def get_all_by_health_metrics(
-    *, db_session, service_type: str, health_metrics: bool
+    *, db_session, service_type: str, health_metrics: bool, project_id: int
 ) -> List[Optional[Service]]:
-    """Gets all services based on the given health metrics value."""
-    return db_session.query(Service).filter(Service.health_metrics.is_(health_metrics)).all()
+    """Gets all services based on the given health metrics value for a given project."""
+    return (
+        db_session.query(Service)
+        .filter(Service.health_metrics.is_(health_metrics))
+        .filter(Service.project_id == project_id)
+        .all()
+    )
 
 
 def create(*, db_session, service_in: ServiceCreate) -> Service:


### PR DESCRIPTION
Fixes bug where the oncall end-of-shift feedback was sending multiple times since the db query wasn't being filter by project.