### PR TITLE
Change `View` button for Case Slack message to use `id` as route parameter 

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -78,7 +78,7 @@ def create_case_message(case: Case, channel_id: str) -> list[Block]:
             accessory=Button(
                 text="View",
                 action_id="button-link",
-                url=f"{DISPATCH_UI_URL}/{case.project.organization.slug}/cases/{case.name}",
+                url=f"{DISPATCH_UI_URL}/{case.project.organization.slug}/cases/{case.id}",
             ),
         ),
         Section(text=f"*Description* \n {case.description}"),


### PR DESCRIPTION
We ues the `id` instead of the name in the Case Page now since it saves a RT with current views.