### PR TITLE
Update slack plugin.py to check if user exists before send direct

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -205,8 +205,10 @@ class SlackConversationPlugin(ConversationPlugin):
         blocks: Optional[List] = None,
         **kwargs,
     ):
-        """Sends a message directly to a user."""
+        """Sends a message directly to a user if the user exists."""
         client = create_slack_client(self.configuration)
+        if not does_user_exist(client, user):
+            return {}
         user_id = resolve_user(client, user)["id"]
 
         if not blocks:
@@ -227,8 +229,10 @@ class SlackConversationPlugin(ConversationPlugin):
         blocks: Optional[List] = None,
         **kwargs,
     ):
-        """Sends an ephemeral message to a user in a channel."""
+        """Sends an ephemeral message to a user in a channel if the user exists."""
         client = create_slack_client(self.configuration)
+        if not does_user_exist(client, user):
+            return {}
         user_id = resolve_user(client, user)["id"]
 
         if not blocks:


### PR DESCRIPTION
It is possible that a message could be attempted to send for a slack account that does not exist anymore. This performs a check before attempting to send so it does not raise an exception if the user does not exist.

This causes two looks ups for every direct or ephemeral send, but will prevent exceptions.