### PR TITLE
Add reporter to individual_participants list

### DIFF
--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -622,6 +622,9 @@ def case_create_resources_flow(
     if case.assignee:
         individual_participants.append((case.assignee.individual, None))
 
+    if case.reporter:
+        individual_participants.append((case.reporter.individual, None))
+
     if create_all_resources:
         # we create the tactical group
         direct_participant_emails = [i.email for i, _ in individual_participants]


### PR DESCRIPTION
I walked back from `Adding the following individuals to help resolve this case` to resolve an issue where Case reporter is not added to the Case conversation. We pass some variant of `participant_emails` all the way down from `case_create_resource_flow`, where this list of emails is populated. It looks like we never add reporter here, if it exists, even though we do it for the assignee.