### PR TITLE
Add alert data to JSON file in Case thread, remove Raw Data button

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/enums.py
+++ b/src/dispatch/plugins/dispatch_slack/case/enums.py
@@ -39,7 +39,6 @@ class CaseShortcutCallbacks(DispatchEnum):
 
 class SignalNotificationActions(DispatchEnum):
     snooze = "signal-notification-snooze"
-    view = "signal-notification-view"
 
 
 class SignalSnoozeActions(DispatchEnum):

--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -1473,35 +1473,6 @@ def handle_report_submission_event(
     )
 
 
-@app.action(SignalNotificationActions.view, middleware=[button_context_middleware, db_middleware])
-def signal_button_click(
-    ack: Ack, body: dict, db_session: Session, context: BoltContext, client: WebClient
-):
-    ack()
-    signal = signal_service.get_signal_instance(
-        db_session=db_session, signal_instance_id=UUID(context["subject"].id)
-    )
-
-    # truncate text and redirect to ui
-    raw_text = json.dumps(signal.raw, indent=2)
-    if len(raw_text) > 2900:
-        blocks = [
-            Section(
-                text="The alert data exceeds Slack's viewing limit. Please go to the Dispatch Web UI for full details.\n"
-            ),
-            Section(text=f"```{raw_text[:2750]}...```"),
-        ]
-    else:
-        blocks = [Section(text=f"```{raw_text}```")]
-
-    modal = Modal(
-        title="Raw Signal",
-        blocks=blocks,
-        close="Close",
-    ).build()
-    client.views_open(trigger_id=body["trigger_id"], view=modal)
-
-
 @app.action(
     SignalEngagementActions.approve,
     middleware=[

--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -194,11 +194,6 @@ def create_signal_messages(case_id: int, channel_id: str, db_session: Session) -
     # Define the initial elements with "Raw Data" and "Snooze" buttons
     elements = [
         Button(
-            text="Raw Data",
-            action_id=SignalNotificationActions.view,
-            value=button_metadata,
-        ),
-        Button(
             text="Snooze",
             action_id=SignalNotificationActions.snooze,
             value=button_metadata,

--- a/src/dispatch/plugins/dispatch_slack/enums.py
+++ b/src/dispatch/plugins/dispatch_slack/enums.py
@@ -38,3 +38,4 @@ class SlackAPIErrorCode(DispatchEnum):
     VIEW_NOT_FOUND = "not_found"  # Could not find corresponding view for the provided view_id
     VIEW_EXPIRED = "expired_trigger_id"  # The provided trigger_id is no longer valid
     IS_ARCHIVED = "is_archived"  # Channel is archived
+    MISSING_SCOPE = "missing_scope"


### PR DESCRIPTION
This PR removes the `Raw Data` button from the Case thread and moves the alert JSON into a JSON file in a subsequent message in the thread. It does not appear to be possible to include the JSON file in the message where `Raw Data` was. I tested this locally by running through the signal instance creation flow via the `/signal_instances` API view.

This change makes the alert data more visible, adds syntax highlighting, and allows for larger alert JSON sizes (the Raw Data modal view was constrained to 2500 characters. 

![Screenshot 2024-03-01 at 5 23 16 PM](https://github.com/Netflix/dispatch/assets/114631109/3e6050b8-e027-451b-a5fb-f98f96518023)
