### PR TITLE
[Bug] moved participant lookup

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -273,12 +273,11 @@ class SlackConversationPlugin(ConversationPlugin):
             send_ephemeral_message(client, conversation_id, user_id, text, blocks)
 
     def add(self, conversation_id: str, participants: List[str]):
-        """Adds users to conversation."""
+        """Adds users to conversation if it is not archived."""
         client = create_slack_client(self.configuration)
-        participants = [resolve_user(client, p)["id"] for p in set(participants)]
-
         archived = conversation_archived(client, conversation_id)
         if not archived:
+            participants = [resolve_user(client, p)["id"] for p in set(participants)]
             add_users_to_conversation(client, conversation_id, participants)
 
     def add_to_thread(self, conversation_id: str, thread_id: str, participants: List[str]):


### PR DESCRIPTION
Moved participant lookup to occur only if it is not archived because the participants will only be added if it is not archived. This created an issue when the participant look up failed because the slack account is deactivated, but the channel was archived so no need for any action anyway.