### PR TITLE
Add a Required column to the TagType table

### DIFF
--- a/src/dispatch/static/dispatch/src/tag_type/Table.vue
+++ b/src/dispatch/static/dispatch/src/tag_type/Table.vue
@@ -50,6 +50,9 @@
             <template #item.discoverability="{ item }">
               <span>{{ combine(item) }}</span>
             </template>
+            <template #item.required="{ value }">
+              <v-checkbox-btn :model-value="value" disabled />
+            </template>
             <template #item.exclusive="{ value }">
               <v-checkbox-btn :model-value="value" disabled />
             </template>
@@ -88,6 +91,7 @@ export default {
         { title: "Name", value: "name", sortable: true },
         { title: "Description", value: "description", sortable: false },
         { title: "Discoverability", value: "discoverability", sortable: false },
+        { title: "Required", value: "required", sortable: false },
         { title: "Exclusive", value: "exclusive", sortable: false },
         { title: "", key: "data-table-actions", sortable: false, align: "end" },
       ],


### PR DESCRIPTION
In https://github.com/Netflix/dispatch/pull/4430 / Add required as a tag type attribute, we added support for `Required` tag types, this PR adds a `Required` column that indicates whether a tag type is required in the backend tag type settings table.

After marking as required

![Screenshot 2024-02-26 at 12 49 07 PM](https://github.com/Netflix/dispatch/assets/114631109/223c9894-e01e-4a62-8a57-56586bb399d6)

Before marking as required

![Screenshot 2024-02-26 at 12 48 58 PM](https://github.com/Netflix/dispatch/assets/114631109/46cc99c4-3b39-40a3-81b6-30756c87c035)
