### PR TITLE
bug: Accurately captures severity level at time of incident report

### DIFF
--- a/src/dispatch/incident/service.py
+++ b/src/dispatch/incident/service.py
@@ -166,9 +166,10 @@ def create(*, db_session, incident_in: IncidentCreate) -> Incident:
         incident_priority_in=incident_in.incident_priority,
     )
 
-    incident_severity = incident_severity_service.get_default(
+    incident_severity = incident_severity_service.get_by_name_or_default(
         db_session=db_session,
         project_id=project.id,
+        incident_severity_in=incident_in.incident_severity,
     )
 
     cost_model = None


### PR DESCRIPTION
# Issue
At present, when reporting a bug, the severity, no matter what is input in the dialog will default to the project's default severity.

# Resolution
Instead of depending on the default severity, this updates the incident service to use the incident severity service's `get_by_name_or_default` method just like the priority uses above.