### PR TITLE
Fixing issue when event comes from an unrecognized sender

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -709,10 +709,12 @@ def handle_timeline_added_event(
         except Exception:
             individual = None
 
+        source = f"Slack message from {individual.name}" if individual else "Slack message"
+
         # we log the event
         event_service.log_incident_event(
             db_session=db_session,
-            source=f"Slack message from {individual.name}",
+            source=source,
             description=message_text,
             incident_id=context["subject"].id,
             individual_id=individual.id if individual else None,


### PR DESCRIPTION
If the `individual` is not found (for instance, if a Slack message from a bot is marked for timeline inclusion), then do not try to get the name.