### PR TITLE
fix: pagerduty_plugin - Updates method for accessing current on-call email

### DIFF
--- a/src/dispatch/plugins/dispatch_pagerduty/service.py
+++ b/src/dispatch/plugins/dispatch_pagerduty/service.py
@@ -86,6 +86,11 @@ def get_oncall_email(client: APISession, service_id: str) -> str:
     escalation_policy = get_escalation_policy(
         client=client, escalation_policy_id=escalation_policy_id
     )
+
+    current_oncall = escalation_policy.get('current_oncall')
+    if current_oncall:
+        return current_oncall.get('user', {}).get('email') if current_oncall else None
+
     filter_name = (
         f"{escalation_policy['escalation_rules'][0]['targets'][0]['type'].split('_')[0]}_ids[]"
     )


### PR DESCRIPTION
## Issue
At present, if a Pagerduty team has more than one on-call schedule (say, for US & India teams), if the first schedule is not the active schedule, engaging the on-call engineer will fail with:
```
Exception: No users could be found for this pagerduty escalation policy (ID). Is there a schedule associated?
```

because requestor looks like this:
```
filter_value = escalation_policy["escalation_rules"][0]["targets"][0]["id"]
```

and the API response looks like this:

```json
"escalation_policy": {
        "id": "redacted",
        "type": "escalation_policy",
        "summary": "Data Team",
        "self": "https://api.pagerduty.com/escalation_policies/REDACTED",
        "html_url": "https://company.pagerduty.com/escalation_policies/REDACTED",
        "name": "Data Team",
        "escalation_rules": [
            {
                "id": "redacted",
                "escalation_delay_in_minutes": 30,
                "targets": [
                    {
                        "id": "redacted",
                        "type": "schedule_reference",
                        "summary": "Schedule 1",
                        "self": "https://api.pagerduty.com/schedules/REDACTED",
                        "html_url": "https://company.pagerduty.com/schedules/REDACTED"
                    },
                    {
                        "id": "redacted",
                        "type": "schedule_reference",
                        "summary": "Schedule 2",
                        "self": "https://api.pagerduty.com/schedules/REDACTED",
                        "html_url": "https://company.pagerduty.com/schedules/REDACTED"
                    }
                ],
 ```

## Resolution

If you watch the network call on Pagerduty's escalation policy page, the API response to `/api/v1/escalation_policies` includes a `current_oncalls` key, which simplifies this logic by not needing to iterate over `targets` and it includes the on-call engineer's email address, negating the need for a lookup.

This update augments the logic to check for that value & return the on-call email (if it exists).  If not, it continues through the legacy logic.

### Example PagerDuty API response for /api/v1/escalation_policies/

```json
{
    "escalation_policy": {
        "id": "redacted",
        "type": "escalation_policy",
        "summary": "Data Team",
        "self": "https://api.pagerduty.com/escalation_policies/REDACTED",
        "html_url": "https://company.pagerduty.com/escalation_policies/REDACTED",
        "name": "Data Team",
        "escalation_rules": [
            {
                "id": "redacted",
                "escalation_delay_in_minutes": 30,
                "targets": [
                    {
                        "id": "redacted",
                        "type": "schedule_reference",
                        "summary": "Schedule 1",
                        "self": "https://api.pagerduty.com/schedules/REDACTED",
                        "html_url": "https://company.pagerduty.com/schedules/REDACTED"
                    },
                    {
                        "id": "redacted",
                        "type": "schedule_reference",
                        "summary": "Schedule 2",
                        "self": "https://api.pagerduty.com/schedules/REDACTED",
                        "html_url": "https://company.pagerduty.com/schedules/REDACTED"
                    }
                ],
                "current_oncall": {
                    "user": {
                        "id": "redacted",
                        "name": "User 1",
                        "email": "user1@example.com",
                        "time_zone": "Pacific Time (US & Canada)",
                        "color": "blue-violet",
                        "role": "observer"
                    },
                    "start": "2024-04-15T15:00:00Z",
                    "end": "2024-04-16T03:00:00Z",
                    "escalation_target": {
                        "id": "redacted",
                        "type": "schedule_reference",
                        "summary": "Schedule 2",
                        "self": "https://api.pagerduty.com/schedules/REDACTED",
                        "html_url": "https://company.pagerduty.com/schedules/REDACTED"
                    }
                },
                "current_oncalls": [
                    {
                        "user": {
                            "id": "redacted",
                            "name": "User 1",
                            "email": "user1@example.com",
                            "time_zone": "Pacific Time (US & Canada)",
                            "color": "blue-violet",
                            "role": "observer"
                        },
                        "start": "2024-04-15T15:00:00Z",
                        "end": "2024-04-16T03:00:00Z",
                        "escalation_target": {
                            "id": "redacted",
                            "type": "schedule_reference",
                            "summary": "Schedule 2",
                            "self": "https://api.pagerduty.com/schedules/REDACTED",
                            "html_url": "https://company.pagerduty.com/schedules/REDACTED"
                        }
                    }
                ],
                "escalation_rule_assignment_strategy": {
                    "type": "assign_to_everyone"
                }
            },
            {
                "id": "redacted",
                "escalation_delay_in_minutes": 30,
                "targets": [
                    {
                        "id": "redacted",
                        "type": "user_reference",
                        "summary": "User 2",
                        "self": "https://api.pagerduty.com/users/REDACTED",
                        "html_url": "https://company.pagerduty.com/users/REDACTED"
                    },
                    {
                        "id": "redacted",
                        "type": "user_reference",
                        "summary": "User 3",
                        "self": "https://api.pagerduty.com/users/REDACTED",
                        "html_url": "https://company.pagerduty.com/users/REDACTED"
                    }
                ],
                "current_oncall": {
                    "user": {
                        "id": "redacted",
                        "name": "User 2",
                        "email": "user2@example.com",
                        "time_zone": "Pacific Time (US & Canada)",
                        "color": "dark-green",
                        "role": "observer"
                    },
                    "start": null,
                    "end": null,
                    "escalation_target": {
                        "id": "redacted",
                        "type": "user_reference",
                        "summary": "User 2",
                        "self": "https://api.pagerduty.com/users/REDACTED",
                        "html_url": "https://company.pagerduty.com/users/REDACTED"
                    }
                },
                "current_oncalls": [
                    {
                        "user": {
                            "id": "redacted",
                            "name": "User 2",
                            "email": "user2@example.com",
                            "time_zone": "Pacific Time (US & Canada)",
                            "color": "dark-green",
                            "role": "observer"
                        },
                        "start": null,
                        "end": null,
                        "escalation_target": {
                            "id": "redacted",
                            "type": "user_reference",
                            "summary": "User 2",
                            "self": "https://api.pagerduty.com/users/REDACTED",
                            "html_url": "https://company.pagerduty.com/users/REDACTED"
                        }
                    },
                    {
                        "user": {
                            "id": "redacted",
                            "name": "User 3",
                            "email": "user3@example.com",
                            "time_zone": "Chennai",
                            "color": "dark-green",
                            "role": "observer"
                        },
                        "start": null,
                        "end": null,
                        "escalation_target": {
                            "id": "redacted",
                            "type": "user_reference",
                            "summary": "User 3",
                            "self": "https://api.pagerduty.com/users/REDACTED",
                            "html_url": "https://company.pagerduty.com/users/REDACTED"
                        }
                    }
                ],
                "escalation_rule_assignment_strategy": {
                    "type": "assign_to_everyone"
                }
            }
        ],
        "services": [
            {
                "id": "redacted",
                "type": "service_reference",
                "summary": "Service 1",
                "self": "https://api.pagerduty.com/services/REDACTED",
                "html_url": "https://company.pagerduty.com/service-directory/REDACTED"
            },
            {
                "id": "redacted",
                "type": "service_reference",
                "summary": "Service 2",
                "self": "https://api.pagerduty.com/services/REDACTED",
                "html_url": "https://company.pagerduty.com/service-directory/REDACTED"
            },
            {
                "id": "redacted",
                "type": "service_reference",
                "summary": "Service 3",
                "self": "https://api.pagerduty.com/services/REDACTED",
                "html_url": "https://company.pagerduty.com/service-directory/REDACTED"
            },
            {
                "id": "redacted",
                "type": "service_reference",
                "summary": "Service 4",
                "self": "https://api.pagerduty.com/services/REDACTED",
                "html_url": "https://company.pagerduty.com/service-directory/REDACTED"
            }
        ],
        "num_loops": 1,
        "teams": [
            {
                "id": "redacted",
                "type": "team_reference",
                "summary": "Data Team",
                "self": "https://api.pagerduty.com/teams/REDACTED",
                "html_url": "https://company.pagerduty.com/teams/REDACTED"
            }
        ],
        "on_call": [
            {
                "level": 1,
                "start": "2024-04-15T15:00:00Z",
                "end": "2024-04-16T03:00:00Z",
                "user": {
                    "id": "redacted",
                    "name": "User 1",
                    "email": "user1@example.com",
                    "time_zone": "Pacific Time (US & Canada)",
                    "color": "blue-violet",
                    "role": "observer",
                    "type": "user"
                }
            },
            {
                "level": 2,
                "start": null,
                "end": null,
                "user": {
                    "id": "redacted",
                    "name": "User 2",
                    "email": "user2@example.com",
                    "time_zone": "Pacific Time (US & Canada)",
                    "color": "dark-green",
                    "role": "observer",
                    "type": "user"
                }
            },
            {
                "level": 2,
                "start": null,
                "end": null,
                "user": {
                    "id": "redacted",
                    "name": "User 3",
                    "email": "user3@example.com",
                    "time_zone": "Chennai",
                    "color": "dark-green",
                    "role": "observer",
                    "type": "user"
                }
            }
        ],
        "description": "",
        "on_call_handoff_notifications": "if_has_services",
        "privilege": {
            "role": "observer",
            "permissions": [
                "index",
                "read",
                "show"
            ]
        }
    }
}
```


