### PR TITLE
Adding copy button to tag picker

### DIFF
--- a/src/dispatch/static/dispatch/src/styles/tagpicker.scss
+++ b/src/dispatch/static/dispatch/src/styles/tagpicker.scss
@@ -43,7 +43,7 @@ button {
   flex-direction: column;
   padding: 8px;
   max-width: 100%;
-  max-height: 250px;
+  max-height: 1250px;
   border-radius: 5px;
   overflow-y: scroll;
   box-shadow: 0 0 10px 5px rgba(0, 0, 0, 0.03);

--- a/src/dispatch/static/dispatch/src/tag/TagPicker.vue
+++ b/src/dispatch/static/dispatch/src/tag/TagPicker.vue
@@ -13,6 +13,9 @@
           {{ menu ? "mdi-minus" : "mdi-plus" }}
         </v-icon>
       </template>
+      <template #append>
+        <v-icon class="panel-button" @click.stop="copyTags">mdi-content-copy</v-icon>
+      </template>
       <div class="form-container mt-2">
         <div class="chip-group" v-show="selectedItems.length">
           <span v-for="(item, index) in selectedItems" :key="item">
@@ -117,6 +120,11 @@
       </div>
     </v-card>
   </span>
+  <v-snackbar v-model="snackbar" :timeout="2400" color="success">
+    <v-row class="fill-height" align="center">
+      <v-col class="text-center">Tags copied to the clipboard</v-col>
+    </v-row>
+  </v-snackbar>
 </template>
 
 <script setup>
@@ -143,6 +151,7 @@ const searchQuery = ref("")
 const filteredMenuItems = ref([])
 const isDropdownOpen = ref(false)
 const loading = ref(true)
+const snackbar = ref(false)
 
 const props = defineProps({
   modelValue: {
@@ -259,6 +268,12 @@ const selectedItems = computed({
     emit("update:modelValue", tags)
   },
 })
+
+const copyTags = () => {
+  const tags = selectedItems.value.map((item) => `${item.tag_type.name}/${item.name}`)
+  navigator.clipboard.writeText(tags.join(", "))
+  snackbar.value = true
+}
 
 const closeMenu = () => {
   menu.value = false


### PR DESCRIPTION
Adds ability to copy the list of tags as `tag_type/tag_name`. For instance, clicking the copy button at the end of the picker here
<img width="778" alt="Screenshot 2024-01-31 at 10 00 29 PM" src="https://github.com/Netflix/dispatch/assets/84562015/8835ba59-ccfd-4a3a-a665-b8da2c190e68">
would copy the text `action/compromise, actor/researcher` to the clipboard.