### PR TITLE
Perform None check for group in update_group

### DIFF
--- a/src/dispatch/group/flows.py
+++ b/src/dispatch/group/flows.py
@@ -99,7 +99,7 @@ def update_group(
     if group is None:
         log.warning(f"Group not updated. No group provided. Cannot {group_action} for {group_member}.")
         return
-    
+
     plugin = plugin_service.get_active_instance(
         db_session=db_session, project_id=subject.project.id, plugin_type="participant-group"
     )

--- a/src/dispatch/group/flows.py
+++ b/src/dispatch/group/flows.py
@@ -96,6 +96,10 @@ def update_group(
     db_session: SessionLocal,
 ):
     """Updates an existing group."""
+    if group is None:
+        log.warning(f"Group not updated. No group provided. Cannot {group_action} for {group_member}.")
+        return
+    
     plugin = plugin_service.get_active_instance(
         db_session=db_session, project_id=subject.project.id, plugin_type="participant-group"
     )


### PR DESCRIPTION
incident.tactical_group can be None and if that is the case, this will handle it by ignoring and just log a warning.