### PR TITLE
Allow user to keep typing date time in PreciseDateTimePicker

### DIFF
--- a/src/dispatch/static/dispatch/src/components/PreciseDateTimePicker.vue
+++ b/src/dispatch/static/dispatch/src/components/PreciseDateTimePicker.vue
@@ -128,7 +128,6 @@
 <script>
 import { zonedTimeToUtc, utcToZonedTime, format } from "date-fns-tz"
 import { fromUnixTime } from "date-fns"
-import { filter } from "lodash"
 
 function removeEndingZ(str) {
   if (str.endsWith("Z")) {


### PR DESCRIPTION
This PR adds the ability for the user to keep typing the date and time without having to Tab through each field, or use the Enter key to advance to the next field. This change also adds more robust key filtering.