### PR TITLE
Set triage_at if case goes directly from open to closed

### DIFF
--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -370,6 +370,9 @@ def case_escalated_status_flow(case: Case, organization_slug: OrganizationSlug, 
 
 def case_closed_status_flow(case: Case, db_session=None):
     """Runs the case closed transition flow."""
+    # if the case missed the triage step, set the time to now
+    if not case.triage_at:
+        case.triage_at = datetime.utcnow()
     # we set the closed_at time
     case.closed_at = datetime.utcnow()
     db_session.add(case)


### PR DESCRIPTION
If a case goes directly from open to closed, set the `triage_at` time to the `closed_at` time.