### PR TITLE
Do not extract new entities from updated instances

### DIFF
--- a/src/dispatch/signal/flows.py
+++ b/src/dispatch/signal/flows.py
@@ -26,32 +26,6 @@ from dispatch.entity_type.models import EntityScopeEnum
 log = logging.getLogger(__name__)
 
 
-def signal_instance_update_flow(
-    signal_instance_id: int,
-    db_session: Session = None,
-):
-    """Create flow used by the API."""
-    signal_instance = signal_service.get_signal_instance(
-        db_session=db_session, signal_instance_id=signal_instance_id
-    )
-    # fetch `all` entities that should be associated with all signal definitions
-    entity_types = entity_type_service.get_all(
-        db_session=db_session, scope=EntityScopeEnum.all
-    ).all()
-    entity_types = signal_instance.signal.entity_types + entity_types
-
-    if entity_types:
-        entities = entity_service.find_entities(
-            db_session=db_session,
-            signal_instance=signal_instance,
-            entity_types=entity_types,
-        )
-        signal_instance.entities = entities
-        db_session.commit()
-
-    return signal_instance
-
-
 def signal_instance_create_flow(
     signal_instance_id: int,
     db_session: Session = None,

--- a/src/dispatch/signal/views.py
+++ b/src/dispatch/signal/views.py
@@ -112,11 +112,6 @@ def create_signal_instance(
         signal_instance = signal_service.update_instance(
             db_session=db_session, signal_instance_in=signal_instance_in
         )
-        # Note: we can do this because it's still relatively cheap, if we add more logic to the flow
-        # this will need to be moved to a background function (similar to case creation)
-        signal_instance = signal_instance_update_flow(
-            db_session=db_session, signal_instance_id=signal_instance.id
-        )
     return signal_instance
 
 

--- a/src/dispatch/signal/views.py
+++ b/src/dispatch/signal/views.py
@@ -45,8 +45,6 @@ from .service import (
     update_signal_filter,
 )
 
-from .flows import signal_instance_update_flow
-
 router = APIRouter()
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Race condition on entity extraction when a duplicate UUID goes through `create_signal_instance_flow` and `update_signal_instance_flow` simultaneously.