### PR TITLE
Validate IncidentUpdate's incident_type field against the retrieved incident type.

### DIFF
--- a/src/dispatch/incident/service.py
+++ b/src/dispatch/incident/service.py
@@ -366,7 +366,7 @@ def update(*, db_session, incident: Incident, incident_in: IncidentUpdate) -> In
         )
 
     # Update total incident reponse cost if incident type has changed.
-    if incident_in.incident_type.id != incident_type.id:
+    if incident_type.id != incident.incident_type.id:
         incident_cost_service.update_incident_response_cost(
             incident_id=incident.id, db_session=db_session
         )

--- a/src/dispatch/incident/service.py
+++ b/src/dispatch/incident/service.py
@@ -366,7 +366,7 @@ def update(*, db_session, incident: Incident, incident_in: IncidentUpdate) -> In
         )
 
     # Update total incident reponse cost if incident type has changed.
-    if incident_in.incident_type.id != incident.incident_type.id:
+    if incident_in.incident_type.id != incident_type.id:
         incident_cost_service.update_incident_response_cost(
             incident_id=incident.id, db_session=db_session
         )


### PR DESCRIPTION
The IncidentUpdate's `incident_type` field is an IncidentTypeBase, which does not have an `id` field. Thus, the initial `id` comparison resulted in an error.

However, earlier in the `incident_service.update()` function call, the `incident_type` is already retrieved. We can perform the comparisons against this object's `id`.