### PR TITLE
Fixes participant role time calculation by defaulting the participant role end time to now.

### DIFF
--- a/src/dispatch/incident_cost/service.py
+++ b/src/dispatch/incident_cost/service.py
@@ -229,7 +229,7 @@ def calculate_incident_response_cost_with_classic_model(incident: Incident, inci
 
                 if participant_role.renounced_at:
                     # the participant left the conversation or got assigned another role
-                    if participant_role.renounced_at < incident.stable_at:
+                    if participant_role.renounced_at < participant_role_renounced_at:
                         # we use the role's renounced_at time if it happened before the
                         # incident was marked as stable or closed
                         participant_role_renounced_at = participant_role.renounced_at


### PR DESCRIPTION
Calculate the participant role time by setting the participant's renounced at time to one of the following choices:
1. the current time if the incident is active
2. the time the incident is set to stable if the incident is stable
3. participant role renouncement time if the participant leaves their role before the incident is stable.