### PR TITLE
Only populate the tacticall report actions field if there are current actions.

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -1548,14 +1548,17 @@ def handle_report_tactical_command(
 
     incident = incident_service.get(db_session=db_session, incident_id=context["subject"].id)
     if incident.tasks:
-        actions = "" if actions is None else actions
-        actions += "\n\nOutstanding Incident Tasks:\n".join(
+        outstanding_actions = "" if actions is None else actions
+        outstanding_actions += "\n\nOutstanding Incident Tasks:\n".join(
             [
                 "-" + task.description
                 for task in incident.tasks
                 if task.status != TaskStatus.resolved
             ]
         )
+
+    if len(outstanding_actions):
+        actions = outstanding_actions
 
     blocks = [
         Input(


### PR DESCRIPTION
Slack throws an error when a PlainTextInput has an empty string as the initial value. This field should be set to None when the initial value is empty.