### PR TITLE
Adds the Slack API endpoint for conversation replies.

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/enums.py
+++ b/src/dispatch/plugins/dispatch_slack/enums.py
@@ -4,6 +4,7 @@ from dispatch.enums import DispatchEnum
 class SlackAPIGetEndpoints(DispatchEnum):
     chat_permalink = "chat.getPermalink"
     conversations_history = "conversations.history"
+    conversations_replies = "conversations.replies"
     conversations_info = "conversations.info"
     team_info = "team.info"
     users_conversations = "users.conversations"


### PR DESCRIPTION
This endpoint enables Dispatch to fetch the contents of a Slack conversation thread.

This endpoint is referenced in `dispatch_slack/service.py`, but not added to the `dispatch_slack/enums.py` file.