### PR TITLE
Swallow send exceptions

### DIFF
--- a/src/dispatch/evergreen/scheduled.py
+++ b/src/dispatch/evergreen/scheduled.py
@@ -30,6 +30,12 @@ def create_evergreen_reminder(
     db_session: SessionLocal, project: Project, owner_email: str, resource_groups: Any
 ):
     """Contains the logic for evergreen reminders."""
+    if not owner_email:
+        log.warning(
+            "Evergreen reminder not sent. No owner email. Project: {project.name}. Organization: {project.organization.name}"
+        )
+        return
+
     plugin = plugin_service.get_active_instance(
         db_session=db_session, plugin_type="email", project_id=project.id
     )

--- a/src/dispatch/plugins/dispatch_slack/enums.py
+++ b/src/dispatch/plugins/dispatch_slack/enums.py
@@ -35,3 +35,4 @@ class SlackAPIErrorCode(DispatchEnum):
     USERS_NOT_FOUND = "users_not_found"
     VIEW_NOT_FOUND = "not_found"  # Could not find corresponding view for the provided view_id
     VIEW_EXPIRED = "expired_trigger_id"  # The provided trigger_id is no longer valid
+    IS_ARCHIVED = "is_archived"  # Channel is archived

--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -189,9 +189,7 @@ class SlackConversationPlugin(ConversationPlugin):
             error = exception.response["error"]
             if error == SlackAPIErrorCode.IS_ARCHIVED:
                 # swallow send errors if the channel is archived
-                message = (
-                    f"SlackAPIError trying to send: {exception.response}. Message: {text}. Type: {notification_type}"
-                )
+                message = f"SlackAPIError trying to send: {exception.response}. Message: {text}. Type: {notification_type}"
                 logger.error(message)
             else:
                 raise exception

--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -49,6 +49,8 @@ from .service import (
     unarchive_conversation,
     update_message,
 )
+from slack_sdk.errors import SlackApiError
+from .enums import SlackAPIErrorCode
 
 logger = logging.getLogger(__name__)
 
@@ -162,26 +164,37 @@ class SlackConversationPlugin(ConversationPlugin):
         **kwargs,
     ):
         """Sends a new message based on data and type."""
-        client = create_slack_client(self.configuration)
-        messages = []
-        if not blocks:
-            blocks = create_message_blocks(message_template, notification_type, items, **kwargs)
+        try:
+            client = create_slack_client(self.configuration)
+            messages = []
+            if not blocks:
+                blocks = create_message_blocks(message_template, notification_type, items, **kwargs)
 
-            for c in chunks(blocks, 50):
-                messages.append(
-                    send_message(
-                        client,
-                        conversation_id,
-                        text,
-                        ts,
-                        Message(blocks=c).build()["blocks"],
-                        persist,
+                for c in chunks(blocks, 50):
+                    messages.append(
+                        send_message(
+                            client,
+                            conversation_id,
+                            text,
+                            ts,
+                            Message(blocks=c).build()["blocks"],
+                            persist,
+                        )
                     )
+            else:
+                for c in chunks(blocks, 50):
+                    messages.append(send_message(client, conversation_id, text, ts, c, persist))
+            return messages
+        except SlackApiError as exception:
+            error = exception.response["error"]
+            if error == SlackAPIErrorCode.IS_ARCHIVED:
+                # swallow send errors if the channel is archived
+                message = (
+                    f"SlackAPIError trying to send: {exception.response}. Message: {text}. Type: {notification_type}"
                 )
-        else:
-            for c in chunks(blocks, 50):
-                messages.append(send_message(client, conversation_id, text, ts, c, persist))
-        return messages
+                logger.error(message)
+            else:
+                raise exception
 
     def send_direct(
         self,


### PR DESCRIPTION
This PR swallows exceptions being thrown if an evergreen message is attempted to be sent with no owner or a Slack message is attempted to be sent to an archived channel.