### PR TITLE
[Bugfix] - We rename case -> incident channel twice

### DIFF
--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -566,11 +566,6 @@ def send_escalation_messages_for_channel_case(
         blocks=messages.create_incident_channel_escalate_message(),
     )
 
-    plugin.instance.rename(
-        conversation_id=incident.conversation.channel_id,
-        name=incident.name,
-    )
-
 
 def common_escalate_flow(
     case: Case,


### PR DESCRIPTION
For dedicated channel cases, we rename the channel to the name of the incident ticket on escalation. This currently happens twice, once where it was removed in this PR (at the end of the escalation flow) and at the beginning in `incident_create_resources`.

This is already done earlier here:

```python
def incident_create_resources(
    *,
    incident: Incident,
    db_session: Session | None = None,
    case: Case | None = None,  # if it was escalated, we'll pass in the escalated case
) -> Incident:
    """Creates all resources required for incidents."""
    # we create the incident ticket
    if not incident.ticket:
        ticket_flows.create_incident_ticket(incident=incident, db_session=db_session)

    # we update the channel name immediately for dedicated channel cases esclated -> incident
    if case and case.dedicated_channel and case.escalated_at is not None:
        plugin = plugin_service.get_active_instance(
            db_session=db_session, project_id=case.project.id, plugin_type="conversation"
        )
        if not plugin:
            log.warning("Incident channel not renamed. No conversation plugin enabled.")
            return

        plugin.instance.rename(
            conversation_id=incident.conversation.channel_id,
            name=incident.name,
        )
```