### PR TITLE
updated delete to trashed

### DIFF
--- a/src/dispatch/plugins/dispatch_google/drive/drive.py
+++ b/src/dispatch/plugins/dispatch_google/drive/drive.py
@@ -276,8 +276,11 @@ def copy_file(client: Any, folder_id: str, file_id: str, new_file_name: str):
 
 
 def delete_file(client: Any, file_id: str):
-    """Deletes a folder or file from a Google Drive."""
-    return make_call(client.files(), "delete", fileId=file_id, supportsAllDrives=True)
+    """Moves a folder or file to Trash in a Google Drive."""
+    property = {"trashed": True}
+    return make_call(
+        client.files(), "update", fileId=file_id, supportsAllDrives=True, body=property
+    )
 
 
 def mark_as_readonly(


### PR DESCRIPTION
Google decided to change this at some point for v3, https://developers.google.com/drive/api/guides/v2-to-v3-reference. so now instead of calling trash, we have to set the property of trashed to True.