### PR TITLE
Only add project to participant filter if non-null

### DIFF
--- a/src/dispatch/static/dispatch/src/components/ParticipantSelect.vue
+++ b/src/dispatch/static/dispatch/src/components/ParticipantSelect.vue
@@ -85,12 +85,14 @@ export default {
       }
 
       if (props.project) {
-        if (Array.isArray(props.project) && props.project.length > 0) {
-          filterOptions = {
-            filters: {
-              project: props.project,
-            },
-            ...filterOptions,
+        if (Array.isArray(props.project)) {
+          if (props.project.length > 0) {
+            filterOptions = {
+              filters: {
+                project: props.project,
+              },
+              ...filterOptions,
+            }
           }
         } else {
           filterOptions = {


### PR DESCRIPTION
Fixes an error in the incident table filter dialog where a project wasn't first selected.