### PR TITLE
Fix bug where entity types created via Modal don't appear in combobox

### DIFF
--- a/src/dispatch/static/dispatch/src/entity/EntityFilterCombobox.vue
+++ b/src/dispatch/static/dispatch/src/entity/EntityFilterCombobox.vue
@@ -55,7 +55,7 @@ import SearchUtils from "@/search/utils"
 import EntityApi from "@/entity/api"
 
 export default {
-  name: "EntityCombobox",
+  name: "EntityFilterCombobox",
 
   props: {
     value: {
@@ -64,7 +64,7 @@ export default {
     },
     label: {
       type: String,
-      default: "Add Entity Types",
+      default: "Add Entities",
     },
     model: {
       type: String,

--- a/src/dispatch/static/dispatch/src/entity_type/EntityTypeFilterCombobox.vue
+++ b/src/dispatch/static/dispatch/src/entity_type/EntityTypeFilterCombobox.vue
@@ -118,7 +118,7 @@ export default {
     },
     label: {
       type: String,
-      default: "Add Entity Types",
+      default: "Add Entity Type Filters",
     },
     model: {
       type: String,
@@ -198,7 +198,7 @@ export default {
           ...filterOptions,
           filters: {
             project: [this.project],
-            scope: ["multiple"],
+            scope: ["multiple", "single"],
           },
         }
         filterOptions = SearchUtils.createParametersFromTableOptions({ ...filterOptions })

--- a/src/dispatch/static/dispatch/src/signal/NewEditDialog.vue
+++ b/src/dispatch/static/dispatch/src/signal/NewEditDialog.vue
@@ -217,6 +217,7 @@
                 v-model="entity_types"
                 :project="project"
                 :signalDefinition="selected"
+                label="Add Entity Types"
               />
             </v-card-text>
           </v-card>


### PR DESCRIPTION
The issue stemmed from us not returning entity types with the type `single`:

```vue
+ scope: ["multiple", "single"]
```

Which is the default type when created via the `+` -> Modal creation dialog (from within the definition edit sheet).