### PR TITLE
 To allow deletable chips to be saved  for `SearchFilterCombobox.vue`, call `$emit` ('input') in remove method

### DIFF
--- a/src/dispatch/static/dispatch/src/search/SearchFilterCombobox.vue
+++ b/src/dispatch/static/dispatch/src/search/SearchFilterCombobox.vue
@@ -160,7 +160,11 @@ export default {
 
   methods: {
     remove(item) {
-      this.searchFilters.splice(this.searchFilters.indexOf(item), 1)
+      const index = this.searchFilters.indexOf(item)
+      if (index !== -1) {
+        this.searchFilters.splice(index, 1)
+        this.$emit("input", this.searchFilters)
+      }
     },
     fetchData() {
       this.error = null


### PR DESCRIPTION
When removing an engagement filter and having no filters set you have to use the combobox X next to the drop down selector and you can't simply remove a filter using the chip x otherwise the change isn't saved. 

you can directly emit changes from the remove method:

```vue
remove(item) {
  const index = this.searchFilters.indexOf(item);
  if (index !== -1) {
    this.searchFilters.splice(index, 1);
    this.$emit("input", this.searchFilters);
  }
},
```

I believe this functionality is meant to be covered in the `set()` function:

```vue
set(value) {
  this.search = null;
  const filters = value.filter((v) => {
    if (typeof v === "string") {
      return false;
    }
    return true;
  });
  this.$emit("input", filters);
},
```

But the root cause of the issue seems to stem from:

```
To ensure the set() method within the searchFilters computed property is called when an item is removed, we need to reassign a new instance of the array to the computed property after performing the removal. This way, the set method will be triggered since we're directly setting the searchFilters computed property to a new value/reference.
```

We could fix this directly, but it seems more appropriate to emit the change from the method that modifies the data, as we did in the `remove` method.