### PR TITLE
Allowing filtering in incident dashboard by participant or commander

### DIFF
--- a/src/dispatch/database/service.py
+++ b/src/dispatch/database/service.py
@@ -504,11 +504,14 @@ def search_filter_sort_paginate(
             sort = False if sort_by else True
             query = search(query_str=query_str, query=query, model=model, sort=sort)
 
-        query = apply_model_specific_filters(model_cls, query, current_user, role)
+        query_restricted = apply_model_specific_filters(model_cls, query, current_user, role)
+        query = query.distinct()
 
         if filter_spec:
             query = apply_filter_specific_joins(model_cls, filter_spec, query)
             query = apply_filters(query, filter_spec, model_cls)
+
+        query = query.intersect(query_restricted)
 
         if sort_by:
             sort_spec = create_sort_spec(model, sort_by, descending)

--- a/src/dispatch/database/service.py
+++ b/src/dispatch/database/service.py
@@ -505,13 +505,13 @@ def search_filter_sort_paginate(
             query = search(query_str=query_str, query=query, model=model, sort=sort)
 
         query_restricted = apply_model_specific_filters(model_cls, query, current_user, role)
-        query = query.distinct()
 
         if filter_spec:
             query = apply_filter_specific_joins(model_cls, filter_spec, query)
             query = apply_filters(query, filter_spec, model_cls)
 
-        query = query.intersect(query_restricted)
+        if model == "Incident":
+            query = query.intersect(query_restricted)
 
         if sort_by:
             sort_spec = create_sort_spec(model, sort_by, descending)

--- a/src/dispatch/database/service.py
+++ b/src/dispatch/database/service.py
@@ -504,13 +504,12 @@ def search_filter_sort_paginate(
             sort = False if sort_by else True
             query = search(query_str=query_str, query=query, model=model, sort=sort)
 
-        query_restricted = apply_model_specific_filters(model_cls, query, current_user, role)
-
         if filter_spec:
             query = apply_filter_specific_joins(model_cls, filter_spec, query)
             query = apply_filters(query, filter_spec, model_cls)
 
         if model == "Incident":
+            query_restricted = apply_model_specific_filters(model_cls, query, current_user, role)
             query = query.intersect(query_restricted)
 
         if sort_by:

--- a/src/dispatch/static/dispatch/src/dashboard/incident/IncidentDialogFilter.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/incident/IncidentDialogFilter.vue
@@ -45,6 +45,28 @@
             <incident-priority-combobox v-model="filters.incident_priority" />
           </v-list-item-content>
         </v-list-item>
+        <v-list-item>
+          <v-list-item-content>
+            <v-card class="mx-auto" outlined elevation="0">
+              <v-card-title>Incident Participant</v-card-title>
+              <v-card-subtitle>Show only incidents with this participant</v-card-subtitle>
+              <participant-select
+                class="ml-10 mr-5"
+                v-model="local_participant"
+                label="Participant"
+                hint="Show only incidents with this participant"
+                :project="filters.project"
+                clearable
+              />
+              <v-checkbox
+                class="ml-10 mr-5"
+                v-model="local_participant_is_commander"
+                label="And this participant is the Incident Commander"
+                :disabled="local_participant == null"
+              />
+            </v-card>
+          </v-list-item-content>
+        </v-list-item>
       </v-list>
       <v-card-actions>
         <v-spacer />
@@ -70,6 +92,7 @@ import ProjectCombobox from "@/project/ProjectCombobox.vue"
 import RouterUtils from "@/router/utils"
 import SearchUtils from "@/search/utils"
 import TagFilterAutoComplete from "@/tag/TagFilterAutoComplete.vue"
+import ParticipantSelect from "@/incident/ParticipantSelect.vue"
 
 let today = function () {
   let now = new Date()
@@ -86,6 +109,7 @@ export default {
     IncidentTypeCombobox,
     ProjectCombobox,
     TagFilterAutoComplete,
+    ParticipantSelect,
   },
 
   props: {
@@ -118,6 +142,8 @@ export default {
           end: null,
         },
       },
+      local_participant_is_commander: false,
+      local_participant: null,
     }
   },
 
@@ -130,6 +156,7 @@ export default {
         this.filters.project.length,
         this.filters.status.length,
         this.filters.tag.length,
+        this.local_participant == null ? 0 : 1,
         1,
       ])
     },
@@ -138,6 +165,15 @@ export default {
 
   methods: {
     applyFilters() {
+      if (this.local_participant) {
+        if (this.local_participant_is_commander) {
+          this.filters.commander = this.local_participant
+          this.filters.participant = null
+        } else {
+          this.filters.commander = null
+          this.filters.participant = this.local_participant
+        }
+      }
       RouterUtils.updateURLFilters(this.filters)
       this.fetchData()
       // we close the dialog

--- a/src/dispatch/static/dispatch/src/router/utils.js
+++ b/src/dispatch/static/dispatch/src/router/utils.js
@@ -14,17 +14,33 @@ export default {
         return
       }
       each(value, function (item) {
-        if (has(flatFilters, key)) {
-          if (typeof item === "string" || item instanceof String) {
-            flatFilters[key].push(item)
+        if (["commander", "participant"].includes(key)) {
+          if (has(flatFilters, key)) {
+            if (typeof item === "string" || item instanceof String) {
+              flatFilters[key].push(item)
+            } else {
+              flatFilters[key].push(item.email)
+            }
           } else {
-            flatFilters[key].push(item.name)
+            if (typeof item === "string" || item instanceof String) {
+              flatFilters[key] = [item]
+            } else {
+              flatFilters[key] = [item.email]
+            }
           }
         } else {
-          if (typeof item === "string" || item instanceof String) {
-            flatFilters[key] = [item]
+          if (has(flatFilters, key)) {
+            if (typeof item === "string" || item instanceof String) {
+              flatFilters[key].push(item)
+            } else {
+              flatFilters[key].push(item.name)
+            }
           } else {
-            flatFilters[key] = [item.name]
+            if (typeof item === "string" || item instanceof String) {
+              flatFilters[key] = [item]
+            } else {
+              flatFilters[key] = [item.name]
+            }
           }
         }
       })
@@ -64,6 +80,24 @@ export default {
               filters[key].push(item)
             } else {
               filters[key] = [item]
+            }
+          })
+        }
+        return
+      }
+      if (["commander", "participant"].includes(key)) {
+        if (typeof value === "string" || value instanceof String) {
+          if (has(filters, key)) {
+            filters[key].push({ email: value })
+          } else {
+            filters[key] = [{ email: value }]
+          }
+        } else {
+          each(value, function (item) {
+            if (has(filters, key)) {
+              filters[key].push({ email: item })
+            } else {
+              filters[key] = [{ email: item }]
             }
           })
         }

--- a/src/dispatch/static/dispatch/src/search/utils.js
+++ b/src/dispatch/static/dispatch/src/search/utils.js
@@ -118,7 +118,7 @@ export default {
           if (!value) {
             return
           }
-          if (has(value, "id")) {
+          if (!["commander", "participant"].includes(key) && has(value, "id")) {
             subFilter.push({
               model: toPascalCase(key),
               field: "id",

--- a/src/dispatch/static/dispatch/src/search/utils.js
+++ b/src/dispatch/static/dispatch/src/search/utils.js
@@ -118,7 +118,14 @@ export default {
           if (!value) {
             return
           }
-          if (!["commander", "participant"].includes(key) && has(value, "id")) {
+          if (["commander", "participant"].includes(key) && has(value, "email")) {
+            subFilter.push({
+              model: toPascalCase(key),
+              field: "email",
+              op: "==",
+              value: value.email,
+            })
+          } else if (has(value, "id")) {
             subFilter.push({
               model: toPascalCase(key),
               field: "id",


### PR DESCRIPTION
Allows the incident dashboard to also be filtered by a particular participant or commander. Fixes issue where members couldn't filter on participant. Changes URL to use email for filtering instead of name.