### PR TITLE
bug: Updates is_bot to support bots defined in apps.event.authorizations.list

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/middleware.py
+++ b/src/dispatch/plugins/dispatch_slack/middleware.py
@@ -208,6 +208,13 @@ def is_bot(request: BoltRequest) -> bool:
     if user == "USLACKBOT":
         return True
 
+    authorizations = body.get("authorizations")
+
+    if authorizations:
+        for auth in authorizations:
+            if auth.get("is_bot") == True:
+                return True
+
     auth_result = request.context.authorize_result
     user_id = request.context.user_id
     bot_id = body.get("event", {}).get("bot_id")


### PR DESCRIPTION
## Issue
Immediately upon creating a channel, our company invites a compliance bot to the channel.  This bot advertises itself to the channel using the `is_bot` property in [apps.events.authorizations.list](https://api.slack.com/methods/apps.event.authorizations.list#examples).  Because this heuristic is not used in [is_bot](https://github.com/Netflix/dispatch/blob/master/src/dispatch/plugins/dispatch_slack/middleware.py#L205), it is not recognized as a bot & throws an error when attempting to read the profile / email:

```python
ERROR:slack_bolt.App:'email'
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/slack_bolt/app/app.py", line 536, in dispatch
    middleware_resp, next_was_not_called = listener.run_middleware(req=req, resp=resp)
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/slack_bolt/listener/listener.py", line 51, in run_middleware
    resp = m.process(req=req, resp=resp, next=next_)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/slack_bolt/middleware/custom_middleware.py", line 34, in process
    return self.func(
           ^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/dispatch/decorators.py", line 134, in wrapper
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/dispatch/plugins/dispatch_slack/middleware.py", line 281, in user_middleware
    email = client.users_info(user=user_id)["user"]["profile"]["email"]
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
KeyError: 'email'
```

## Change
This augments the logic of `is_bot` to read the authorizations list to determine if the user in question is a bot while being backwards compatible with its existing heuristics.