### PR TITLE
Change Case Page route to name and revert all previous changes

### DIFF
--- a/src/dispatch/case/messaging.py
+++ b/src/dispatch/case/messaging.py
@@ -37,7 +37,7 @@ def send_case_close_reminder(case: Case, db_session: SessionLocal):
     items = [
         {
             "name": case.name,
-            "dispatch_ui_case_url": f"{DISPATCH_UI_URL}/{case.project.organization.name}/cases/{case.id}",  # noqa
+            "dispatch_ui_case_url": f"{DISPATCH_UI_URL}/{case.project.organization.name}/cases/{case.name}",  # noqa
             "title": case.title,
             "status": case.status,
         }
@@ -77,7 +77,7 @@ def send_case_triage_reminder(case: Case, db_session: SessionLocal):
             "name": case.name,
             "title": case.title,
             "status": case.status,
-            "dispatch_ui_case_url": f"{DISPATCH_UI_URL}/{case.project.organization.name}/cases/{case.id}",  # noqa
+            "dispatch_ui_case_url": f"{DISPATCH_UI_URL}/{case.project.organization.name}/cases/{case.name}",  # noqa
         }
     ]
 

--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -78,7 +78,7 @@ def create_case_message(case: Case, channel_id: str) -> list[Block]:
             accessory=Button(
                 text="View",
                 action_id="button-link",
-                url=f"{DISPATCH_UI_URL}/{case.project.organization.slug}/cases/{case.id}",
+                url=f"{DISPATCH_UI_URL}/{case.project.organization.slug}/cases/{case.name}",
             ),
         ),
         Section(text=f"*Description* \n {case.description}"),

--- a/src/dispatch/static/dispatch/src/case/PageHeader.vue
+++ b/src/dispatch/static/dispatch/src/case/PageHeader.vue
@@ -33,17 +33,24 @@
 
 <script setup lang="ts">
 import { useRoute } from "vue-router"
-import { computed, ref } from "vue"
+import { useStore } from "vuex"
+import { computed, ref, watch } from "vue"
 import LockButton from "@/components/LockButton.vue"
 import EscalateButton from "@/case/EscalateButton.vue"
 import DTooltip from "@/components/DTooltip.vue"
 import ParticipantAvatarGroup from "@/participant/ParticipantAvatarGroup.vue"
 import SavingState from "@/components/SavingState.vue"
 import CaseApi from "@/case/api"
+import type { Ref } from "vue"
 
 const route = useRoute()
+const store = useStore()
 
 const props = defineProps({
+  caseId: {
+    type: Number,
+    required: true,
+  },
   caseName: {
     type: String,
     required: true,
@@ -68,22 +75,28 @@ const props = defineProps({
 
 const caseParticipants = ref([])
 const loading = ref(false)
+const caseIdRef: Ref<any> = ref(props.caseId)
 
-const fetchParticipants = async () => {
-  const caseId = route.params.id
-  loading.value = true
-  try {
-    // get case participants
-    CaseApi.getParticipants(caseId, true).then((response) => {
-      // Pass true to fetch minimal data
-      caseParticipants.value = response.data
-    })
-    loading.value = false
-  } catch (e) {
-    console.error("Failed to fetch case participants", e)
-    loading.value = false
-  }
-}
+watch(
+  () => props.caseId,
+  async (caseId) => {
+    caseIdRef.value = caseId
+    if (caseId) {
+      try {
+        // get case participants
+        CaseApi.getParticipants(caseIdRef.value, true).then((response) => {
+          // Pass true to fetch minimal data
+          caseParticipants.value = response.data
+        })
+        loading.value = false
+      } catch (e) {
+        console.error("Failed to fetch case participants", e)
+        loading.value = false
+      }
+    }
+  },
+  { immediate: true }
+)
 
 const emit = defineEmits(["toggle-drawer"])
 
@@ -105,9 +118,6 @@ const breadcrumbItems = computed(() => {
   ]
   return items
 })
-
-// Fetch participants immediately when the component is created
-fetchParticipants()
 </script>
 
 <style scoped>

--- a/src/dispatch/static/dispatch/src/case/Table.vue
+++ b/src/dispatch/static/dispatch/src/case/Table.vue
@@ -92,7 +92,7 @@
                   <v-list-item
                     :to="{
                       name: 'CasePage',
-                      params: { id: item.id },
+                      params: { name: item.name },
                     }"
                   >
                     <v-list-item-title>View</v-list-item-title>

--- a/src/dispatch/static/dispatch/src/router/config.js
+++ b/src/dispatch/static/dispatch/src/router/config.js
@@ -205,7 +205,7 @@ export const protectedRoute = [
           ],
         },
         {
-          path: "/:organization/cases/:id",
+          path: "/:organization/cases/:name",
           name: "CasePage",
           meta: { title: "Page" },
           component: () => import("@/case/Page.vue"),


### PR DESCRIPTION
The `id` being the route is generally worse for the user, even though the page load time in this implementation is slightly slower, the breaking change from `name` -> `id` is not worth it. We can try some different approaches to improving time to render & interactive for most Case Page visits.