### PR TITLE
Only show copy button in tag picker if prop is set

### DIFF
--- a/src/dispatch/static/dispatch/src/case/DetailsTab.vue
+++ b/src/dispatch/static/dispatch/src/case/DetailsTab.vue
@@ -116,6 +116,7 @@
           model="case"
           :model-id="id"
           :project="project"
+          show-copy
         />
       </v-col>
       <v-col cols="12">

--- a/src/dispatch/static/dispatch/src/incident/DetailsTab.vue
+++ b/src/dispatch/static/dispatch/src/incident/DetailsTab.vue
@@ -100,6 +100,7 @@
           :project="project"
           model="incident"
           :model-id="id"
+          show-copy
         />
       </v-col>
       <v-col cols="12">

--- a/src/dispatch/static/dispatch/src/signal/NewEditDialog.vue
+++ b/src/dispatch/static/dispatch/src/signal/NewEditDialog.vue
@@ -109,6 +109,7 @@
                     model="signal"
                     :model-id="id"
                     :project="project"
+                    show-copy
                   />
                 </v-col>
               </v-row>

--- a/src/dispatch/static/dispatch/src/tag/TagPicker.vue
+++ b/src/dispatch/static/dispatch/src/tag/TagPicker.vue
@@ -13,7 +13,7 @@
           {{ menu ? "mdi-minus" : "mdi-plus" }}
         </v-icon>
       </template>
-      <template #append>
+      <template #append v-if="showCopy">
         <v-icon class="panel-button" @click.stop="copyTags">mdi-content-copy</v-icon>
       </template>
       <div class="form-container mt-2">
@@ -171,6 +171,10 @@ const props = defineProps({
   modelId: {
     type: Number,
     default: null,
+  },
+  showCopy: {
+    type: Boolean,
+    default: false,
   },
 })
 


### PR DESCRIPTION
This PR adds a new prop to the tag picker and hides the copy button by default. To show the copy button, set the `show-copy` prop.