### PR TITLE
Updates the resource deletion call.

### DIFF
--- a/src/dispatch/plugins/dispatch_google/drive/drive.py
+++ b/src/dispatch/plugins/dispatch_google/drive/drive.py
@@ -5,6 +5,7 @@
     :license: Apache, see LICENSE for more details.
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
+
 import functools
 import io
 import json
@@ -276,7 +277,7 @@ def copy_file(client: Any, folder_id: str, file_id: str, new_file_name: str):
 
 def delete_file(client: Any, file_id: str):
     """Deletes a folder or file from a Google Drive."""
-    return make_call(client.files(), "trash", fileId=file_id, supportsAllDrives=True)
+    return make_call(client.files(), "delete", fileId=file_id, supportsAllDrives=True)
 
 
 def mark_as_readonly(


### PR DESCRIPTION
 The new deletion command is 'delete', not 'trash'.
 
 How to test:
1. Create an incident with the Google Drive and/or Google Doc plugins enabled.
2. Delete the incident. Both the folder and docs will be deleted.