### PR TITLE
Restricting oncall feedback permission

### DIFF
--- a/src/dispatch/feedback/service/views.py
+++ b/src/dispatch/feedback/service/views.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, HTTPException, status, Depends
 from dispatch.auth.permissions import (
     FeedbackDeletePermission,
     PermissionsDependency,
+    SensitiveProjectActionPermission,
 )
 from dispatch.database.core import DbSession
 from dispatch.database.service import search_filter_sort_paginate, CommonParameters
@@ -15,13 +16,21 @@ from .service import get, delete
 router = APIRouter()
 
 
-@router.get("", response_model=ServiceFeedbackPagination)
+@router.get(
+        "",
+        response_model=ServiceFeedbackPagination,
+        dependencies=[Depends(PermissionsDependency([SensitiveProjectActionPermission]))],
+)
 def get_feedback_entries(commons: CommonParameters):
     """Get all feedback entries, or only those matching a given search term."""
     return search_filter_sort_paginate(model="ServiceFeedback", **commons)
 
 
-@router.get("/{service_feedback_id}", response_model=ServiceFeedbackRead)
+@router.get(
+        "/{service_feedback_id}",
+        response_model=ServiceFeedbackRead,
+        dependencies=[Depends(PermissionsDependency([SensitiveProjectActionPermission]))],
+)
 def get_feedback(db_session: DbSession, service_feedback_id: PrimaryKey):
     """Get a feedback entry by its id."""
     feedback = get(db_session=db_session, service_feedback_id=service_feedback_id)

--- a/src/dispatch/static/dispatch/src/feedback/service/store.js
+++ b/src/dispatch/static/dispatch/src/feedback/service/store.js
@@ -53,10 +53,14 @@ const actions = {
       { ...state.table.options },
       "ServiceFeedback"
     )
-    return ServiceFeedbackApi.getAll(params).then((response) => {
-      commit("SET_TABLE_LOADING", false)
-      commit("SET_TABLE_ROWS", response.data)
-    })
+    return ServiceFeedbackApi.getAll(params)
+      .then((response) => {
+        commit("SET_TABLE_LOADING", false)
+        commit("SET_TABLE_ROWS", response.data)
+      })
+      .catch(() => {
+        commit("SET_TABLE_LOADING", false)
+      })
   }, 500),
   removeShow({ commit }, feedback) {
     commit("SET_DIALOG_DELETE", true)


### PR DESCRIPTION
Restricts viewing the oncall feedback table to admins and above.