### PR TITLE
Change View Case button to Open in Dispatch

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -76,7 +76,7 @@ def create_case_message(case: Case, channel_id: str) -> list[Block]:
         Section(
             text=f"*Title* \n {case.title}.",
             accessory=Button(
-                text="View",
+                text="Open in Dispatch",
                 action_id="button-link",
                 url=f"{DISPATCH_UI_URL}/{case.project.organization.slug}/cases/{case.name}",
             ),


### PR DESCRIPTION
I find that the `View` button is often overlooked. `Open in Dispatch` will make the button larger and is a clearer description of what the button does.