### PR TITLE
Replace Slack user_ids in messages with names

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/enums.py
+++ b/src/dispatch/plugins/dispatch_slack/enums.py
@@ -34,6 +34,7 @@ class SlackAPIErrorCode(DispatchEnum):
     FATAL_ERROR = "fatal_error"
     USER_IN_CHANNEL = "user_in_channel"
     USER_NOT_IN_CHANNEL = "user_not_in_channel"
+    USER_NOT_FOUND = "user_not_found"
     USERS_NOT_FOUND = "users_not_found"
     VIEW_NOT_FOUND = "not_found"  # Could not find corresponding view for the provided view_id
     VIEW_EXPIRED = "expired_trigger_id"  # The provided trigger_id is no longer valid

--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -676,6 +676,17 @@ def handle_not_configured_reaction_event(
     ack()
 
 
+def get_user_name_from_id(client: Any, user_id: str) -> str:
+    """Returns the user's name given their user ID."""
+    user = client.users_info(user=user_id)
+    return user["user"]["profile"]["real_name"]
+
+
+def replace_slack_users_in_message(client: Any, message: str) -> str:
+    """Replaces slack user ids in a message with their names."""
+    return re.sub(r"<@([^>]+)>", lambda x: f"@{get_user_name_from_id(client, x.group(1))}", message)
+
+
 def handle_timeline_added_event(
     ack: Ack, client: Any, context: BoltContext, payload: Any, db_session: Session
 ) -> None:
@@ -690,7 +701,7 @@ def handle_timeline_added_event(
     response = dispatch_slack_service.list_conversation_messages(
         client, conversation_id, latest=message_ts, limit=1, inclusive=1
     )
-    message_text = response["messages"][0]["text"]
+    message_text = replace_slack_users_in_message(client, response["messages"][0]["text"])
     message_sender_id = response["messages"][0]["user"]
 
     # TODO: (wshel) handle case reactions

--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -678,8 +678,12 @@ def handle_not_configured_reaction_event(
 
 def get_user_name_from_id(client: Any, user_id: str) -> str:
     """Returns the user's name given their user ID."""
-    user = client.users_info(user=user_id)
-    return user["user"]["profile"]["real_name"]
+    try:
+        user = client.users_info(user=user_id)
+        return user["user"]["profile"]["real_name"]
+    except SlackApiError:
+        # if can't find user, just return the original text
+        return user_id
 
 
 def replace_slack_users_in_message(client: Any, message: str) -> str:


### PR DESCRIPTION
When using the designated Slack reaction on a message with a user (or users) that have been tagged, the message previously came into the timeline with the user_id(s). This PR replaces those ids with the users' names.
Previously:
`<@WJK2RF4DD> do you have the files?`
Now:
`@David Whittaker do you have the files?`