### PR TITLE
Display label correctly for SignalInstanceNode

### DIFF
--- a/src/dispatch/static/dispatch/src/case/GraphTab.vue
+++ b/src/dispatch/static/dispatch/src/case/GraphTab.vue
@@ -41,7 +41,7 @@ watchEffect(() => {
       const instanceNode = {
         id: instance.raw.id,
         type: "signal",
-        label: instance.raw.name,
+        label: instance.signal.name,
         data: instance.raw,
         position: { x: 100 * (index + 1), y: 100 * (index + 1) },
         class: "light",


### PR DESCRIPTION
This label was too tightly coupled to the raw data, it should work across all Dispatch Signals now.