### PR TITLE
Clicking escalate in the status group brings up escalation dialog

### DIFF
--- a/src/dispatch/static/dispatch/src/case/CaseStatusSelectGroup.vue
+++ b/src/dispatch/static/dispatch/src/case/CaseStatusSelectGroup.vue
@@ -197,6 +197,11 @@ const changeStatus = async (newStatus) => {
 }
 
 const openDialog = (newStatus) => {
+  if (newStatus == "Escalated") {
+    const caseDetails = store.state.case_management.selected
+    store.dispatch("case_management/showEscalateDialog", caseDetails)
+    return
+  }
   const statusObj = statuses.value.find((status) => status.name === newStatus) // find the status object
   selectedStatus.value = newStatus
   selectedStatusTooltip.value = statusObj.tooltip // store the tooltip

--- a/src/dispatch/static/dispatch/src/incident/ReportSubmissionForm.vue
+++ b/src/dispatch/static/dispatch/src/incident/ReportSubmissionForm.vue
@@ -32,11 +32,7 @@
           <project-select v-model="project" />
         </v-col>
         <v-col cols="12">
-          <incident-type-select
-            :project="project"
-            v-model="incident_type"
-            value="this.incidentType"
-          />
+          <incident-type-select label="Incident Type" :project="project" v-model="incident_type" />
         </v-col>
         <v-col cols="12">
           <incident-priority-select :project="project" v-model="incident_priority" />


### PR DESCRIPTION
Ensuring that clicking on "Escalated" in the status group now brings up the escalation dialog. Also, fixing display error in incident type picker.

![image](https://github.com/Netflix/dispatch/assets/84562015/e0402f3b-37f5-4abb-8a5b-b891483e99d6)
