### PR TITLE
Updates classic cost model to append new response costs instead of overwriting them.

### DIFF
--- a/src/dispatch/incident/flows.py
+++ b/src/dispatch/incident/flows.py
@@ -1,7 +1,7 @@
 import logging
 
 from datetime import datetime
-from types import Optional
+from typing import Optional
 
 from sqlalchemy.orm import Session
 

--- a/src/dispatch/incident/flows.py
+++ b/src/dispatch/incident/flows.py
@@ -1,6 +1,7 @@
 import logging
 
 from datetime import datetime
+from types import Optional
 
 from sqlalchemy.orm import Session
 
@@ -9,6 +10,7 @@ from dispatch.conversation import flows as conversation_flows
 from dispatch.database.core import resolve_attr
 from dispatch.decorators import background_task
 from dispatch.document import flows as document_flows
+from dispatch.document.models import Document
 from dispatch.enums import DocumentResourceTypes
 from dispatch.enums import Visibility, EventType
 from dispatch.event import service as event_service
@@ -16,6 +18,7 @@ from dispatch.group import flows as group_flows
 from dispatch.group.enums import GroupType, GroupAction
 from dispatch.incident import service as incident_service
 from dispatch.incident.models import IncidentRead
+from dispatch.incident_cost import service as incident_cost_service
 from dispatch.individual import service as individual_service
 from dispatch.participant import flows as participant_flows
 from dispatch.participant import service as participant_service
@@ -392,25 +395,7 @@ def incident_active_status_flow(incident: Incident, db_session=None):
     conversation_flows.unarchive_conversation(incident=incident, db_session=db_session)
 
 
-def incident_stable_status_flow(incident: Incident, db_session=None):
-    """Runs the incident stable flow."""
-    # we set the stable time
-    incident.stable_at = datetime.utcnow()
-    db_session.add(incident)
-    db_session.commit()
-
-    if incident.incident_document:
-        # we update the incident document
-        document_flows.update_document(
-            document=incident.incident_document,
-            project_id=incident.project.id,
-            db_session=db_session,
-        )
-
-    if incident.incident_review_document:
-        log.info("The post-incident review document has already been created. Skipping creation...")
-        return
-
+def create_incident_review_document(incident: Incident, db_session=None) -> Optional[Document]:
     # we create the post-incident review document
     document_flows.create_document(
         subject=incident,
@@ -425,9 +410,23 @@ def incident_stable_status_flow(incident: Incident, db_session=None):
         project_id=incident.project.id,
         db_session=db_session,
     )
+    return incident.incident_review_document
+
+
+def handle_incident_review_updates(incident: Incident, db_session=None):
+    """Manages the steps following the creation of an incident review document.
+
+    This includes updating the incident costs with the incident review costss, notifying the participants, and bookmarking the document in the conversation.
+    """
+    # Add the incident review costs to the incident costs.
+    incident_cost_service.update_incident_response_cost(
+        incident_id=incident.id,
+        db_session=db_session,
+        incident_review=bool(incident.incident_review_document),
+    )
 
     if incident.incident_review_document and incident.conversation:
-        # we send a notification about the incident review document to the conversation
+        # Send a notification about the incident review document to the conversation
         send_incident_review_document_notification(
             incident.conversation.channel_id,
             incident.incident_review_document.weblink,
@@ -435,10 +434,35 @@ def incident_stable_status_flow(incident: Incident, db_session=None):
             db_session,
         )
 
-        # we bookmark the incident review document in the conversation
+        # Bookmark the incident review document in the conversation
         conversation_flows.add_conversation_bookmark(
             incident=incident, resource=incident.incident_review_document, db_session=db_session
         )
+
+
+def incident_stable_status_flow(incident: Incident, db_session=None):
+    """Runs the incident stable flow."""
+    # Set the stable time.
+    incident.stable_at = datetime.utcnow()
+    db_session.add(incident)
+    db_session.commit()
+
+    if incident.incident_document:
+        # Update the incident document.
+        document_flows.update_document(
+            document=incident.incident_document,
+            project_id=incident.project.id,
+            db_session=db_session,
+        )
+
+    if incident.incident_review_document:
+        log.info("The post-incident review document has already been created. Skipping creation...")
+        return
+
+    # Create the post-incident review document.
+    create_incident_review_document(incident=incident, db_session=db_session)
+
+    handle_incident_review_updates(incident=incident, db_session=db_session)
 
 
 def incident_closed_status_flow(incident: Incident, db_session=None):

--- a/src/dispatch/incident_cost/service.py
+++ b/src/dispatch/incident_cost/service.py
@@ -4,6 +4,7 @@ import math
 from typing import List, Optional
 
 from dispatch.database.core import SessionLocal
+from dispatch.cost_model.models import CostModelActivity
 from dispatch.incident import service as incident_service
 from dispatch.incident.enums import IncidentStatus
 from dispatch.incident.models import Incident
@@ -13,7 +14,7 @@ from dispatch.participant import service as participant_service
 from dispatch.participant.models import ParticipantRead
 from dispatch.participant_activity import service as participant_activity_service
 from dispatch.participant_activity.models import ParticipantActivityCreate
-from dispatch.participant_role.models import ParticipantRoleType
+from dispatch.participant_role.models import ParticipantRoleType, ParticipantRole
 from dispatch.plugin import service as plugin_service
 
 from .models import IncidentCost, IncidentCostCreate, IncidentCostUpdate
@@ -31,12 +32,12 @@ def get(*, db_session, incident_cost_id: int) -> Optional[IncidentCost]:
 
 def get_by_incident_id(*, db_session, incident_id: int) -> List[Optional[IncidentCost]]:
     """Gets incident costs by their incident id."""
-    return db_session.query(IncidentCost).filter(IncidentCost.incident_id == incident_id)
+    return db_session.query(IncidentCost).filter(IncidentCost.incident_id == incident_id).all()
 
 
 def get_by_incident_id_and_incident_cost_type_id(
     *, db_session, incident_id: int, incident_cost_type_id: int
-) -> List[Optional[IncidentCost]]:
+) -> Optional[IncidentCost]:
     """Gets incident costs by their incident id and incident cost type id."""
     return (
         db_session.query(IncidentCost)
@@ -51,9 +52,11 @@ def get_all(*, db_session) -> List[Optional[IncidentCost]]:
     return db_session.query(IncidentCost)
 
 
-def get_or_create(*, db_session, incident_cost_in: IncidentCostCreate) -> IncidentCost:
-    """Gets or creates an incident cost."""
-    if incident_cost_in.id:
+def get_or_create(
+    *, db_session, incident_cost_in: IncidentCostCreate | IncidentCostUpdate
+) -> IncidentCost:
+    """Gets or creates an incident cost object."""
+    if type(incident_cost_in) is IncidentCostUpdate and incident_cost_in.id:
         incident_cost = get(db_session=db_session, incident_cost_id=incident_cost_in.id)
     else:
         incident_cost = create(db_session=db_session, incident_cost_in=incident_cost_in)
@@ -124,44 +127,115 @@ def get_incident_review_hours(incident: Incident) -> int:
     return incident_review_prep + incident_review_meeting
 
 
+def get_hourly_rate(project) -> int:
+    """Calculates and rounds up the employee hourly rate within a project."""
+    return math.ceil(project.annual_employee_cost / project.business_year_hours)
+
+
+def calculate_response_cost(
+    hourly_rate, total_response_time_seconds, incident_review_hours=0
+) -> int:
+    """Calculates and rounds up the incident response cost."""
+    return math.ceil(
+        ((total_response_time_seconds / SECONDS_IN_HOUR) + incident_review_hours) * hourly_rate
+    )
+
+
+def get_or_create_incident_response_cost(
+    incident: Incident, db_session: SessionLocal
+) -> Optional[IncidentCost]:
+    response_cost_type = incident_cost_type_service.get_default(
+        db_session=db_session, project_id=incident.project.id
+    )
+
+    if not response_cost_type:
+        log.warning(
+            f"A default cost type for response cost doesn't exist in the {incident.project.name} project and organization {incident.project.organization.name}. Response costs for incident {incident.name} won't be calculated."
+        )
+        return None
+
+    incident_response_cost = get_by_incident_id_and_incident_cost_type_id(
+        db_session=db_session,
+        incident_id=incident.id,
+        incident_cost_type_id=response_cost_type.id,
+    )
+
+    if not incident_response_cost:
+        # we create the response cost if it doesn't exist
+        incident_cost_type = IncidentCostTypeRead.from_orm(response_cost_type)
+        incident_cost_in = IncidentCostCreate(
+            incident_cost_type=incident_cost_type, project=incident.project
+        )
+        incident_response_cost = create(db_session=db_session, incident_cost_in=incident_cost_in)
+        incident.incident_costs.append(incident_response_cost)
+        db_session.add(incident)
+        db_session.commit()
+
+    return incident_response_cost
+
+
+def fetch_incident_events(
+    incident: Incident, activity: CostModelActivity, oldest: str, db_session: SessionLocal
+) -> List[Optional[tuple[datetime.timestamp, str]]]:
+    plugin_instance = plugin_service.get_active_instance_by_slug(
+        db_session=db_session,
+        slug=activity.plugin_event.plugin.slug,
+        project_id=incident.project.id,
+    )
+    if not plugin_instance:
+        log.warning(
+            f"Cannot fetch cost model activity. Its associated plugin {activity.plugin_event.plugin.title} is not enabled."
+        )
+        return []
+
+    # Array of sorted (timestamp, user_id) tuples.
+    return plugin_instance.instance.fetch_incident_events(
+        db_session=db_session,
+        subject=incident,
+        plugin_event_id=activity.plugin_event.id,
+        oldest=oldest,
+    )
+
+
 def calculate_incident_response_cost_with_cost_model(
     incident: Incident, db_session: SessionLocal
 ) -> int:
-    """Calculates the cost of an incident using the incident's cost model."""
+    """Calculates the cost of an incident using the incident's cost model.
+
+    This function aggregates all new incident costs based on plugin activity since the last incident cost update.
+    If this is the first time performing cost calculation for this incident, it computes the total costs from the incident's creation.
+
+    Args:
+        incident: The incident to calculate the incident response cost for.
+        db_session: The database session.
+
+    Returns:
+        int: The incident response cost in dollars.
+    """
 
     participants_total_response_time_seconds = 0
+    oldest = "0"
+
+    # Used for determining whether we've previously calculated the incident cost.
+    current_time = datetime.now(tz=timezone.utc).replace(tzinfo=None)
+
+    incident_response_cost = get_or_create_incident_response_cost(
+        incident=incident, db_session=db_session
+    )
+    if not incident_response_cost:
+        log.warning(f"Cannot calculate incident response cost for incident {incident.name}.")
+        return 0
+
+    # Ignore events that happened before the last incident cost update.
+    if incident_response_cost.updated_at < current_time:
+        oldest = incident_response_cost.updated_at.replace(tzinfo=timezone.utc).timestamp()
 
     # Get the cost model. Iterate through all the listed activities we want to record.
     for activity in incident.cost_model.activities:
-        plugin_instance = plugin_service.get_active_instance_by_slug(
-            db_session=db_session,
-            slug=activity.plugin_event.plugin.slug,
-            project_id=incident.project.id,
-        )
-        if not plugin_instance:
-            log.warning(
-                f"Cannot fetch cost model activity. Its associated plugin {activity.plugin_event.plugin.title} is not enabled."
-            )
-            continue
-
-        oldest = "0"
-        response_cost_type = incident_cost_type_service.get_default(
-            db_session=db_session, project_id=incident.project.id
-        )
-        incident_response_cost = get_by_incident_id_and_incident_cost_type_id(
-            db_session=db_session,
-            incident_id=incident.id,
-            incident_cost_type_id=response_cost_type.id,
-        )
-        if incident_response_cost:
-            oldest = incident_response_cost.updated_at.replace(tzinfo=timezone.utc).timestamp()
 
         # Array of sorted (timestamp, user_id) tuples.
-        incident_events = plugin_instance.instance.fetch_incident_events(
-            db_session=db_session,
-            subject=incident,
-            plugin_event_id=activity.plugin_event.id,
-            oldest=oldest,
+        incident_events = fetch_incident_events(
+            incident=incident, activity=activity, oldest=oldest, db_session=db_session
         )
 
         for ts, user_id in incident_events:
@@ -189,101 +263,176 @@ def calculate_incident_response_cost_with_cost_model(
                     participant_response_time.total_seconds()
                 )
 
-    # Calculate and round up the hourly rate.
-    hourly_rate = math.ceil(
-        incident.project.annual_employee_cost / incident.project.business_year_hours
+    hourly_rate = get_hourly_rate(incident.project)
+    amount = calculate_response_cost(
+        hourly_rate=hourly_rate,
+        total_response_time_seconds=participants_total_response_time_seconds,
     )
-    additional_incident_cost = math.ceil(
-        (participants_total_response_time_seconds / SECONDS_IN_HOUR) * hourly_rate
-    )
-    return incident.total_cost + additional_incident_cost
+
+    return incident.total_cost + amount
 
 
-def calculate_incident_response_cost_with_classic_model(incident: Incident, incident_review=True):
-    participants_total_response_time_seconds = 0
+def get_participant_role_time_seconds(
+    incident: Incident, participant_role: ParticipantRole, start_at: datetime
+) -> int:
+    """Calculates the time spent by a participant in an incident role starting from a given time.
+
+    The participant's time spent in the incident role is adjusted based on the role's engagement multiplier.
+
+    Args:
+        incident: The incident the participant is part of.
+        participant_role: The role of the participant and the time they assumed and renounced the role.
+        start_at: Only time spent after this will be considered.
+
+    Returns:
+        int: The time spent by the participant in the incident role in seconds.
+    """
+    if participant_role.renounced_at and participant_role.renounced_at < start_at:
+        # skip calculating already-recorded activity
+        return 0
+
+    if participant_role.role == ParticipantRoleType.observer:
+        # skip calculating cost for participants with the observer role
+        return 0
+
+    if participant_role.activity == 0:
+        # skip calculating cost for roles that have no activity
+        return 0
+
+    participant_role_assumed_at = participant_role.assumed_at
+
+    # we set the renounced_at default time to the current time
+    participant_role_renounced_at = datetime.now(tz=timezone.utc).replace(tzinfo=None)
+
+    if incident.status == IncidentStatus.active:
+        if participant_role.renounced_at:
+            # the participant left the conversation or got assigned another role
+            # we use the role's renounced_at time
+            participant_role_renounced_at = participant_role.renounced_at
+    else:
+        # we set the renounced_at default time to the stable_at time if the stable_at time exists
+        if incident.stable_at:
+            participant_role_renounced_at = incident.stable_at
+
+        if participant_role.renounced_at:
+            # the participant left the conversation or got assigned another role
+            if participant_role.renounced_at < participant_role_renounced_at:
+                # we use the role's renounced_at time if it happened before the
+                # incident was marked as stable or closed
+                participant_role_renounced_at = participant_role.renounced_at
+
+    # the time the participant has spent in the incident role since the last incident cost update
+    participant_role_time = participant_role_renounced_at - max(
+        participant_role_assumed_at, start_at
+    )
+    if participant_role_time.total_seconds() < 0:
+        # the participant was added after the incident was marked as stable
+        return 0
+
+    # we calculate the number of hours the participant has spent in the incident role
+    participant_role_time_hours = participant_role_time.total_seconds() / SECONDS_IN_HOUR
+
+    # we make the assumption that participants only spend 8 hours a day working on the incident,
+    # if the incident goes past 24hrs
+    # TODO(mvilanova): adjust based on incident priority
+    if participant_role_time_hours > HOURS_IN_DAY:
+        days, hours = divmod(participant_role_time_hours, HOURS_IN_DAY)
+        participant_role_time_hours = math.ceil(((days * HOURS_IN_DAY) / 3) + hours)
+
+    # we make the assumption that participants spend more or less time based on their role
+    # and we adjust the time spent based on that
+    return (
+        participant_role_time_hours
+        * SECONDS_IN_HOUR
+        * get_engagement_multiplier(participant_role.role)
+    )
+
+
+def get_total_participant_roles_time_seconds(incident: Incident, start_at: datetime) -> int:
+    """Calculates the time spent by all participants in this incident starting from a given time.
+
+    The participant hours are adjusted based on their role(s)'s engagement multiplier.
+
+    Args:
+        incident: The incident the participant is part of.
+        participant_role: The role of the participant and the time they assumed and renounced the role.
+        start_at: Only time spent after this will be considered.
+
+    Returns:
+        int: The total time spent by all participants in the incident roles in seconds.
+
+    """
+    total_participants_roles_time_seconds = 0
     for participant in incident.participants:
-        participant_total_roles_time_seconds = 0
-
         for participant_role in participant.participant_roles:
-            if participant_role.role == ParticipantRoleType.observer:
-                # skip calculating cost for participants with the observer role
-                continue
-
-            if participant_role.activity == 0:
-                # skip calculating cost for roles that have no activity
-                continue
-
-            participant_role_assumed_at = participant_role.assumed_at
-            # we set the renounced_at default time to the current time
-            participant_role_renounced_at = datetime.utcnow()
-
-            if incident.status == IncidentStatus.active:
-                if participant_role.renounced_at:
-                    # the participant left the conversation or got assigned another role
-                    # we use the role's renounced_at time
-                    participant_role_renounced_at = participant_role.renounced_at
-            else:
-                # we set the renounced_at default time to the stable_at time if the stable_at time exists
-                if incident.stable_at:
-                    participant_role_renounced_at = incident.stable_at
-
-                if participant_role.renounced_at:
-                    # the participant left the conversation or got assigned another role
-                    if participant_role.renounced_at < participant_role_renounced_at:
-                        # we use the role's renounced_at time if it happened before the
-                        # incident was marked as stable or closed
-                        participant_role_renounced_at = participant_role.renounced_at
-
-            # we calculate the time the participant has spent in the incident role
-            participant_role_time = participant_role_renounced_at - participant_role_assumed_at
-
-            if participant_role_time.total_seconds() < 0:
-                # the participant was added after the incident was marked as stable
-                continue
-
-            # we calculate the number of hours the participant has spent in the incident role
-            participant_role_time_hours = participant_role_time.total_seconds() / SECONDS_IN_HOUR
-
-            # we make the assumption that participants only spend 8 hours a day working on the incident,
-            # if the incident goes past 24hrs
-            # TODO(mvilanova): adjust based on incident priority
-            if participant_role_time_hours > HOURS_IN_DAY:
-                days, hours = divmod(participant_role_time_hours, HOURS_IN_DAY)
-                participant_role_time_hours = math.ceil(((days * HOURS_IN_DAY) / 3) + hours)
-
-            # we make the assumption that participants spend more or less time based on their role
-            # and we adjust the time spent based on that
-            participant_role_time_seconds = int(
-                participant_role_time_hours
-                * SECONDS_IN_HOUR
-                * get_engagement_multiplier(participant_role.role)
+            total_participants_roles_time_seconds += get_participant_role_time_seconds(
+                incident=incident,
+                participant_role=participant_role,
+                start_at=start_at,
             )
+    return total_participants_roles_time_seconds
 
-            participant_total_roles_time_seconds += participant_role_time_seconds
 
-        participants_total_response_time_seconds += participant_total_roles_time_seconds
+def calculate_incident_response_cost_with_classic_model(
+    incident: Incident, db_session: SessionLocal, incident_review: bool = False
+) -> int:
+    """Calculates the cost of an incident using the classic incident cost model.
+
+    This function aggregates all new incident costs since the last incident cost update. If this is the first time performing cost calculation for this incident, it computes the total costs from the incident's creation.
+
+    Args:
+        incident: The incident to calculate the incident response cost for.
+        db_session: The database session.
+        incident_review: Whether to add the incident review costs in this calculation.
+
+    Returns:
+        int: The incident response cost in dollars.
+    """
+    last_update = incident.created_at
+    incident_review_hours = 0
+
+    # Used for determining whether we've previously calculated the incident cost.
+    curent_time = datetime.now(tz=timezone.utc).replace(tzinfo=None)
+
+    incident_response_cost = get_or_create_incident_response_cost(
+        incident=incident, db_session=db_session
+    )
+    if not incident_response_cost:
+        return 0
+
+    # Ignore activities that happened before the last incident cost update.
+    if incident_response_cost.updated_at < curent_time:
+        last_update = incident_response_cost.updated_at
+
+    # TODO: Implement a more robust way to ensure we are calculating the incident review hours only once.
     if incident_review:
         incident_review_hours = get_incident_review_hours(incident)
-    # we calculate and round up the hourly rate
-    hourly_rate = math.ceil(
-        incident.project.annual_employee_cost / incident.project.business_year_hours
+
+    # Aggregates the incident response costs accumulated since the last incident cost update
+    total_participants_roles_time_seconds = get_total_participant_roles_time_seconds(
+        incident, start_at=last_update
     )
 
-    # we calculate and round up the incident cost
-    return math.ceil(
-        ((participants_total_response_time_seconds / SECONDS_IN_HOUR) + incident_review_hours)
-        * hourly_rate
+    # Calculates and rounds up the incident cost
+    hourly_rate = get_hourly_rate(incident.project)
+    amount = calculate_response_cost(
+        hourly_rate=hourly_rate,
+        total_response_time_seconds=total_participants_roles_time_seconds,
+        incident_review_hours=incident_review_hours,
     )
+
+    return incident_response_cost.amount + amount
 
 
 def calculate_incident_response_cost(
-    incident_id: int, db_session: SessionLocal, incident_review=True
+    incident_id: int, db_session: SessionLocal, incident_review: bool = False
 ) -> int:
     """Calculates the response cost of a given incident."""
     incident = incident_service.get(db_session=db_session, incident_id=incident_id)
     if not incident:
         log.warning(f"Incident with id {incident_id} not found.")
         return 0
+
     if incident.cost_model and incident.cost_model.enabled:
         log.debug(f"Calculating {incident.name} incident cost with model {incident.cost_model}.")
         return calculate_incident_response_cost_with_cost_model(
@@ -291,45 +440,43 @@ def calculate_incident_response_cost(
         )
     else:
         log.debug("No incident cost model found. Defaulting to classic incident cost model.")
+
         return calculate_incident_response_cost_with_classic_model(
-            incident=incident, incident_review=incident_review
+            incident=incident, db_session=db_session, incident_review=incident_review
         )
 
 
-def update_incident_response_cost(incident_id: int, db_session: SessionLocal) -> int:
-    """Updates the response cost of a given incident."""
+def update_incident_response_cost(
+    incident_id: int, db_session: SessionLocal, incident_review: bool = False
+) -> int:
+    """Updates the response cost of a given incident.
+
+    Args:
+        incident_id: The incident id.
+        db_session: The database session.
+        incident_review: Whether to add the incident review costs in this calculation.
+
+    Returns:
+        int: The incident response cost in dollars.
+    """
     incident = incident_service.get(db_session=db_session, incident_id=incident_id)
-    response_cost_type = incident_cost_type_service.get_default(
-        db_session=db_session, project_id=incident.project.id
+    incident_response_cost = get_or_create_incident_response_cost(
+        incident=incident, db_session=db_session
     )
 
-    if response_cost_type is None:
-        log.warning(
-            f"A default cost type for response cost doesn't exist in the {incident.project.name} project and organization {incident.project.organization.name}. Response costs for incident {incident.name} won't be calculated."
-        )
+    if not incident_response_cost:
+        log.warning(f"Cannot calculate incident response cost for incident {incident.name}.")
         return 0
 
-    incident_response_cost = get_by_incident_id_and_incident_cost_type_id(
-        db_session=db_session,
-        incident_id=incident.id,
-        incident_cost_type_id=response_cost_type.id,
+    amount = calculate_incident_response_cost(
+        incident_id=incident.id, db_session=db_session, incident_review=incident_review
     )
-    if incident_response_cost is None:
-        # we create the response cost if it doesn't exist
-        incident_cost_type = IncidentCostTypeRead.from_orm(response_cost_type)
-        incident_cost_in = IncidentCostCreate(
-            incident_cost_type=incident_cost_type, project=incident.project
-        )
-        incident_response_cost = create(db_session=db_session, incident_cost_in=incident_cost_in)
-    amount = calculate_incident_response_cost(incident_id=incident.id, db_session=db_session)
-    # we don't need to update the cost amount if it hasn't changed
-    if incident_response_cost.amount == amount:
-        return incident_response_cost.amount
 
-    # we save the new incident cost amount
-    incident_response_cost.amount = amount
-    incident.incident_costs.append(incident_response_cost)
-    db_session.add(incident)
-    db_session.commit()
+    # we update the cost amount only if the incident cost has changed
+    if incident_response_cost.amount != amount:
+        incident_response_cost.amount = amount
+        incident.incident_costs.append(incident_response_cost)
+        db_session.add(incident)
+        db_session.commit()
 
     return incident_response_cost.amount

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -127,19 +127,12 @@ class ProjectFactory(BaseFactory):
     description = FuzzyText()
     default = False
     color = Faker().color()
+    organization = SubFactory(OrganizationFactory)
 
     class Meta:
         """Factory Configuration."""
 
         model = Project
-
-    @post_generation
-    def organization(self, create, extracted, **kwargs):
-        if not create:
-            return
-
-        if extracted:
-            self.organization_id = extracted.id
 
 
 class CostModelFactory(BaseFactory):

--- a/tests/incident_cost/test_incident_cost_service.py
+++ b/tests/incident_cost/test_incident_cost_service.py
@@ -5,6 +5,12 @@ def test_get(session, incident_cost):
     assert t_incident_cost.id == incident_cost.id
 
 
+def test_get_by_incident_id(session, incident_cost):
+    from dispatch.incident_cost.service import get_by_incident_id
+
+    assert get_by_incident_id(db_session=session, incident_id=incident_cost.incident_id)
+
+
 def test_get_all(session, incident_costs):
     from dispatch.incident_cost.service import get_all
 
@@ -24,6 +30,21 @@ def test_create(session, incident_cost_type, project):
         project=project,
     )
     incident_cost = create(db_session=session, incident_cost_in=incident_cost_in)
+    assert incident_cost
+
+
+def test_get_or_create__create(session, incident_cost_type, project):
+    from dispatch.incident_cost.service import get_or_create
+    from dispatch.incident_cost.models import IncidentCostCreate
+
+    amount = 10000
+
+    incident_cost_in = IncidentCostCreate(
+        amount=amount,
+        incident_cost_type=incident_cost_type,
+        project=project,
+    )
+    incident_cost = get_or_create(db_session=session, incident_cost_in=incident_cost_in)
     assert incident_cost
 
 
@@ -47,6 +68,36 @@ def test_delete(session, incident_cost):
     assert not get(db_session=session, incident_cost_id=incident_cost.id)
 
 
+def test_fetch_incident_event__enabled_plugins(
+    incident,
+    cost_model_activity,
+    session,
+    conversation_plugin_instance,
+):
+    from dispatch.incident_cost.service import fetch_incident_events
+
+    conversation_plugin_instance.project_id = incident.project.id
+    cost_model_activity.plugin_event.plugin = conversation_plugin_instance.plugin
+    conversation_plugin_instance.enabled = True
+
+    assert fetch_incident_events(incident, cost_model_activity, oldest="0", db_session=session)
+
+
+def test_fetch_incident_event__no_enabled_plugins(
+    incident,
+    cost_model_activity,
+    session,
+    conversation_plugin_instance,
+):
+    from dispatch.incident_cost.service import fetch_incident_events
+
+    conversation_plugin_instance.project_id = incident.project.id
+    cost_model_activity.plugin_event.plugin = conversation_plugin_instance.plugin
+    conversation_plugin_instance.enabled = False
+
+    assert not fetch_incident_events(incident, cost_model_activity, oldest="0", db_session=session)
+
+
 def test_calculate_incident_response_cost_with_cost_model(
     session,
     incident,
@@ -60,9 +111,7 @@ def test_calculate_incident_response_cost_with_cost_model(
     from datetime import timedelta
     import math
     from dispatch.incident.service import get
-    from dispatch.incident_cost.service import (
-        update_incident_response_cost,
-    )
+    from dispatch.incident_cost.service import update_incident_response_cost, get_hourly_rate
     from dispatch.incident_cost_type import service as incident_cost_type_service
     from dispatch.participant_activity.service import (
         get_all_incident_participant_activities_for_incident,
@@ -102,9 +151,7 @@ def test_calculate_incident_response_cost_with_cost_model(
     participants_total_response_time_seconds = timedelta(seconds=0)
     for activity in activities:
         participants_total_response_time_seconds += activity.ended_at - activity.started_at
-    hourly_rate = math.ceil(
-        incident.project.annual_employee_cost / incident.project.business_year_hours
-    )
+    hourly_rate = get_hourly_rate(incident.project)
     expected_incident_cost = (
         math.ceil(
             (participants_total_response_time_seconds.seconds / SECONDS_IN_HOUR) * hourly_rate
@@ -113,4 +160,191 @@ def test_calculate_incident_response_cost_with_cost_model(
     )
 
     assert cost
-    assert cost == expected_incident_cost == incident.total_cost
+    assert cost == expected_incident_cost
+    assert cost == incident.total_cost
+
+
+def test_calculate_incident_response_cost_with_cost_model__no_enabled_plugins(
+    session,
+    incident,
+    incident_cost_type,
+    cost_model_activity,
+    plugin_instance,
+    conversation,
+    participant,
+):
+    """Tests that the incident cost is calculated correctly when a cost model is enabled."""
+    from dispatch.incident.service import get
+    from dispatch.incident_cost.service import update_incident_response_cost
+    from dispatch.incident_cost_type import service as incident_cost_type_service
+    from dispatch.participant_activity.service import (
+        get_all_incident_participant_activities_for_incident,
+    )
+
+    # Disable the plugin instance for the cost model plugin event.
+    plugin_instance.project_id = incident.project.id
+    plugin_instance.enabled = False
+    cost_model_activity.plugin_event.plugin = plugin_instance.plugin
+    participant.user_conversation_id = "0XDECAFBAD"
+    participant.incident = incident
+
+    # Set up a default incident costs type.
+    for cost_type in incident_cost_type_service.get_all(db_session=session):
+        cost_type.default = False
+    incident_cost_type.default = True
+    incident_cost_type.project = incident.project
+
+    # Set up incident.
+    incident = get(db_session=session, incident_id=incident.id)
+    incident.cost_model.enabled = True
+    incident.cost_model.activities = [cost_model_activity]
+    incident.conversation = conversation
+
+    # Calculates and updates the incident cost.
+    cost = update_incident_response_cost(incident_id=incident.id, db_session=session)
+    activities = get_all_incident_participant_activities_for_incident(
+        db_session=session, incident_id=incident.id
+    )
+    assert not activities
+    assert not cost
+    assert not incident.total_cost
+
+
+def test_calculate_incident_response_cost_without_cost_model(
+    incident, session, incident_cost_type, participant_role, participant
+):
+    """Tests that the incident response cost is created and calculated correctly with the classic cost model."""
+    from datetime import timedelta, datetime, UTC
+    from dispatch.incident.service import get
+    from dispatch.incident_cost.service import calculate_incident_response_cost_with_classic_model
+    from dispatch.incident_cost_type import service as incident_cost_type_service
+
+    # Set up a default incident costs type.
+    for cost_type in incident_cost_type_service.get_all(db_session=session):
+        cost_type.default = False
+    incident_cost_type.default = True
+    incident_cost_type.project = incident.project
+
+    # Set up timestamps
+    incident.created_at = (datetime.now(UTC) - timedelta(hours=1)).replace(tzinfo=None)
+
+    # Set up incident participants
+    participant_role.participant = participant
+    participant_role.activity = 1
+    participant_role.assumed_at = (datetime.now(UTC) - timedelta(hours=1)).replace(tzinfo=None)
+    incident.participants.append(participant_role.participant)
+
+    updated_incident_cost = calculate_incident_response_cost_with_classic_model(
+        incident=incident, db_session=session, incident_review=False
+    )
+
+    assert updated_incident_cost
+
+
+def test_calculate_incident_response_cost_without_cost_model__update_cost(
+    incident, session, incident_cost_type, participant_role, participant, incident_cost
+):
+    """Tests that the incident response cost is updated correctly with the classic cost model."""
+    from datetime import timedelta, datetime, UTC
+
+    from dispatch.incident import service as incident_service
+    from dispatch.incident_cost.service import (
+        calculate_incident_response_cost_with_classic_model,
+    )
+    from dispatch.incident_cost_type import service as incident_cost_type_service
+
+    incident = incident_service.get(db_session=session, incident_id=incident.id)
+
+    # Use a large annual_employee_cost to make the incident cost updates more noticeable.
+    incident.project.annual_employee_cost = 100000000
+
+    # Set up a default incident costs type.
+    for cost_type in incident_cost_type_service.get_all(db_session=session):
+        cost_type.default = False
+    incident_cost_type.default = True
+    incident_cost_type.project = incident.project
+
+    # Set up timestamps
+    incident.created_at = (datetime.now(UTC) - timedelta(hours=1)).replace(tzinfo=None)
+
+    # Create initial incident response cost.
+    incident_cost.incident_cost_type = incident_cost_type
+    incident_cost.incident = incident
+
+    # Set up incident participants.
+    participant_role.participant = participant
+    participant_role.activity = 1
+    participant_role.assumed_at = (datetime.now(UTC) - timedelta(hours=1)).replace(tzinfo=None)
+    incident.participants.append(participant_role.participant)
+
+    initial_incident_cost = incident_cost.amount
+
+    updated_incident_cost = calculate_incident_response_cost_with_classic_model(
+        incident=incident, db_session=session, incident_review=False
+    )
+
+    assert updated_incident_cost
+    assert initial_incident_cost < updated_incident_cost
+
+
+def test_update_incident_response_cost(incident, session, incident_cost_type):
+    from dispatch.incident import service as incident_service
+    from dispatch.incident_cost.service import (
+        update_incident_response_cost,
+        get_by_incident_id_and_incident_cost_type_id,
+        get_hourly_rate,
+    )
+    from dispatch.incident_cost_type import service as incident_cost_type_service
+
+    # Set up a default incident costs type.
+    for cost_type in incident_cost_type_service.get_all(db_session=session):
+        cost_type.default = False
+    incident_cost_type.default = True
+    incident_cost_type.project = incident.project
+
+    incident = incident_service.get(db_session=session, incident_id=incident.id)
+    incident.cost_model = None
+
+    # Create the inital incident response cost.
+    incident_response_cost = update_incident_response_cost(
+        incident_id=incident.id, db_session=session, incident_review=False
+    )
+
+    # Validate incident cost retrieval.
+    t_incident_response_cost = get_by_incident_id_and_incident_cost_type_id(
+        db_session=session, incident_id=incident.id, incident_cost_type_id=incident_cost_type.id
+    )
+    assert t_incident_response_cost
+    assert t_incident_response_cost.amount == incident_response_cost
+
+    # Add the incident review cost to the incident response cost.
+    incident_review_cost = update_incident_response_cost(
+        incident_id=incident.id, db_session=session, incident_review=True
+    )
+
+    # Validate the cost of the incident review.
+    # With 1 participant, the incident review cost should be equal to the hourly rate.
+    assert incident_review_cost == incident_response_cost + get_hourly_rate(incident.project)
+
+
+def test_update_incident_response_cost__fail(incident, session):
+    from dispatch.incident import service as incident_service
+    from dispatch.incident_cost.service import (
+        update_incident_response_cost,
+        get_by_incident_id,
+    )
+    from dispatch.incident_cost_type import service as incident_cost_type_service
+
+    incident = incident_service.get(db_session=session, incident_id=incident.id)
+
+    # Ensure there is no default cost type for this project.
+    for cost_type in incident_cost_type_service.get_all(db_session=session):
+        cost_type.default = False
+
+    # Fail to create the inital incident response cost.
+    assert not update_incident_response_cost(
+        incident_id=incident.id, db_session=session, incident_review=False
+    )
+
+    # Validate that the incident cost was not created nor saved in the database.
+    assert not get_by_incident_id(db_session=session, incident_id=incident.id)

--- a/tests/incident_cost/test_incident_cost_service.py
+++ b/tests/incident_cost/test_incident_cost_service.py
@@ -215,7 +215,6 @@ def test_calculate_incident_response_cost_without_cost_model(
 ):
     """Tests that the incident response cost is created and calculated correctly with the classic cost model."""
     from datetime import timedelta, datetime, UTC
-    from dispatch.incident.service import get
     from dispatch.incident_cost.service import calculate_incident_response_cost_with_classic_model
     from dispatch.incident_cost_type import service as incident_cost_type_service
 


### PR DESCRIPTION
This PR adds the following changes:
- Adds the incident review cost to the incident only when the incident review document is created.
- Updates the classic cost model to add new incident response costs since the last update instead of recalculating the entire cost.
- Refactors the Incident Cost service.
- Increases code coverage of the Incident Cost service to 90%.
- Improves documentation.