### PR TITLE
return object when an item is selected in case/incident table

### DIFF
--- a/src/dispatch/static/dispatch/src/case/Table.vue
+++ b/src/dispatch/static/dispatch/src/case/Table.vue
@@ -45,6 +45,7 @@
             v-model="selected"
             loading-text="Loading... Please wait"
             show-select
+            return-object
             @click:row="showCaseEditSheet"
           >
             <template #item.case_severity.name="{ value }">

--- a/src/dispatch/static/dispatch/src/incident/Table.vue
+++ b/src/dispatch/static/dispatch/src/incident/Table.vue
@@ -46,6 +46,7 @@
             v-model="selected"
             loading-text="Loading... Please wait"
             show-select
+            return-object
             @click:row="showIncidentEditSheet"
           >
             <template #item.project.name="{ item, value }">


### PR DESCRIPTION
The `id` was being returned instead of the entire `Case`/`Incident` object, this appears to be different behavior in the Vue3 Vutetify tables than how it used to work.