### PR TITLE
Handle slack rate limit for does_user_exist

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -145,7 +145,7 @@ def get_user_info_by_email(client: WebClient, email: str) -> dict:
 def does_user_exist(client: WebClient, email: str) -> bool:
     """Checks if a user exists in the Slack workspace by their email."""
     try:
-        user = get_user_info_by_email(client, email)
+        get_user_info_by_email(client, email)
         return True
     except SlackApiError as e:
         if e.response["error"] == SlackAPIErrorCode.USERS_NOT_FOUND:

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -145,11 +145,7 @@ def get_user_info_by_email(client: WebClient, email: str) -> dict:
 def does_user_exist(client: WebClient, email: str) -> bool:
     """Checks if a user exists in the Slack workspace by their email."""
     try:
-        client.api_call(
-            api_method=SlackAPIGetEndpoints.users_lookup_by_email,
-            http_verb="GET",
-            params={"email": email},
-        )
+        user = get_user_info_by_email(client, email)
         return True
     except SlackApiError as e:
         if e.response["error"] == SlackAPIErrorCode.USERS_NOT_FOUND:


### PR DESCRIPTION
Update `does_user_exist` in slack/service.py to use the `get_user_info_by_email` and `make_call` functions. If the USER_NOT_FOUND error occurs from `make_call` it is expected to be raised again and handled in `does_user_exist`