### PR TITLE
Mirror the incident bottom sheet to prevent focus from being stolen

### DIFF
--- a/src/dispatch/static/dispatch/src/case/BulkEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/case/BulkEditSheet.vue
@@ -1,5 +1,11 @@
 <template>
-  <v-bottom-sheet v-model="showBulkEdit" hide-overlay persistent>
+  <v-bottom-sheet
+    v-model="showBulkEdit"
+    :scrim="false"
+    persistent
+    no-click-animation
+    :retain-focus="false"
+  >
     <handoff-dialog />
     <closed-dialog />
     <v-card :loading="bulkEditLoading" rounded="0">


### PR DESCRIPTION
Selecting a case via the checkbox in the table spawns a sheet at the bottom of the page, in Case table this steals focus, and you cannot close the bottom sheet. This does not happen on incident table, so we copy that one. Note, this component should likely be standardized in `@/components` in the future as they are basically the same.