### PR TITLE
[Bugfix] - Timezone and expression construction for snooze created via Slack

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -616,7 +616,7 @@ def handle_snooze_submission_event(
         # Create the new filter from the form data
         if form_data.get(DefaultBlockIds.entity_select):
             entities = [
-                {"id": int(entity.value)}  # change entity.name to int(entity.value)
+                {"id": int(entity.value)}
                 for entity in form_data[DefaultBlockIds.entity_select]
             ]
         else:

--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -1,6 +1,6 @@
 import logging
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 import json
 import pytz
@@ -616,7 +616,7 @@ def handle_snooze_submission_event(
         # Create the new filter from the form data
         if form_data.get(DefaultBlockIds.entity_select):
             entities = [
-                {"name": entity.name, "value": entity.value}
+                {"id": int(entity.value)}  # change entity.name to int(entity.value)
                 for entity in form_data[DefaultBlockIds.entity_select]
             ]
         else:
@@ -656,7 +656,7 @@ def handle_snooze_submission_event(
         )
 
         # Calculate the new date by adding the timedelta object to the current date and time
-        date = datetime.now() + delta
+        date = datetime.now(tz=timezone.utc) + delta
 
         project = project_service.get(db_session=db_session, project_id=signal.project_id)
 


### PR DESCRIPTION
Snooze filters created via Slack did not correctly set timezone to UTC, so they were always in the past. Additionally, the expression that was constructed did not match the expected format:

```json
[
	{
		"or": [
			{
				"model": "Entity",
				"field": "id",
				"op": "==",
				"value": 35
			}
		]
	}
]
```

We update how we build the `filter` we pass to `create_filter_expression`:

```python
        if form_data.get(DefaultBlockIds.entity_select):
            entities = [
                {"id": int(entity.value)}
                for entity in form_data[DefaultBlockIds.entity_select]
            ]
```

Which results in the correct expression.

This was tested E2E locally, debug output:

```bash
FOUND f=<SignalFilter #42> on INSTANCE with f.mode='active' and f.action='snooze' and f.expiration=datetime.datetime(2024, 3, 12, 19, 30, 36, 895947)
mode f.mode='active' was active
mode f.mode='active' was snooze
expiration f.expiration=datetime.datetime(2024, 3, 12, 19, 30, 36, 895947) was not less than current time 2024-03-12 16:30:52.327661+00:00
running query
RUNNING QUERY query=<sqlalchemy.orm.query.Query object at 0x1341b6f10> SELECT signal_instance.id AS signal_instance_id, signal_instance.case_id AS signal_instance_case_id, signal_instance.engagement_thread_ts AS signal_instance_engagement_thread_ts, signal_instance.case_type_id AS signal_instance_case_type_id, signal_instance.case_priority_id AS signal_instance_case_priority_id, signal_instance.filter_action AS signal_instance_filter_action, signal_instance.canary AS signal_instance_canary, signal_instance.raw AS signal_instance_raw, signal_instance.signal_id AS signal_instance_signal_id, signal_instance.project_id AS signal_instance_project_id, signal_instance.created_at AS signal_instance_created_at, signal_instance.updated_at AS signal_instance_updated_at 
FROM signal_instance LEFT OUTER JOIN (assoc_signal_instance_entities AS assoc_signal_instance_entities_1 JOIN entity ON entity.id = assoc_signal_instance_entities_1.entity_id) ON signal_instance.id = assoc_signal_instance_entities_1.signal_instance_id 
WHERE signal_instance.signal_id = %(signal_id_1)s AND entity.id = %(id_1)s
RUNNING EXPRESSION f.expression=[{'or': [{'model': 'Entity', 'field': 'id', 'op': '==', 'value': 84}]}]
Expression found 1 instances
FILTER 1 signal_instance.filter_action=<SignalFilterAction.snooze: 'snooze'>
FILTER 2 signal_instance.filter_action=<SignalFilterAction.snooze: 'snooze'>
FILTER 3 signal_instance.filter_action=<SignalFilterAction.snooze: 'snooze'> && filtered=True
```