### PR TITLE
pagerduty_plugin: Updates method for accessing current on-call email

### DIFF
--- a/src/dispatch/plugins/dispatch_pagerduty/service.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/service.py
@@ -86,30 +86,17 @@ def get_oncall_email(client: APISession, service_id: str) -> str:
     escalation_policy = get_escalation_policy(
         client=client, escalation_policy_id=escalation_policy_id
     )
-    filter_name = (
-        f"{escalation_policy['escalation_rules'][0]['targets'][0]['type'].split('_')[0]}_ids[]"
-    )
-    filter_value = escalation_policy["escalation_rules"][0]["targets"][0]["id"]
 
-    oncalls = list(
-        client.iter_all(
-            "oncalls",  # method
-            {
-                filter_name: [filter_value],
-                "escalation_policy_ids[]": [escalation_policy_id],
-            },  # params
-        )
-    )
+    current_oncall = escalation_policy['current_oncall']
 
-    if oncalls:
-        user_id = list(oncalls)[0]["user"]["id"]
-    else:
+    if not current_oncall:
         raise Exception(
             f"No users could be found for this pagerduty escalation policy ({escalation_policy_id}). Is there a schedule associated?"
         )
-    user = get_user(client=client, user_id=user_id)
 
-    return user["email"]
+    current_oncall_user_email = current_oncall['user']['email']
+
+    return current_oncall_user_email
 
 
 def page_oncall(


### PR DESCRIPTION
## Issue
At present, if a Pagerduty team has more than one on-call schedule (say, for US & India teams), if the first schedule is not the active schedule, engaging the on-call engineer will fail with:
```
Exception: No users could be found for this pagerduty escalation policy (ID). Is there a schedule associated?
```

because requestor looks like this:
```
filter_value = escalation_policy["escalation_rules"][0]["targets"][0]["id"]
```

and the API response looks like this:

```json
"escalation_policy": {
        "id": "redacted",
        "type": "escalation_policy",
        "summary": "Data Team",
        "self": "https://api.pagerduty.com/escalation_policies/REDACTED",
        "html_url": "https://company.pagerduty.com/escalation_policies/REDACTED",
        "name": "Data Team",
        "escalation_rules": [
            {
                "id": "redacted",
                "escalation_delay_in_minutes": 30,
                "targets": [
                    {
                        "id": "redacted",
                        "type": "schedule_reference",
                        "summary": "Schedule 1",
                        "self": "https://api.pagerduty.com/schedules/REDACTED",
                        "html_url": "https://company.pagerduty.com/schedules/REDACTED"
                    },
                    {
                        "id": "redacted",
                        "type": "schedule_reference",
                        "summary": "Schedule 2",
                        "self": "https://api.pagerduty.com/schedules/REDACTED",
                        "html_url": "https://company.pagerduty.com/schedules/REDACTED"
                    }
                ],
 ```

## Resolution
The API response includes `current_oncalls` key, which simplifies this logic by not needing to iterate over `targets` and it includes the on-call engineer's email address, negating the need for a lookup.

[Example PagerDuty API response for /api/v1/escalation_policies/](https://github.com/Netflix/dispatch/files/14984318/sample-pd-response.json)
