### PR TITLE
[Bugs] Check incident status before re-adding IC

### DIFF
--- a/src/dispatch/incident/flows.py
+++ b/src/dispatch/incident/flows.py
@@ -1028,7 +1028,7 @@ def incident_remove_participant_flow(
 
                     return
 
-    if user_email == incident.commander.individual.email:
+    if incident.status != IncidentStatus.closed and user_email == incident.commander.individual.email:
         # we add the participant to the conversation
         conversation_flows.add_incident_participants(
             incident=incident, participant_emails=[user_email], db_session=db_session


### PR DESCRIPTION
If an incident is closed, we expect the incident conversation to be closed as well. This will cause errors in slack, if we try to add someone to an archived conversation and send a message to that archived conversation.