### PR TITLE
Adds routing to an incident's forms tab.

### DIFF
--- a/src/dispatch/static/dispatch/src/incident/EditSheet.vue
+++ b/src/dispatch/static/dispatch/src/incident/EditSheet.vue
@@ -138,8 +138,11 @@ export default {
     $route: {
       immediate: true,
       handler(newVal) {
-        if (newVal.meta && newVal.meta.showTimeline) {
+        if (!newVal.meta) return
+        if (newVal.meta.showTimeline) {
           this.tab = 3
+        } else if (newVal.meta.showForms) {
+          this.tab = 6
         }
       },
     },

--- a/src/dispatch/static/dispatch/src/incident/FormsTab.vue
+++ b/src/dispatch/static/dispatch/src/incident/FormsTab.vue
@@ -111,7 +111,7 @@ export default {
       "project_id",
       "table.options.filters",
     ]),
-    ...mapFields("incident", { selected_incident: "selected" }),
+    ...mapFields("incident", { selected_incident: "selected", project: "selected.project" }),
   },
   methods: {
     ...mapActions("forms", ["getAll", "createShow", "editShow", "showDeleteDialog"]),
@@ -123,17 +123,23 @@ export default {
         },
       }
     },
+    getFormsData() {
+      if (this.selected_incident) {
+        this.incident_id = this.selected_incident.id
+      }
+      if (this.project) {
+        this.project_id = this.project.id
+      }
+      this.getAll()
+    },
   },
   created() {
-    this.project_id = this.selected_incident.project.id
-    this.incident_id = this.selected_incident.id
-
-    this.getAll()
+    this.getFormsData()
 
     this.$watch(
-      (vm) => [vm.project, vm.selected_incident],
+      (vm) => [vm.project, vm.selected_incident, vm.project],
       () => {
-        this.getAll()
+        this.getFormsData()
       }
     )
   },

--- a/src/dispatch/static/dispatch/src/router/config.js
+++ b/src/dispatch/static/dispatch/src/router/config.js
@@ -169,6 +169,16 @@ export const protectedRoute = [
                 showTimeline: true,
               },
             },
+            {
+              path: "/:organization/incidents/:name/forms",
+              name: "IncidentTableEditForms",
+              component: () => import("@/incident/EditSheet.vue"),
+              props: true,
+              meta: {
+                showEditSheet: true,
+                showForms: true,
+              },
+            },
           ],
         },
       ],


### PR DESCRIPTION
Provides direct link to an incident's forms page.
Fixes a minor race condition bug.

How to test:
1. Navigate to `{DISPATCH_UI_URL}/default/incidents/{incident.name}/forms`