### PR TITLE
Sets signal field in SignalInstanceRead as optional.

### DIFF
--- a/src/dispatch/signal/models.py
+++ b/src/dispatch/signal/models.py
@@ -382,7 +382,7 @@ class SignalInstanceCreate(SignalInstanceBase):
 class SignalInstanceRead(SignalInstanceBase):
     id: uuid.UUID
     fingerprint: Optional[str]
-    signal: SignalRead
+    signal: Optional[SignalRead]
 
 
 class SignalInstancePagination(Pagination):


### PR DESCRIPTION
Not all SignalInstances are tied to a signal.