### PR TITLE
Renames parameter create_resources to create_all_resources

### DIFF
--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -191,6 +191,8 @@ def case_new_create_flow(
         case=case, db_session=db_session
     )
 
+    # NOTE: we create all external resources for a Case unless it's
+    # created from a Signal, as it gets expensive when we have lots of them.
     case_create_resources_flow(
         db_session=db_session,
         case_id=case.id,

--- a/src/dispatch/signal/flows.py
+++ b/src/dispatch/signal/flows.py
@@ -147,7 +147,7 @@ def signal_instance_create_flow(
         service_id=None,
         conversation_target=conversation_target,
         case_id=case.id,
-        create_resources=False,
+        create_all_resources=False,
     )
 
     if signal_instance.signal.engagements and entities:


### PR DESCRIPTION
* Renamed the `create_resources` parameter to `create_all_resources`, as we do create some (e.g. conversation) even if it's set to `False`
* Removed ticket update call as we now always call `case_create_resources_flow`