### PR TITLE
Replaces hyperlinks in a specified Google Doc.

### DIFF
--- a/src/dispatch/plugins/dispatch_google/common.py
+++ b/src/dispatch/plugins/dispatch_google/common.py
@@ -12,7 +12,9 @@ TIMEOUT = 300
 socket.setdefaulttimeout(TIMEOUT)
 
 
-def get_service(config: GoogleConfiguration, service_name: str, version: str, scopes: list):
+def get_service(
+    config: GoogleConfiguration, service_name: str, version: str, scopes: list
+) -> googleapiclient.discovery.Resource:
     """Formats specified credentials for Google clients."""
     data = {
         "type": "service_account",

--- a/src/dispatch/plugins/dispatch_google/docs/plugin.py
+++ b/src/dispatch/plugins/dispatch_google/docs/plugin.py
@@ -24,7 +24,7 @@ def remove_control_characters(s):
     return "".join(ch for ch in s if unicodedata.category(ch)[0] != "C")
 
 
-def find_links(obj: Any, find_key: str) -> Iterator[List[Any]]:
+def find_links(obj: dict | list, find_key: str) -> Iterator[list[Any]]:
     """Enumerate all the links found.
     Returns a path of object, from leaf to parents to root.
 
@@ -48,7 +48,7 @@ def find_links(obj: Any, find_key: str) -> Iterator[List[Any]]:
                 yield found
 
 
-def iter_links(document: dict) -> List[Tuple[str, str]]:
+def iter_links(document: dict) -> list[tuple[str, str]]:
     """Find all the links and return them.
 
     This method was originally implemented in the open source library `Beancount`.

--- a/src/dispatch/plugins/dispatch_google/docs/plugin.py
+++ b/src/dispatch/plugins/dispatch_google/docs/plugin.py
@@ -58,16 +58,16 @@ def find_links(obj: dict, find_key: str) -> iter(list[Any]):
                 yield found
 
 
-def iter_links(document_content: dict) -> list[tuple[str, str]]:
+def iter_links(document_content: list) -> list[tuple[str, str]]:
     """Find all the links and return them.
     Parameters:
-        document_content (dict): The contents of the body of a Google Doc (googleapi.discovery.Resource).
+        document_content (list): The contents of the body of a Google Doc (googleapi.discovery.Resource).
 
     Returns:
         list: A list of tuples containing the hyperlink url (str) and its corresponding hyperlink element (str).
         e.g. [('https://www.netflix.com', {...{"textRun": {"textStyle": {"link": {"url": "https://www.netflix.com"}}}}})]
 
-    See https://developers.google.com/docs/api/samples/output-json for an example of a Google Doc Resource.
+    See https://developers.google.com/docs/api/samples/output-json.
 
     This method was originally implemented in the open source library `Beancount`.
     The original source code can be found at

--- a/src/dispatch/plugins/dispatch_google/docs/plugin.py
+++ b/src/dispatch/plugins/dispatch_google/docs/plugin.py
@@ -7,15 +7,18 @@
 """
 
 import logging
-from typing import Any, Iterator, List, Tuple
+from typing import Any
 import unicodedata
+
+from googleapiclient.discovery import Resource
+from googleapiclient.errors import HttpError
 
 from dispatch.decorators import apply, counter, timer
 from dispatch.plugins.bases import DocumentPlugin
 from dispatch.plugins.dispatch_google import docs as google_docs_plugin
 from dispatch.plugins.dispatch_google.common import get_service
 from dispatch.plugins.dispatch_google.config import GoogleConfiguration
-from googleapiclient.errors import HttpError
+
 
 log = logging.getLogger(__name__)
 
@@ -24,9 +27,16 @@ def remove_control_characters(s):
     return "".join(ch for ch in s if unicodedata.category(ch)[0] != "C")
 
 
-def find_links(obj: dict | list, find_key: str) -> Iterator[list[Any]]:
+def find_links(obj: dict, find_key: str) -> iter(list[Any]):
     """Enumerate all the links found.
     Returns a path of object, from leaf to parents to root.
+
+    Parameters:
+        obj (dict): The object to search for links.
+        find_key (str): The key to search for.
+
+    Returns:
+        iter: The generator of a list containing the value and the path to the value.
 
     This method was originally implemented in the open source library `Beancount`.
     The original source code can be found at
@@ -48,15 +58,21 @@ def find_links(obj: dict | list, find_key: str) -> Iterator[list[Any]]:
                 yield found
 
 
-def iter_links(document: dict) -> list[tuple[str, str]]:
+def iter_links(document_content: dict) -> list[tuple[str, str]]:
     """Find all the links and return them.
+    Parameters:
+        document_content (dict): The contents of the body of a Google Doc (googleapi.discovery.Resource).
+
+    Returns:
+        list: A list of tuples containing the hyperlink url (str) and its corresponding hyperlink element (str).
+        e.g. [('https://www.netflix.com', {...{"textRun": {"textStyle": {"link": {"url": "https://www.netflix.com"}}}}})]
 
     This method was originally implemented in the open source library `Beancount`.
     The original source code can be found at
     https://github.com/beancount/beancount/blob/master/tools/transform_links_in_docs.py.
     BeanCount is licensed under the GNU GPLv2.0 license.
     """
-    for jpath in find_links(document, "link"):
+    for jpath in find_links(document_content, "link"):
         for item in jpath:
             if "textRun" in item:
                 link = item["textRun"]["textStyle"]["link"]
@@ -66,10 +82,18 @@ def iter_links(document: dict) -> list[tuple[str, str]]:
                 yield (url, item)
 
 
-def replace_weblinks(client: Any, document_id: str, replacements: List[str]) -> None:
+def replace_weblinks(client: Resource, document_id: str, replacements: list[str]) -> None:
     """Replaces hyperlinks in specified document.
 
     If the url contains a placeholder, it will be replaced with the value in the replacements list.
+
+    Parameters:
+        client (Resource): the Google API client.
+        document_id (str): the document id.
+        replacements (list[str]): A list of string replacements to make.
+
+    Returns:
+        None
     """
     requests = []
     document_content = client.get(documentId=document_id).execute().get("body").get("content")
@@ -94,18 +118,27 @@ def replace_weblinks(client: Any, document_id: str, replacements: List[str]) -> 
         return
 
     body = {"requests": requests}
-    return client.batchUpdate(documentId=document_id, body=body).execute()
+    client.batchUpdate(documentId=document_id, body=body).execute()
 
 
-def replace_text(client: Any, document_id: str, replacements: List[str]) -> None:
-    """Replaces text in specified document."""
+def replace_text(client: Resource, document_id: str, replacements: list[str]) -> None:
+    """Replaces text in specified document.
+
+    Parameters:
+        client (Resource): the Google API client.
+        document_id (str): the document id.
+        replacements (list[str]): A list of string replacements to make.
+
+    Returns:
+        None
+    """
     requests = []
     for k, v in replacements.items():
         requests.append(
             {"replaceAllText": {"containsText": {"text": k, "matchCase": "true"}, "replaceText": v}}
         )
     body = {"requests": requests}
-    return client.batchUpdate(documentId=document_id, body=body).execute()
+    client.batchUpdate(documentId=document_id, body=body).execute()
 
 
 @apply(timer, exclude=["__init__"])
@@ -126,15 +159,15 @@ class GoogleDocsDocumentPlugin(DocumentPlugin):
             "https://www.googleapis.com/auth/drive",
         ]
 
-    def update(self, document_id: str, **kwargs):
+    def update(self, document_id: str, **kwargs) -> None:
         """Replaces text in document."""
         # TODO escape and use f strings? (kglisson)
         kwargs = {"{{" + k + "}}": v for k, v in kwargs.items()}
         client = get_service(self.configuration, "docs", "v1", self.scopes).documents()
         replace_weblinks(client, document_id, kwargs)
-        return replace_text(client, document_id, kwargs)
+        replace_text(client, document_id, kwargs)
 
-    def insert(self, document_id: str, request):
+    def insert(self, document_id: str, request) -> bool | None:
         client = get_service(self.configuration, "docs", "v1", self.scopes).documents()
         body = {"requests": request}
         try:
@@ -149,7 +182,7 @@ class GoogleDocsDocumentPlugin(DocumentPlugin):
             log.exception(e)
             return False
 
-    def get_table_details(self, document_id: str, header: str):
+    def get_table_details(self, document_id: str, header: str) -> tuple[bool, int, int, list[int]]:
         client = get_service(self.configuration, "docs", "v1", self.scopes).documents()
         try:
             document_content = (
@@ -207,7 +240,7 @@ class GoogleDocsDocumentPlugin(DocumentPlugin):
             return table_exists, header_index, -1, table_indices
         return table_exists, header_index, -1, table_indices
 
-    def delete_table(self, document_id: str, request):
+    def delete_table(self, document_id: str, request) -> bool | None:
         try:
             client = get_service(self.configuration, "docs", "v1", self.scopes).documents()
             body = {"requests": request}

--- a/src/dispatch/plugins/dispatch_google/docs/plugin.py
+++ b/src/dispatch/plugins/dispatch_google/docs/plugin.py
@@ -67,6 +67,8 @@ def iter_links(document_content: dict) -> list[tuple[str, str]]:
         list: A list of tuples containing the hyperlink url (str) and its corresponding hyperlink element (str).
         e.g. [('https://www.netflix.com', {...{"textRun": {"textStyle": {"link": {"url": "https://www.netflix.com"}}}}})]
 
+    See https://developers.google.com/docs/api/samples/output-json for an example of a Google Doc Resource.
+
     This method was originally implemented in the open source library `Beancount`.
     The original source code can be found at
     https://github.com/beancount/beancount/blob/master/tools/transform_links_in_docs.py.

--- a/src/dispatch/plugins/dispatch_google/docs/plugin.py
+++ b/src/dispatch/plugins/dispatch_google/docs/plugin.py
@@ -85,18 +85,18 @@ def iter_links(document_content: list) -> Generator[list[tuple[str, str]], None,
                 yield (url, item)
 
 
-def replace_weblinks(client: Resource, document_id: str, replacements: list[str]) -> None:
+def replace_weblinks(client: Resource, document_id: str, replacements: list[str]) -> int:
     """Replaces hyperlinks in specified document.
 
     If the url contains a placeholder, it will be replaced with the value in the replacements list.
 
     Parameters:
-        client (Resource): the Google API client.
-        document_id (str): the document id.
+        client (Resource): The Google API client.
+        document_id (str): The document id.
         replacements (list[str]): A list of string replacements to make.
 
     Returns:
-        None
+        int: The number of hyperlink update requests made.
     """
     document = client.get(documentId=document_id).execute()
 
@@ -124,22 +124,24 @@ def replace_weblinks(client: Resource, document_id: str, replacements: list[str]
                 )
 
     if not requests:
-        return
+        return 0
 
     body = {"requests": requests}
     client.batchUpdate(documentId=document_id, body=body).execute()
 
+    return len(requests)
 
-def replace_text(client: Resource, document_id: str, replacements: list[str]) -> None:
+
+def replace_text(client: Resource, document_id: str, replacements: list[str]) -> int:
     """Replaces text in specified document.
 
     Parameters:
-        client (Resource): the Google API client.
-        document_id (str): the document id.
+        client (Resource): The Google API client.
+        document_id (str): The document id.
         replacements (list[str]): A list of string replacements to make.
 
     Returns:
-        None
+        int: The number of replacement requests made.
     """
     requests = []
     for k, v in replacements.items():
@@ -148,6 +150,8 @@ def replace_text(client: Resource, document_id: str, replacements: list[str]) ->
         )
     body = {"requests": requests}
     client.batchUpdate(documentId=document_id, body=body).execute()
+
+    return len(requests)
 
 
 @apply(timer, exclude=["__init__"])

--- a/src/dispatch/plugins/dispatch_test/document.py
+++ b/src/dispatch/plugins/dispatch_test/document.py
@@ -3,7 +3,7 @@ from googleapiclient.discovery import Resource
 from googleapiclient.http import HttpRequestMock, BatchHttpRequest
 from httplib2 import Response
 
-_DOCUMENT = {
+_DOCUMENT_SUCCESS = {
     "body": {
         "content": [
             {
@@ -17,7 +17,7 @@ _DOCUMENT = {
                             "textRun": {
                                 "content": "Incident Conversation Commands Reference",
                                 "textStyle": {
-                                    "link": {"url": "https://www.netflix.com"},
+                                    "link": {"url": "https://www.netflix.com/login"},
                                 },
                             },
                         }
@@ -28,23 +28,14 @@ _DOCUMENT = {
     }
 }
 
-
-class TestDocumentResource(Resource):
-    """A mock Google Document Resource"""
-
-    def __init__(self, document: dict = _DOCUMENT):
-        self.document = document
-
-    def get(self, attr: str) -> dict:
-        """Returns a resource from the document."""
-        return self.document[attr]
+_DOCUMENT_FAIL = {"body": {"content": []}}
 
 
 class TestResource(Resource):
     """A mock Google API Client"""
 
-    def __init__(self):
-        pass
+    def __init__(self, has_link: bool = True):
+        self.has_link = has_link
 
     def batchUpdate(self, **kwargs) -> BatchHttpRequest:
         """Performs one or more update API requests."""
@@ -55,10 +46,12 @@ class TestResource(Resource):
 
     def get(self, documentId: int) -> HttpRequestMock:
         """Returns a mock HTTP request to fetch a document."""
+        document = _DOCUMENT_SUCCESS if self.has_link else _DOCUMENT_FAIL
+
         return HttpRequestMock(
             resp=Response({"status": 200}),
             content="",
-            postproc=lambda _x, _y: TestDocumentResource(),
+            postproc=lambda _x, _y: document,
         )
 
 

--- a/src/dispatch/plugins/dispatch_test/document.py
+++ b/src/dispatch/plugins/dispatch_test/document.py
@@ -1,4 +1,65 @@
 from dispatch.plugins.bases import DocumentPlugin
+from googleapiclient.discovery import Resource
+from googleapiclient.http import HttpRequestMock, BatchHttpRequest
+from httplib2 import Response
+
+_DOCUMENT = {
+    "body": {
+        "content": [
+            {
+                "startIndex": 0,
+                "endIndex": 40,
+                "paragraph": {
+                    "elements": [
+                        {
+                            "endIndex": 40,
+                            "startIndex": 0,
+                            "textRun": {
+                                "content": "Incident Conversation Commands Reference",
+                                "textStyle": {
+                                    "link": {"url": "https://www.netflix.com"},
+                                },
+                            },
+                        }
+                    ],
+                },
+            },
+        ]
+    }
+}
+
+
+class TestDocumentResource(Resource):
+    """A mock Google Document Resource"""
+
+    def __init__(self, document: dict = _DOCUMENT):
+        self.document = document
+
+    def get(self, attr: str) -> dict:
+        """Returns a resource from the document."""
+        return self.document[attr]
+
+
+class TestResource(Resource):
+    """A mock Google API Client"""
+
+    def __init__(self):
+        pass
+
+    def batchUpdate(self, **kwargs) -> BatchHttpRequest:
+        """Performs one or more update API requests."""
+        return BatchHttpRequest(
+            callback=None,
+            batch_uri=None,
+        )
+
+    def get(self, documentId: int) -> HttpRequestMock:
+        """Returns a mock HTTP request to fetch a document."""
+        return HttpRequestMock(
+            resp=Response({"status": 200}),
+            content="",
+            postproc=lambda _x, _y: TestDocumentResource(),
+        )
 
 
 class TestDocumentPlugin(DocumentPlugin):

--- a/tests/dispatch_google_docs/test_dispatch_google_docs.py
+++ b/tests/dispatch_google_docs/test_dispatch_google_docs.py
@@ -1,0 +1,65 @@
+# Representation of document in the Google Docs API.
+# See https://developers.google.com/docs/api/samples/output-json.
+_DOCUMENT = {
+    "body": {
+        "content": [
+            {
+                "startIndex": 0,
+                "endIndex": 40,
+                "paragraph": {
+                    "elements": [
+                        {
+                            "endIndex": 40,
+                            "startIndex": 0,
+                            "textRun": {
+                                "content": "Incident Conversation Commands Reference",
+                                "textStyle": {
+                                    "link": {"url": "https://www.netflix.com"},
+                                },
+                            },
+                        }
+                    ],
+                },
+            },
+        ]
+    }
+}
+
+
+def test_find_links():
+    """Tests the find_links function returns the expected urls."""
+    from dispatch.plugins.dispatch_google.docs.plugin import find_links
+
+    links = list(find_links(_DOCUMENT.get("body").get("content"), "link"))
+    # We have one link in the document.
+    assert len(links) == 1
+    # The url field is nested 8 levels deep.
+    assert len(links[0]) == 8
+    assert links[0][0]["url"] == "https://www.netflix.com"
+
+
+def test_iter_links():
+    """Tests the iter_links function returns the expected urls and elements.
+
+    The expected value is a tuple with the url "https://www.netflix.com" and the element
+    {
+        "endIndex": 40,
+        "startIndex": 0,
+        "textRun": {
+            "content": "Incident Conversation Commands Reference",
+            "textStyle": {"link": {"url": "https://www.netflix.com"}},
+        },
+    }
+    """
+    from dispatch.plugins.dispatch_google.docs.plugin import iter_links
+
+    for url, item in iter_links(_DOCUMENT.get("body").get("content")):
+        assert url == "https://www.netflix.com"
+        assert item.get("endIndex") == 40
+        assert item.get("startIndex") == 0
+        assert "textRun" in item
+        assert item.get("textRun").get("content") == "Incident Conversation Commands Reference"
+
+        return
+
+    assert False

--- a/tests/dispatch_google_docs/test_dispatch_google_docs.py
+++ b/tests/dispatch_google_docs/test_dispatch_google_docs.py
@@ -1,41 +1,33 @@
 # Representation of document in the Google Docs API.
 # See https://developers.google.com/docs/api/samples/output-json.
-_DOCUMENT = {
-    "body": {
-        "content": [
-            {
-                "startIndex": 0,
-                "endIndex": 40,
-                "paragraph": {
-                    "elements": [
-                        {
-                            "endIndex": 40,
-                            "startIndex": 0,
-                            "textRun": {
-                                "content": "Incident Conversation Commands Reference",
-                                "textStyle": {
-                                    "link": {"url": "https://www.netflix.com"},
-                                },
-                            },
-                        }
-                    ],
-                },
-            },
-        ]
-    }
-}
 
 
 def test_find_links():
     """Tests the find_links function returns the expected urls."""
     from dispatch.plugins.dispatch_google.docs.plugin import find_links
+    from dispatch.plugins.dispatch_test.document import TestDocumentResource
 
-    links = list(find_links(_DOCUMENT.get("body").get("content"), "link"))
+    links = list(find_links(TestDocumentResource().get("body").get("content"), "link"))
     # We have one link in the document.
     assert len(links) == 1
     # The url field is nested 8 levels deep.
     assert len(links[0]) == 8
     assert links[0][0]["url"] == "https://www.netflix.com"
+
+
+def test_no_find_links():
+    """Tests the find_links function returns an empty list when the document does not contain urls."""
+    from dispatch.plugins.dispatch_google.docs.plugin import find_links
+    from dispatch.plugins.dispatch_test.document import TestDocumentResource
+
+    links = list(
+        find_links(
+            TestDocumentResource({"body": {"content": {"something": "not something"}}}),
+            "link",
+        )
+    )
+
+    assert not links
 
 
 def test_iter_links():
@@ -52,9 +44,10 @@ def test_iter_links():
     }
     """
     from dispatch.plugins.dispatch_google.docs.plugin import iter_links
+    from dispatch.plugins.dispatch_test.document import TestDocumentResource
 
     has_link = False
-    for url, item in iter_links(_DOCUMENT.get("body").get("content")):
+    for url, item in iter_links(TestDocumentResource().get("body").get("content")):
         assert url == "https://www.netflix.com"
         assert item.get("endIndex") == 40
         assert item.get("startIndex") == 0
@@ -63,3 +56,46 @@ def test_iter_links():
         has_link = True
 
     assert has_link
+
+
+def test_no_iter_links():
+    """Tests the iter_links function returns an empty list when the document does not contain urls.
+
+    The expected value is a tuple with the url "https://www.netflix.com" and the element
+    {
+        "endIndex": 40,
+        "startIndex": 0,
+        "textRun": {
+            "content": "Incident Conversation Commands Reference",
+            "textStyle": {"link": {"url": "https://www.netflix.com"}},
+        },
+    }
+    """
+    from dispatch.plugins.dispatch_google.docs.plugin import iter_links
+    from dispatch.plugins.dispatch_test.document import TestDocumentResource
+
+    links = list(
+        iter_links(
+            TestDocumentResource({"body": {"content": {"something": "not something"}}})
+            .get("body")
+            .get("content")
+        )
+    )
+
+    assert not links
+
+
+def test_replace_text():
+    """Tests the replace_text function."""
+    from dispatch.plugins.dispatch_google.docs.plugin import replace_text
+    from dispatch.plugins.dispatch_test.document import TestResource
+
+    replace_text(client=TestResource(), document_id="1234", replacements={"old": "new"})
+
+
+def test_replace_weblinks():
+    """Tests the replace_weblinks function."""
+    from dispatch.plugins.dispatch_google.docs.plugin import replace_weblinks
+    from dispatch.plugins.dispatch_test.document import TestResource
+
+    replace_weblinks(client=TestResource(), document_id="1234", replacements={"old": "new"})

--- a/tests/dispatch_google_docs/test_dispatch_google_docs.py
+++ b/tests/dispatch_google_docs/test_dispatch_google_docs.py
@@ -53,13 +53,13 @@ def test_iter_links():
     """
     from dispatch.plugins.dispatch_google.docs.plugin import iter_links
 
+    has_link = False
     for url, item in iter_links(_DOCUMENT.get("body").get("content")):
         assert url == "https://www.netflix.com"
         assert item.get("endIndex") == 40
         assert item.get("startIndex") == 0
         assert "textRun" in item
         assert item.get("textRun").get("content") == "Incident Conversation Commands Reference"
+        has_link = True
 
-        return
-
-    assert False
+    assert has_link

--- a/tests/dispatch_google_docs/test_dispatch_google_docs.py
+++ b/tests/dispatch_google_docs/test_dispatch_google_docs.py
@@ -5,24 +5,30 @@
 def test_find_links():
     """Tests the find_links function returns the expected urls."""
     from dispatch.plugins.dispatch_google.docs.plugin import find_links
-    from dispatch.plugins.dispatch_test.document import TestDocumentResource
+    from dispatch.plugins.dispatch_test.document import TestResource
 
-    links = list(find_links(TestDocumentResource().get("body").get("content"), "link"))
+    client = TestResource(has_link=True)
+    document = client.get(documentId=0).execute()
+
+    links = list(find_links(document.get("body").get("content"), "link"))
     # We have one link in the document.
     assert len(links) == 1
     # The url field is nested 8 levels deep.
     assert len(links[0]) == 8
-    assert links[0][0]["url"] == "https://www.netflix.com"
+    assert links[0][0]["url"] == "https://www.netflix.com/login"
 
 
-def test_no_find_links():
+def test_find_links__no_links():
     """Tests the find_links function returns an empty list when the document does not contain urls."""
     from dispatch.plugins.dispatch_google.docs.plugin import find_links
-    from dispatch.plugins.dispatch_test.document import TestDocumentResource
+    from dispatch.plugins.dispatch_test.document import TestResource
+
+    client = TestResource(has_link=False)
+    document = client.get(documentId=0).execute()
 
     links = list(
         find_links(
-            TestDocumentResource({"body": {"content": {"something": "not something"}}}),
+            document,
             "link",
         )
     )
@@ -44,11 +50,15 @@ def test_iter_links():
     }
     """
     from dispatch.plugins.dispatch_google.docs.plugin import iter_links
-    from dispatch.plugins.dispatch_test.document import TestDocumentResource
+
+    from dispatch.plugins.dispatch_test.document import TestResource
+
+    client = TestResource(has_link=True)
+    document = client.get(documentId=0).execute()
 
     has_link = False
-    for url, item in iter_links(TestDocumentResource().get("body").get("content")):
-        assert url == "https://www.netflix.com"
+    for url, item in iter_links(document):
+        assert url == "https://www.netflix.com/login"
         assert item.get("endIndex") == 40
         assert item.get("startIndex") == 0
         assert "textRun" in item
@@ -58,29 +68,14 @@ def test_iter_links():
     assert has_link
 
 
-def test_no_iter_links():
-    """Tests the iter_links function returns an empty list when the document does not contain urls.
-
-    The expected value is a tuple with the url "https://www.netflix.com" and the element
-    {
-        "endIndex": 40,
-        "startIndex": 0,
-        "textRun": {
-            "content": "Incident Conversation Commands Reference",
-            "textStyle": {"link": {"url": "https://www.netflix.com"}},
-        },
-    }
-    """
+def test_iter_links__no_links():
+    """Tests the iter_links function returns an empty list when the document does not contain urls."""
     from dispatch.plugins.dispatch_google.docs.plugin import iter_links
-    from dispatch.plugins.dispatch_test.document import TestDocumentResource
+    from dispatch.plugins.dispatch_test.document import TestResource
 
-    links = list(
-        iter_links(
-            TestDocumentResource({"body": {"content": {"something": "not something"}}})
-            .get("body")
-            .get("content")
-        )
-    )
+    client = TestResource(has_link=False)
+    document = client.get(documentId=0).execute()
+    links = list(iter_links(document.get("body").get("content")))
 
     assert not links
 
@@ -90,7 +85,19 @@ def test_replace_text():
     from dispatch.plugins.dispatch_google.docs.plugin import replace_text
     from dispatch.plugins.dispatch_test.document import TestResource
 
-    replace_text(client=TestResource(), document_id="1234", replacements={"old": "new"})
+    assert replace_text(
+        client=TestResource(),
+        document_id="1234",
+        replacements={"current": "new", "login": "signup"},
+    )
+
+
+def test_replace_text__no_replacements():
+    """Tests the replace_text function where there is no specified replacement."""
+    from dispatch.plugins.dispatch_google.docs.plugin import replace_text
+    from dispatch.plugins.dispatch_test.document import TestResource
+
+    assert not replace_text(client=TestResource(), document_id="1234", replacements={})
 
 
 def test_replace_weblinks():
@@ -98,4 +105,28 @@ def test_replace_weblinks():
     from dispatch.plugins.dispatch_google.docs.plugin import replace_weblinks
     from dispatch.plugins.dispatch_test.document import TestResource
 
-    replace_weblinks(client=TestResource(), document_id="1234", replacements={"old": "new"})
+    assert replace_weblinks(
+        client=TestResource(), document_id="1234", replacements={"login": "signup"}
+    )
+
+
+def test_replace_weblinks__no_links():
+    """Tests the replace_weblinks function where the document does not contain links."""
+    from dispatch.plugins.dispatch_google.docs.plugin import replace_weblinks
+    from dispatch.plugins.dispatch_test.document import TestResource
+
+    assert not replace_weblinks(
+        client=TestResource(has_link=False), document_id="1234", replacements={"login": "signup"}
+    )
+
+
+def test_replace_weblinks__no_valid_replacements():
+    """Tests the replace_weblinks function where the document does not contain any of the replacement keys."""
+    from dispatch.plugins.dispatch_google.docs.plugin import replace_weblinks
+    from dispatch.plugins.dispatch_test.document import TestResource
+
+    assert not replace_weblinks(
+        client=TestResource(),
+        document_id="1234",
+        replacements={"key": "value"},
+    )


### PR DESCRIPTION
If the url of a hyperlink contains a placeholder, it will be replaced with the corresponding value in a replacements list.

For example, if we aim to substitute all instances of `{{name}}` in a Google Doc with `netflix`, a hyperlink that originally directed to `http://www.{{name}}.com` will be transformed into `http://www.netflix.com`