### PR TITLE
[Bug] Adding the message template in SlackAPIError when channel is archived

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -217,7 +217,7 @@ class SlackConversationPlugin(ConversationPlugin):
             error = exception.response["error"]
             if error == SlackAPIErrorCode.IS_ARCHIVED:
                 # swallow send errors if the channel is archived
-                message = f"SlackAPIError trying to send: {exception.response}. Message: {text}. Type: {notification_type}"
+                message = f"SlackAPIError trying to send: {exception.response}. Message: {text}. Type: {notification_type}. Template: {message_template}"
                 logger.error(message)
             else:
                 raise exception


### PR DESCRIPTION
Something is causing the an attempt to do something with an archived incident channel and incident. In this case, in the incident commander is removed from the channel because the slack account is deactivated and it is unclear why there is a job trying to add the person back. Trying to figure out where this is happening and the only thing, aside from updating all the calls with different notifications types, was to include the template. Then when/if it happens again, we can trace where it is coming from.