### PR TITLE
Don't show additional attorney questions section if schema is empty

### DIFF
--- a/src/dispatch/static/dispatch/src/forms/table/AttorneyEditForm.vue
+++ b/src/dispatch/static/dispatch/src/forms/table/AttorneyEditForm.vue
@@ -52,7 +52,7 @@
             <v-textarea v-model="attorney_analysis" label="Attorney analysis" />
           </v-col>
         </v-row>
-        <div v-if="attorney_page_schema">
+        <div v-if="attorney_page_schema && attorney_page_schema.length > 0">
           <span class="text-body-1 mt-3 text-medium-emphasis">Additional attorney questions</span>
           <FormKit
             style="margin-left: 20px; margin-right: 20px; margin-top: 10px"


### PR DESCRIPTION
This fixes a bug where the "Additional attorney questions" section would show even when there was no schema.