### PR TITLE
Update case service to return only lists for get_participants

### DIFF
--- a/src/dispatch/case/service.py
+++ b/src/dispatch/case/service.py
@@ -373,7 +373,7 @@ def delete(*, db_session, case_id: int):
 
 def get_participants(
     *, db_session: Session, case_id: int, minimal: bool = False
-) -> list[Participant] | None:
+) -> list[Participant]:
     """Returns a list of participants based on the given case id."""
     if minimal:
         case = (
@@ -390,4 +390,4 @@ def get_participants(
             .first()
         )
 
-    return case.participants if case else None
+    return [] if case is None or case.participants is None else case.participants


### PR DESCRIPTION
Changed return type to be only a list for get_participants, but allow participants list to be empty. This was causing an issue with the case view get_case_participants when the return of get_participants was None.