### PR TITLE
Fix self closing custom component lint flag on DateWindowInput

### DIFF
--- a/src/dispatch/static/dispatch/src/components/DateWindowInput.vue
+++ b/src/dispatch/static/dispatch/src/components/DateWindowInput.vue
@@ -23,10 +23,10 @@
             </v-list>
           </v-col>
           <v-col>
-            <v-date-picker title="Start Date" v-model="start" show-adjacent-months></v-date-picker>
+            <v-date-picker title="Start Date" v-model="start" show-adjacent-months />
           </v-col>
           <v-col>
-            <v-date-picker title="End Date" v-model="end" show-adjacent-months></v-date-picker>
+            <v-date-picker title="End Date" v-model="end" show-adjacent-months />
           </v-col>
         </v-row>
       </v-container>


### PR DESCRIPTION
Resolves:

```
Require self-closing on Vue.js custom components (<v-date-picker>)
```