### PR TITLE
Ensuring that the tag picker reloads on project selection

### DIFF
--- a/src/dispatch/static/dispatch/src/case/DetailsTab.vue
+++ b/src/dispatch/static/dispatch/src/case/DetailsTab.vue
@@ -110,7 +110,13 @@
         </v-row>
       </v-col>
       <v-col cols="12">
-        <tag-filter-auto-complete label="Tags" v-model="tags" model="case" :model-id="id" />
+        <tag-filter-auto-complete
+          label="Tags"
+          v-model="tags"
+          model="case"
+          :model-id="id"
+          :project="project"
+        />
       </v-col>
       <v-col cols="12">
         <case-filter-combobox label="Related" v-model="related" :project="project" />

--- a/src/dispatch/static/dispatch/src/case/TableExportDialog.vue
+++ b/src/dispatch/static/dispatch/src/case/TableExportDialog.vue
@@ -26,7 +26,12 @@
                   <project-combobox v-model="project" label="Projects" />
                 </v-list-item>
                 <v-list-item>
-                  <tag-filter-auto-complete v-model="tag" label="Tags" model="case" />
+                  <tag-filter-auto-complete
+                    v-model="tag"
+                    label="Tags"
+                    model="case"
+                    :project="project"
+                  />
                 </v-list-item>
                 <v-list-item>
                   <tag-type-filter-combobox v-model="tag_type" label="Tag Types" />

--- a/src/dispatch/static/dispatch/src/case/TableFilterDialog.vue
+++ b/src/dispatch/static/dispatch/src/case/TableFilterDialog.vue
@@ -35,7 +35,12 @@
           <tag-type-filter-combobox v-model="local_tag_type" label="Tag Types" />
         </v-list-item>
         <v-list-item>
-          <tag-filter-auto-complete v-model="local_tag" label="Tags" model="case" />
+          <tag-filter-auto-complete
+            v-model="local_tag"
+            label="Tags"
+            model="case"
+            :project="local_project"
+          />
         </v-list-item>
       </v-list>
       <v-card-actions>

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseDialogFilter.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseDialogFilter.vue
@@ -20,7 +20,12 @@
           <project-combobox v-model="filters.project" label="Projects" />
         </v-list-item>
         <v-list-item>
-          <tag-filter-auto-complete v-model="filters.tag" label="Tags" model="case" />
+          <tag-filter-auto-complete
+            v-model="filters.tag"
+            label="Tags"
+            model="case"
+            :project="filters.project"
+          />
         </v-list-item>
         <v-list-item>
           <case-type-combobox v-model="filters.case_type" />

--- a/src/dispatch/static/dispatch/src/dashboard/incident/IncidentDialogFilter.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/incident/IncidentDialogFilter.vue
@@ -20,7 +20,12 @@
           <project-combobox v-model="filters.project" label="Projects" />
         </v-list-item>
         <v-list-item>
-          <tag-filter-auto-complete v-model="filters.tag" label="Tags" model="incident" />
+          <tag-filter-auto-complete
+            v-model="filters.tag"
+            label="Tags"
+            model="incident"
+            :project="filters.project"
+          />
         </v-list-item>
         <v-list-item>
           <incident-type-combobox v-model="filters.incident_type" />

--- a/src/dispatch/static/dispatch/src/data/query/TableFilterDialog.vue
+++ b/src/dispatch/static/dispatch/src/data/query/TableFilterDialog.vue
@@ -17,7 +17,12 @@
           <tag-type-filter-combobox v-model="local_tag_type" label="Tag Types" />
         </v-list-item>
         <v-list-item>
-          <tag-filter-auto-complete v-model="local_tag" label="Tags" model="query" />
+          <tag-filter-auto-complete
+            v-model="local_tag"
+            label="Tags"
+            model="query"
+            :project="local_project"
+          />
         </v-list-item>
       </v-list>
       <v-card-actions>

--- a/src/dispatch/static/dispatch/src/data/source/TableFilterDialog.vue
+++ b/src/dispatch/static/dispatch/src/data/source/TableFilterDialog.vue
@@ -29,7 +29,12 @@
           <project-combobox v-model="local_project" label="Projects" />
         </v-list-item>
         <v-list-item>
-          <tag-filter-auto-complete v-model="local_tag" label="Tags" model="source" />
+          <tag-filter-auto-complete
+            v-model="local_tag"
+            label="Tags"
+            model="source"
+            :project="local_project"
+          />
         </v-list-item>
         <v-list-item>
           <tag-type-filter-combobox v-model="local_tag_type" label="Tag Types" />

--- a/src/dispatch/static/dispatch/src/incident/TableExportDialog.vue
+++ b/src/dispatch/static/dispatch/src/incident/TableExportDialog.vue
@@ -26,7 +26,12 @@
                   <project-combobox v-model="project" label="Projects" />
                 </v-list-item>
                 <v-list-item>
-                  <tag-filter-auto-complete v-model="tag" label="Tags" model="incident" />
+                  <tag-filter-auto-complete
+                    v-model="tag"
+                    label="Tags"
+                    model="incident"
+                    :project="project"
+                  />
                 </v-list-item>
                 <v-list-item>
                   <tag-type-filter-combobox v-model="tag_type" label="Tag Types" />

--- a/src/dispatch/static/dispatch/src/incident/TableFilterDialog.vue
+++ b/src/dispatch/static/dispatch/src/incident/TableFilterDialog.vue
@@ -35,7 +35,12 @@
           <tag-type-filter-combobox v-model="local_tag_type" label="Tag Types" />
         </v-list-item>
         <v-list-item>
-          <tag-filter-auto-complete v-model="local_tag" label="Tags" model="incident" />
+          <tag-filter-auto-complete
+            v-model="local_tag"
+            label="Tags"
+            model="incident"
+            :project="local_project"
+          />
         </v-list-item>
         <v-list-item>
           <v-card class="mx-auto">

--- a/src/dispatch/static/dispatch/src/incident_role/PolicyRoleBuilder.vue
+++ b/src/dispatch/static/dispatch/src/incident_role/PolicyRoleBuilder.vue
@@ -57,7 +57,7 @@
               <v-list-item>
                 <tag-filter-auto-complete
                   label="Tags"
-                  :project="project"
+                  project="project"
                   v-model="policy.tags"
                   model="incident"
                 />

--- a/src/dispatch/static/dispatch/src/incident_role/PolicyRoleBuilder.vue
+++ b/src/dispatch/static/dispatch/src/incident_role/PolicyRoleBuilder.vue
@@ -57,7 +57,7 @@
               <v-list-item>
                 <tag-filter-auto-complete
                   label="Tags"
-                  project="project"
+                  :project="project"
                   v-model="policy.tags"
                   model="incident"
                 />

--- a/src/dispatch/static/dispatch/src/signal/NewEditDialog.vue
+++ b/src/dispatch/static/dispatch/src/signal/NewEditDialog.vue
@@ -108,6 +108,7 @@
                     v-model="tags"
                     model="signal"
                     :model-id="id"
+                    :project="project"
                   />
                 </v-col>
               </v-row>

--- a/src/dispatch/static/dispatch/src/tag/TagPicker.vue
+++ b/src/dispatch/static/dispatch/src/tag/TagPicker.vue
@@ -120,7 +120,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from "vue"
+import { ref, computed, onMounted, watch } from "vue"
 import { cloneDeep } from "lodash"
 import SearchUtils from "@/search/utils"
 import TagApi from "@/tag/api"
@@ -165,6 +165,13 @@ const props = defineProps({
   },
 })
 
+watch(
+  () => props.project,
+  () => {
+    fetchData()
+  }
+)
+
 const fetchData = () => {
   loading.value = true
 
@@ -178,7 +185,13 @@ const fetchData = () => {
   let filters = {}
 
   if (props.project) {
-    filters["project"] = [props.project]
+    if (Array.isArray(props.project)) {
+      if (props.project.length > 0) {
+        filters["project"] = props.project
+      }
+    } else {
+      filters["project"] = [props.project]
+    }
   }
 
   // add a filter to only retrun discoverable tags


### PR DESCRIPTION
The new tag picker component was not watching the project prop for changes and thus was not filtering properly.