### PR TITLE
bug: Fixes tags not showing up during incident report / update

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -281,6 +281,8 @@ def handle_update_incident_project_select_action(
         "selected_option"
     ]["value"]
 
+    context["subject"].project_id = project_id
+
     project = project_service.get(
         db_session=db_session,
         project_id=project_id,
@@ -2002,6 +2004,9 @@ def handle_report_incident_command(
     """Handles the report incident command."""
     ack()
 
+    if body.get("channel_id"):
+        context["subject"].channel_id = body["channel_id"]
+
     blocks = [
         Context(
             elements=[
@@ -2149,6 +2154,8 @@ def handle_report_incident_project_select_action(
     project_id = values[DefaultBlockIds.project_select][IncidentReportActions.project_select][
         "selected_option"
     ]["value"]
+
+    context["subject"].project_id = project_id
 
     project = project_service.get(db_session=db_session, project_id=project_id)
 


### PR DESCRIPTION
# Issue
When attempting to define tags during incident reporting / updating in Slack, we were not seeing any tags autocomplete even though we have a large number associated w/ the selected project.

<img width="483" alt="Screenshot 2024-05-08 at 12 02 58 PM" src="https://github.com/Netflix/dispatch/assets/433643/a4d43186-e49b-44a6-981d-ea51998e95cb">

# Root Cause
[handle_tag_search_action](https://github.com/Meandmybadself/dispatch/blob/master/src/dispatch/plugins/dispatch_slack/incident/interactive.py#L233) uses `project_id` as defined in the BoltContext to query for tags associated with a project.  
This value is initially set in [subject_middleware](https://github.com/Meandmybadself/dispatch/blob/master/src/dispatch/plugins/dispatch_slack/middleware.py#L397) at the start of the interaction & never updated.

If the selected project is not the default project, this will return an empty set of tags.

# Proposed Solution
When a project is defined/updated in the modal, we should reflect that value in the context so it is available in subsequent interactions.
