### PR TITLE
Fixes participant announcement message

### DIFF
--- a/src/dispatch/incident/messaging.py
+++ b/src/dispatch/incident/messaging.py
@@ -658,7 +658,7 @@ def send_participant_announcement_message(
                     f"*Name:* {participant_name_mrkdwn}\n"
                     f"*Team*: {participant_team}, {participant_department}\n"
                     f"*Location*: {participant_location}\n"
-                    f"*Incident Role(s)*: {(', ').join(participant_roles)}\n"
+                    f"*{subject_type} Role(s)*: {(', ').join(participant_roles)}\n"
                 ),
             },
         },


### PR DESCRIPTION
The message always shows `Incident Role(s)` even if it's a case participant. This PR changes it to make it dependent on the subject type.
<img width="397" alt="Screenshot 2024-06-12 at 11 59 47 AM" src="https://github.com/Netflix/dispatch/assets/39573146/67c8c488-1a23-4080-b0b9-2db2cd375034">
