### PR TITLE
Fixes incident naming and incident resource creation during active incident creation.

### DIFF
--- a/src/dispatch/incident/flows.py
+++ b/src/dispatch/incident/flows.py
@@ -358,6 +358,7 @@ def incident_create_resources_flow(
     return incident_create_resources(incident=incident, db_session=db_session)
 
 
+@background_task
 def incident_create_flow(
     *,
     organization_slug: str,


### PR DESCRIPTION
Previously incidents created with the active status were not being populated with incident names and incident resources. This is due to a timeout with the `@timer` decorator in `incident_service.get()`.
This bug fix reintroduces the `@background_task` decorator to `incident_create_flow()`, enabling these resources to be created.