### PR TITLE
Show the value of the Entity in Slack snooze dropdown

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/fields.py
+++ b/src/dispatch/plugins/dispatch_slack/fields.py
@@ -619,7 +619,7 @@ def entity_select(
 ):
     """Creates an entity select."""
     entity_options = [
-        {"text": entity.entity_type.name[:75], "value": entity.id}
+        {"text": entity.value[:75], "value": entity.id}
         for entity in entity_service.get_all_desc_by_signal(
             db_session=db_session, signal_id=signal_id
         )
@@ -664,7 +664,7 @@ def signal_definition_select(
     signals: list[Signal],
     action_id: str = DefaultActionIds.signal_definition_select,
     block_id: str = DefaultBlockIds.signal_definition_select,
-    label: str = "Signal Defintions",
+    label: str = "Signal Definitions",
     initial_option: Participant = None,
     **kwargs,
 ):


### PR DESCRIPTION
![Screenshot 2023-11-29 at 2 34 49 PM](https://github.com/Netflix/dispatch/assets/114631109/088503e5-1b93-4751-90f6-796e7838eeb5)

Current state is above, you do not know which value you are selection. This shows the `value` of the Entity, (e.g. `will@lol.com`)