### PR TITLE
Fixes calls to renamed incident cost functions

### DIFF
--- a/src/dispatch/incident_cost/scheduled.py
+++ b/src/dispatch/incident_cost/scheduled.py
@@ -12,7 +12,7 @@ from dispatch.scheduler import scheduler
 
 from .service import (
     calculate_incident_response_cost,
-    get_or_create_incident_response_cost,
+    get_or_create_default_incident_response_cost,
 )
 
 
@@ -38,7 +38,9 @@ def calculate_incidents_response_cost(db_session: SessionLocal, project: Project
     for incident in incidents:
         try:
             # we get the response cost for the given incident
-            incident_response_cost = get_or_create_incident_response_cost(incident, db_session)
+            incident_response_cost = get_or_create_default_incident_response_cost(
+                incident, db_session
+            )
 
             # we don't need to update the cost of closed incidents
             # if they already have a response cost and this was updated

--- a/src/dispatch/incident_cost/scheduled.py
+++ b/src/dispatch/incident_cost/scheduled.py
@@ -6,16 +6,13 @@ from dispatch.database.core import SessionLocal
 from dispatch.decorators import scheduled_project_task, timer
 from dispatch.incident import service as incident_service
 from dispatch.incident.enums import IncidentStatus
-from dispatch.incident_cost.models import IncidentCostCreate
 from dispatch.incident_cost_type import service as incident_cost_type_service
-from dispatch.incident_cost_type.models import IncidentCostTypeRead
 from dispatch.project.models import Project
 from dispatch.scheduler import scheduler
 
 from .service import (
     calculate_incident_response_cost,
-    create,
-    get_by_incident_id_and_incident_cost_type_id,
+    get_or_create_incident_response_cost,
 )
 
 
@@ -41,11 +38,7 @@ def calculate_incidents_response_cost(db_session: SessionLocal, project: Project
     for incident in incidents:
         try:
             # we get the response cost for the given incident
-            incident_response_cost = get_by_incident_id_and_incident_cost_type_id(
-                db_session=db_session,
-                incident_id=incident.id,
-                incident_cost_type_id=response_cost_type.id,
-            )
+            incident_response_cost = get_or_create_incident_response_cost(incident, db_session)
 
             # we don't need to update the cost of closed incidents
             # if they already have a response cost and this was updated
@@ -54,16 +47,6 @@ def calculate_incidents_response_cost(db_session: SessionLocal, project: Project
                 if incident_response_cost:
                     if incident_response_cost.updated_at > incident.stable_at:
                         continue
-
-            if incident_response_cost is None:
-                # we create the response cost if it doesn't exist
-                incident_cost_type = IncidentCostTypeRead.from_orm(response_cost_type)
-                incident_cost_in = IncidentCostCreate(
-                    incident_cost_type=incident_cost_type, project=project
-                )
-                incident_response_cost = create(
-                    db_session=db_session, incident_cost_in=incident_cost_in
-                )
 
             # we calculate the response cost amount
             amount = calculate_incident_response_cost(incident.id, db_session)

--- a/src/dispatch/incident_cost/service.py
+++ b/src/dispatch/incident_cost/service.py
@@ -161,9 +161,13 @@ def get_default_incident_response_cost(
     )
 
 
-def get_or_create_incident_response_cost(
+def get_or_create_default_incident_response_cost(
     incident: Incident, db_session: SessionLocal
 ) -> Optional[IncidentCost]:
+    """Gets or creates the default incident cost for an incident.
+
+    The default incident cost is the cost associated with the participant effort in an incident's response.
+    """
     response_cost_type = incident_cost_type_service.get_default(
         db_session=db_session, project_id=incident.project.id
     )
@@ -239,7 +243,7 @@ def calculate_incident_response_cost_with_cost_model(
     # Used for determining whether we've previously calculated the incident cost.
     current_time = datetime.now(tz=timezone.utc).replace(tzinfo=None)
 
-    incident_response_cost = get_or_create_incident_response_cost(
+    incident_response_cost = get_or_create_default_incident_response_cost(
         incident=incident, db_session=db_session
     )
     if not incident_response_cost:
@@ -414,7 +418,7 @@ def calculate_incident_response_cost_with_classic_model(
     # Used for determining whether we've previously calculated the incident cost.
     curent_time = datetime.now(tz=timezone.utc).replace(tzinfo=None)
 
-    incident_response_cost = get_or_create_incident_response_cost(
+    incident_response_cost = get_or_create_default_incident_response_cost(
         incident=incident, db_session=db_session
     )
     if not incident_response_cost:

--- a/src/dispatch/incident_cost/service.py
+++ b/src/dispatch/incident_cost/service.py
@@ -141,6 +141,26 @@ def calculate_response_cost(
     )
 
 
+def get_default_incident_response_cost(
+    incident: Incident, db_session: SessionLocal
+) -> Optional[IncidentCost]:
+    response_cost_type = incident_cost_type_service.get_default(
+        db_session=db_session, project_id=incident.project.id
+    )
+
+    if not response_cost_type:
+        log.warning(
+            f"A default cost type for response cost doesn't exist in the {incident.project.name} project and organization {incident.project.organization.name}. Response costs for incident {incident.name} won't be calculated."
+        )
+        return None
+
+    return get_by_incident_id_and_incident_cost_type_id(
+        db_session=db_session,
+        incident_id=incident.id,
+        incident_cost_type_id=response_cost_type.id,
+    )
+
+
 def get_or_create_incident_response_cost(
     incident: Incident, db_session: SessionLocal
 ) -> Optional[IncidentCost]:
@@ -460,17 +480,18 @@ def update_incident_response_cost(
         int: The incident response cost in dollars.
     """
     incident = incident_service.get(db_session=db_session, incident_id=incident_id)
-    incident_response_cost = get_or_create_incident_response_cost(
+
+    amount = calculate_incident_response_cost(
+        incident_id=incident.id, db_session=db_session, incident_review=incident_review
+    )
+
+    incident_response_cost = get_default_incident_response_cost(
         incident=incident, db_session=db_session
     )
 
     if not incident_response_cost:
         log.warning(f"Cannot calculate incident response cost for incident {incident.name}.")
         return 0
-
-    amount = calculate_incident_response_cost(
-        incident_id=incident.id, db_session=db_session, incident_review=incident_review
-    )
 
     # we update the cost amount only if the incident cost has changed
     if incident_response_cost.amount != amount:

--- a/src/dispatch/incident_cost/service.py
+++ b/src/dispatch/incident_cost/service.py
@@ -234,7 +234,7 @@ def calculate_incident_response_cost_with_cost_model(
     """
 
     participants_total_response_time_seconds = 0
-    oldest = "0"
+    oldest = incident.created_at.replace(tzinfo=timezone.utc).timestamp()
 
     # Used for determining whether we've previously calculated the incident cost.
     current_time = datetime.now(tz=timezone.utc).replace(tzinfo=None)


### PR DESCRIPTION
How to test:

Run `dispatch scheduler start` and ensure that the incident costs are correctly updated.