### PR TITLE
use `flex-shrink` and `min-width 0` for signal instance tab viewer

### DIFF
--- a/src/dispatch/static/dispatch/src/case/CaseSignalInstanceTab.vue
+++ b/src/dispatch/static/dispatch/src/case/CaseSignalInstanceTab.vue
@@ -2,8 +2,8 @@
   <v-container>
     <v-row>
       <!-- Column for Data Table -->
-      <v-col cols="3">
-        <v-card min-width="350" class="signal-card" elevation="0">
+      <v-col cols="3" class="d-flex">
+        <v-card class="signal-card flex-card" elevation="0">
           <v-virtual-scroll :items="signalInstances" height="828" class="pt-2">
             <template #default="{ item }">
               <div class="d-flex align-center">
@@ -23,8 +23,8 @@
         </v-card>
       </v-col>
       <!-- Column for Raw Signal Viewer -->
-      <v-col cols="9">
-        <v-card elevation="0" class="signal-card pt-2">
+      <v-col cols="9" class="d-flex">
+        <v-card class="signal-card flex-card" elevation="0">
           <span class="dispatch-text-paragraph">
             <!-- {{ selectedItem.signal.name }} -->
           </span>
@@ -109,5 +109,10 @@ watch(
 .signal-card {
   border: 0.5px solid rgb(216, 216, 216) !important;
   border-radius: 8px !important;
+}
+.flex-card {
+  flex: 1;
+  min-width: 0; // Allow the card to shrink below its content size
+  overflow: hidden; // Clip the content and add ... if the content is too big
 }
 </style>


### PR DESCRIPTION
prevent button overlap on small viewports