### PR TITLE
Validate project-specific fields in UI

### DIFF
--- a/src/dispatch/static/dispatch/src/case/priority/CasePrioritySelect.vue
+++ b/src/dispatch/static/dispatch/src/case/priority/CasePrioritySelect.vue
@@ -7,6 +7,7 @@
     label="Priority"
     return-object
     :loading="loading"
+    :rules="[priority_in_project]"
   >
     <template #item="data">
       <v-list-item v-bind="data.props" :title="null">
@@ -44,6 +45,11 @@ export default {
     return {
       loading: false,
       items: [],
+      error: null,
+      priority_in_project: () => {
+        this.validatePriority()
+        return this.error
+      },
     }
   },
 
@@ -54,11 +60,21 @@ export default {
       },
       set(value) {
         this.$emit("update:modelValue", value)
+        this.validatePriority()
       },
     },
   },
 
   methods: {
+    validatePriority() {
+      const project_id = this.project?.id || 0
+      const in_project = this.case_priority?.project?.id == project_id
+      if (in_project) {
+        this.error = true
+      } else {
+        this.error = "Only priorities in selected project are allowed"
+      }
+    },
     fetchData() {
       this.error = null
       this.loading = "error"
@@ -104,6 +120,8 @@ export default {
       (vm) => [vm.project],
       () => {
         this.fetchData()
+        this.validatePriority()
+        this.$emit("update:modelValue", this.case_priority)
       }
     )
   },

--- a/src/dispatch/static/dispatch/src/case/priority/CasePrioritySelect.vue
+++ b/src/dispatch/static/dispatch/src/case/priority/CasePrioritySelect.vue
@@ -7,7 +7,7 @@
     label="Priority"
     return-object
     :loading="loading"
-    :rules="[priority_in_project]"
+    :rules="[is_priority_in_project]"
   >
     <template #item="data">
       <v-list-item v-bind="data.props" :title="null">
@@ -46,7 +46,7 @@ export default {
       loading: false,
       items: [],
       error: null,
-      priority_in_project: () => {
+      is_priority_in_project: () => {
         this.validatePriority()
         return this.error
       },

--- a/src/dispatch/static/dispatch/src/case/severity/CaseSeveritySelect.vue
+++ b/src/dispatch/static/dispatch/src/case/severity/CaseSeveritySelect.vue
@@ -7,7 +7,7 @@
     label="Severity"
     return-object
     :loading="loading"
-    :rules="[severity_in_project]"
+    :rules="[is_severity_in_project]"
   >
     <template #item="data">
       <v-list-item v-bind="data.props" :title="null">
@@ -46,7 +46,7 @@ export default {
       loading: false,
       items: [],
       error: null,
-      severity_in_project: () => {
+      is_severity_in_project: () => {
         this.validateSeverity()
         return this.error
       },

--- a/src/dispatch/static/dispatch/src/case/severity/CaseSeveritySelect.vue
+++ b/src/dispatch/static/dispatch/src/case/severity/CaseSeveritySelect.vue
@@ -7,6 +7,7 @@
     label="Severity"
     return-object
     :loading="loading"
+    :rules="[severity_in_project]"
   >
     <template #item="data">
       <v-list-item v-bind="data.props" :title="null">
@@ -44,6 +45,11 @@ export default {
     return {
       loading: false,
       items: [],
+      error: null,
+      severity_in_project: () => {
+        this.validateSeverity()
+        return this.error
+      },
     }
   },
 
@@ -54,11 +60,21 @@ export default {
       },
       set(value) {
         this.$emit("update:modelValue", value)
+        this.validateSeverity()
       },
     },
   },
 
   methods: {
+    validateSeverity() {
+      const project_id = this.project?.id || 0
+      const in_project = this.case_severity?.project?.id == project_id
+      if (in_project) {
+        this.error = true
+      } else {
+        this.error = "Only severities in selected project are allowed"
+      }
+    },
     fetchData() {
       this.error = null
       this.loading = "error"
@@ -104,6 +120,8 @@ export default {
       (vm) => [vm.project],
       () => {
         this.fetchData()
+        this.validateSeverity()
+        this.$emit("update:modelValue", this.case_severity)
       }
     )
   },

--- a/src/dispatch/static/dispatch/src/case/type/CaseTypeSelect.vue
+++ b/src/dispatch/static/dispatch/src/case/type/CaseTypeSelect.vue
@@ -11,7 +11,7 @@
     :loading="loading"
     no-filter
     :error-messages="show_error"
-    :rules="[type_in_project]"
+    :rules="[is_type_in_project]"
   >
     <template #item="data">
       <v-list-item v-bind="data.props" :title="null">
@@ -71,7 +71,7 @@ export default {
       more: false,
       numItems: 5,
       error: null,
-      type_in_project: () => {
+      is_type_in_project: () => {
         this.validateType()
         return this.error
       },

--- a/src/dispatch/static/dispatch/src/case/type/CaseTypeSelect.vue
+++ b/src/dispatch/static/dispatch/src/case/type/CaseTypeSelect.vue
@@ -11,6 +11,7 @@
     :loading="loading"
     no-filter
     :error-messages="show_error"
+    :rules="[type_in_project]"
   >
     <template #item="data">
       <v-list-item v-bind="data.props" :title="null">
@@ -69,6 +70,11 @@ export default {
       search: null,
       more: false,
       numItems: 5,
+      error: null,
+      type_in_project: () => {
+        this.validateType()
+        return this.error
+      },
     }
   },
 
@@ -79,6 +85,7 @@ export default {
       },
       set(value) {
         this.$emit("update:modelValue", value)
+        this.validateType()
       },
     },
     show_error() {
@@ -96,7 +103,15 @@ export default {
       this.numItems = this.numItems + 5
       this.fetchData()
     },
-
+    validateType() {
+      const project_id = this.project?.id || 0
+      const in_project = this.case_type?.project?.id == project_id
+      if (in_project) {
+        this.error = true
+      } else {
+        this.error = "Only types in selected project are allowed"
+      }
+    },
     fetchData() {
       this.error = null
       this.loading = "error"
@@ -155,6 +170,8 @@ export default {
       (vm) => [vm.project],
       () => {
         this.fetchData()
+        this.validateType()
+        this.$emit("update:modelValue", this.case_type)
       }
     )
   },

--- a/src/dispatch/static/dispatch/src/incident/priority/IncidentPrioritySelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/priority/IncidentPrioritySelect.vue
@@ -9,6 +9,7 @@
     return-object
     :loading="loading"
     :error-messages="show_error"
+    :rules="[priority_in_project]"
   />
 </template>
 
@@ -41,6 +42,11 @@ export default {
     return {
       loading: false,
       items: [],
+      error: null,
+      priority_in_project: () => {
+        this.validatePriority()
+        return this.error
+      },
     }
   },
 
@@ -51,6 +57,7 @@ export default {
       },
       set(value) {
         this.$emit("update:modelValue", value)
+        this.validatePriority()
       },
     },
     show_error() {
@@ -65,6 +72,15 @@ export default {
   },
 
   methods: {
+    validatePriority() {
+      const project_id = this.project?.id || 0
+      const in_project = this.incident_priorities?.project?.id == project_id
+      if (in_project) {
+        this.error = true
+      } else {
+        this.error = "Only priorities in selected project are allowed"
+      }
+    },
     fetchData() {
       this.error = null
       this.loading = "error"
@@ -110,6 +126,8 @@ export default {
       (vm) => [vm.project, vm.status],
       () => {
         this.fetchData()
+        this.validatePriority()
+        this.$emit("update:modelValue", this.incident_priorities)
       }
     )
   },

--- a/src/dispatch/static/dispatch/src/incident/priority/IncidentPrioritySelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/priority/IncidentPrioritySelect.vue
@@ -9,7 +9,7 @@
     return-object
     :loading="loading"
     :error-messages="show_error"
-    :rules="[priority_in_project]"
+    :rules="[is_priority_in_project]"
   />
 </template>
 
@@ -43,7 +43,7 @@ export default {
       loading: false,
       items: [],
       error: null,
-      priority_in_project: () => {
+      is_priority_in_project: () => {
         this.validatePriority()
         return this.error
       },

--- a/src/dispatch/static/dispatch/src/incident/severity/IncidentSeveritySelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/severity/IncidentSeveritySelect.vue
@@ -7,6 +7,7 @@
     label="Severity"
     return-object
     :loading="loading"
+    :rules="[severity_in_project]"
   >
     <template #item="data">
       <v-list-item v-bind="data.props" :title="null">
@@ -45,6 +46,11 @@ export default {
     return {
       loading: false,
       items: [],
+      error: null,
+      severity_in_project: () => {
+        this.validateSeverity()
+        return this.error
+      },
     }
   },
 
@@ -55,11 +61,21 @@ export default {
       },
       set(value) {
         this.$emit("update:modelValue", value)
+        this.validateSeverity()
       },
     },
   },
 
   methods: {
+    validateSeverity() {
+      const project_id = this.project?.id || 0
+      const in_project = this.incidentSeverity?.project?.id == project_id
+      if (in_project) {
+        this.error = true
+      } else {
+        this.error = "Only severities in selected project are allowed"
+      }
+    },
     fetchData() {
       this.error = null
       this.loading = "error"
@@ -105,6 +121,8 @@ export default {
       (vm) => [vm.project],
       () => {
         this.fetchData()
+        this.validateSeverity()
+        this.$emit("update:modelValue", this.incidentSeverity)
       }
     )
   },

--- a/src/dispatch/static/dispatch/src/incident/severity/IncidentSeveritySelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/severity/IncidentSeveritySelect.vue
@@ -7,7 +7,7 @@
     label="Severity"
     return-object
     :loading="loading"
-    :rules="[severity_in_project]"
+    :rules="[is_severity_in_project]"
   >
     <template #item="data">
       <v-list-item v-bind="data.props" :title="null">
@@ -47,7 +47,7 @@ export default {
       loading: false,
       items: [],
       error: null,
-      severity_in_project: () => {
+      is_severity_in_project: () => {
         this.validateSeverity()
         return this.error
       },

--- a/src/dispatch/static/dispatch/src/incident/type/IncidentTypeSelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/type/IncidentTypeSelect.vue
@@ -7,6 +7,7 @@
     :label="label"
     return-object
     :loading="loading"
+    :rules="[type_in_project]"
   >
     <template #item="{ props, item }">
       <v-list-item v-bind="props" :title="null">
@@ -63,6 +64,11 @@ export default {
       items: [],
       more: false,
       numItems: 5,
+      error: null,
+      type_in_project: () => {
+        this.validateType()
+        return this.error
+      },
     }
   },
 
@@ -73,6 +79,7 @@ export default {
       },
       set(value) {
         this.$emit("update:modelValue", value)
+        this.validateType()
       },
     },
   },
@@ -81,6 +88,15 @@ export default {
     loadMore() {
       this.numItems = this.numItems + 5
       this.fetchData()
+    },
+    validateType() {
+      const project_id = this.project?.id || 0
+      const in_project = this.incident_type?.project?.id == project_id
+      if (in_project) {
+        this.error = true
+      } else {
+        this.error = "Only types in selected project are allowed"
+      }
     },
     fetchData() {
       this.error = null
@@ -132,6 +148,8 @@ export default {
       (vm) => [vm.project],
       () => {
         this.fetchData()
+        this.validateType()
+        this.$emit("update:modelValue", this.incident_type)
       }
     )
   },

--- a/src/dispatch/static/dispatch/src/incident/type/IncidentTypeSelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/type/IncidentTypeSelect.vue
@@ -7,7 +7,7 @@
     :label="label"
     return-object
     :loading="loading"
-    :rules="[type_in_project]"
+    :rules="[is_type_in_project]"
   >
     <template #item="{ props, item }">
       <v-list-item v-bind="props" :title="null">
@@ -65,7 +65,7 @@ export default {
       more: false,
       numItems: 5,
       error: null,
-      type_in_project: () => {
+      is_type_in_project: () => {
         this.validateType()
         return this.error
       },

--- a/src/dispatch/static/dispatch/src/tag/TagPicker.vue
+++ b/src/dispatch/static/dispatch/src/tag/TagPicker.vue
@@ -7,7 +7,7 @@
       variant="outlined"
       v-model="dummyText"
       class="main-panel"
-      :rules="[tag_in_project]"
+      :rules="[is_tag_in_project]"
     >
       <template #prepend-inner>
         <v-icon class="panel-button">
@@ -174,7 +174,7 @@ watch(
     validateTags(selectedItems.value)
   }
 )
-const tag_in_project = () => {
+const is_tag_in_project = () => {
   return error.value
 }
 


### PR DESCRIPTION
This PR adds validation to project-specific fields in incident and case selectors for types, priorities, severities, and tags.

![image](https://github.com/Netflix/dispatch/assets/84562015/905ec8a9-8f90-49e0-822e-e1ef8b344480)
