### PR TITLE
Cases should be created with a conversation target

### DIFF
--- a/src/dispatch/case/service.py
+++ b/src/dispatch/case/service.py
@@ -126,7 +126,14 @@ def get_all_last_x_hours_by_status(
 
 
 def create(*, db_session, case_in: CaseCreate, current_user: DispatchUser = None) -> Case:
-    """Creates a new case."""
+    """Creates a new case.
+
+    Returns:
+        The created case.
+
+    Raises:
+        ValidationError: If the case type does not have a conversation target, the case will not be created.
+    """
     project = project_service.get_by_name_or_default(
         db_session=db_session, project_in=case_in.project
     )
@@ -136,6 +143,13 @@ def create(*, db_session, case_in: CaseCreate, current_user: DispatchUser = None
         tag_objs.append(tag_service.get_or_create(db_session=db_session, tag_in=t))
 
     # TODO(mvilanova): allow to provide related cases and incidents, and duplicated cases
+    case_type = case_type_service.get_by_name_or_default(
+        db_session=db_session, project_id=project.id, case_type_in=case_in.case_type
+    )
+    if not case_type or not case_type.conversation_target:
+        raise ValueError(
+            f"Case type with name {case_in.case_type.name} does not have a conversation target. The case will not be created."
+        )
 
     case = Case(
         title=case_in.title,
@@ -144,12 +158,8 @@ def create(*, db_session, case_in: CaseCreate, current_user: DispatchUser = None
         status=case_in.status,
         dedicated_channel=case_in.dedicated_channel,
         tags=tag_objs,
+        case_type=case_type,
     )
-
-    case_type = case_type_service.get_by_name_or_default(
-        db_session=db_session, project_id=project.id, case_type_in=case_in.case_type
-    )
-    case.case_type = case_type
 
     case.visibility = case_type.visibility
     if case_in.visibility:

--- a/src/dispatch/case/views.py
+++ b/src/dispatch/case/views.py
@@ -149,7 +149,12 @@ def create_case(
         case_in.reporter = ParticipantUpdate(
             individual=IndividualContactRead(email=current_user.email)
         )
-    case = create(db_session=db_session, case_in=case_in, current_user=current_user)
+
+    try:
+        case = create(db_session=db_session, case_in=case_in, current_user=current_user)
+    except ValueError as e:
+        log.exception(e)
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=[{"msg": e.args[0]}])
 
     if case.status == CaseStatus.triage:
         background_tasks.add_task(

--- a/src/dispatch/case/views.py
+++ b/src/dispatch/case/views.py
@@ -154,7 +154,9 @@ def create_case(
         case = create(db_session=db_session, case_in=case_in, current_user=current_user)
     except ValueError as e:
         log.exception(e)
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=[{"msg": e.args[0]}])
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY, detail=[{"msg": e.args[0]}]
+        ) from e
 
     if case.status == CaseStatus.triage:
         background_tasks.add_task(

--- a/src/dispatch/static/dispatch/src/components/NotificationSnackbarsWrapper.vue
+++ b/src/dispatch/static/dispatch/src/components/NotificationSnackbarsWrapper.vue
@@ -5,8 +5,7 @@
     :color="notification.type"
     @update:model-value="setSeen(notification.index)"
   >
-    {{ notification.text }}
-    <v-btn variant="text" @click="setSeen(notification.index)"> Close </v-btn>
+    <span class="text-center">{{ notification.text }}</span>
   </v-snackbar>
 </template>
 
@@ -91,3 +90,11 @@ export default {
   },
 }
 </script>
+
+<style scoped>
+.text-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+</style>

--- a/src/dispatch/static/dispatch/src/components/NotificationSnackbarsWrapper.vue
+++ b/src/dispatch/static/dispatch/src/components/NotificationSnackbarsWrapper.vue
@@ -6,9 +6,7 @@
     @update:model-value="setSeen(notification.index)"
   >
     {{ notification.text }}
-    <template #actions="{ attrs }">
-      <v-btn variant="text" v-bind="attrs" @click="setSeen(notification.index)"> Close </v-btn>
-    </template>
+    <v-btn variant="text" @click="setSeen(notification.index)"> Close </v-btn>
   </v-snackbar>
 </template>
 

--- a/tests/case/test_case_service.py
+++ b/tests/case/test_case_service.py
@@ -77,6 +77,45 @@ def test_create(session, participant, case_type, case_severity, case_priority, p
     assert case_out.assignee.individual.email == user.email
 
 
+def test_create__fails_with_no_conversation_target(
+    session, participant, case_type, case_severity, case_priority, project, user
+):
+    """Assert that a case cannot be created without a conversation_target.
+
+    Case conversations are created as threads by default and require a conversation target to be created.
+    """
+    from dispatch.case.service import create as create_case
+    from dispatch.enums import Visibility
+
+    case_type.project = project
+    case_type.conversation_target = None
+    case_severity.project = project
+    case_priority.project = project
+    session.add(case_type)
+    session.add(case_severity)
+    session.add(case_priority)
+    session.commit()
+
+    # No assignee, No oncall_service, resolves current_user to assignee
+
+    case_in = CaseCreate(
+        title="A",
+        description="B",
+        resolution=None,
+        visibility=Visibility.open,
+        case_type=case_type,
+        case_severity=case_severity,
+        case_priority=case_priority,
+        reporter=participant,
+        project=project,
+    )
+    try:
+        case_in = create_case(db_session=session, case_in=case_in, current_user=user)
+        assert not case_in
+    except Exception as e:
+        assert "conversation target" in str(e)
+
+
 def test_update(session, case: Case, project):
     from dispatch.case.service import update as update_case
     from dispatch.case.enums import CaseStatus

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -707,7 +707,7 @@ class CaseTypeFactory(BaseFactory):
 
     name = FuzzyText()
     description = FuzzyText()
-
+    conversation_target = FuzzyText()
     project = SubFactory(ProjectFactory)
 
     class Meta:


### PR DESCRIPTION
Return an error message to the user when reporting cases with no conversation targets. 

Case conversations are created as threads by default and require a conversation target to be created.