### PR TITLE
Adding linting to migrations

### DIFF
--- a/.github/workflows/lint-migrations.yml
+++ b/.github/workflows/lint-migrations.yml
@@ -37,6 +37,7 @@ jobs:
           chmod +x eugene
       - name: Generate sql files
         run: |
+          export DISPATCH_ENCRYPTION_KEY=supersecret
           dispatch database upgrade --revision-type tenant  --sql
       - name: Lint files
         run: ./eugene lint alembic_output.sql -f md --accept-failures > lint.md

--- a/.github/workflows/lint-migrations.yml
+++ b/.github/workflows/lint-migrations.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python 3.11
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11.2
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -35,36 +35,9 @@ jobs:
           chmod +x eugene
       - name: Generate sql files
         run: |
-          # Navigate to the git repository root, if not already there
-          cd "$(git rev-parse --show-toplevel)" || exit
-
-          # Perform git diff to check for changes in the specified directory
-          changed_files=$(git diff --name-only -- src/dispatch/database/revisions/tenant/versions)
-
-          # Filter for newly added files (*.py)
-          new_files=$(echo "$changed_files" | grep -E "^src/dispatch/database/revisions/tenant/versions/2024-06-12_.*\.py$")
-
-          # Check if there is exactly one new file and handle errors for multiple or no files
-          if [[ $(echo "$new_files" | wc -l) -ne 1 ]]; then
-            echo "Error: There should be exactly one new revision file. Found: $(echo "$new_files" | wc -l)"
-            exit 1
-          fi
-
-          new_file_path=$(echo "$new_files" | head -n 1)
-          new_revision_id=$(basename "$new_file_path" .py | cut -d'_' -f2)
-
-          # Get the most recent revision ID excluding the newly added one
-          old_file=$(git ls-files src/dispatch/database/revisions/tenant/versions | grep -oP '2024-06-12_\K[^.]+(?=\.py)' | grep -v "$new_revision_id" | sort -rV | head -n 1)
-
-          if [[ -z "$old_file" ]]; then
-            echo "Error: No old revision ID found"
-            exit 1
-          fi
-
-          old_revision_id=$(echo "$old_file")
-          dispatch database upgrade --revision-type tenant --revision="${old_revision_id}:${new_revision_id}" --sql
+          dispatch database upgrade --revision-type tenant  --sql
       - name: Lint files
-        run: ./eugene lint --git-diff origin/main migration-scripts -f md --accept-failures > lint.md
+        run: ./eugene lint alembic_output.sql -f md --accept-failures > lint.md
       - name: Post Comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-migrations.yml
+++ b/.github/workflows/lint-migrations.yml
@@ -45,7 +45,7 @@ jobs:
           export DISPATCH_JWT_SECRET="foo"
           dispatch database upgrade --revision-type tenant --sql
       - name: Lint files
-        run: ./eugene lint alembic_output.sql -f md --accept-failures > lint.md
+        run: ./eugene lint --ignore E9 alembic_output.sql -f md --accept-failures > lint.md
       - name: Post Comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-migrations.yml
+++ b/.github/workflows/lint-migrations.yml
@@ -43,6 +43,12 @@ jobs:
           export DATABASE_CREDENTIALS="dispatch:dispatch"
           export DISPATCH_ENCRYPTION_KEY="NJHDWDJ3PbHT8h"
           export DISPATCH_JWT_SECRET="foo"
+
+          changed_files=$(git diff --name-only -- src/dispatch/database/revisions/tenant/versions)
+          if [ -z "$changed_files" ]; then
+            echo "No migration files changed, skipping linting"
+            exit 0
+          fi
           dispatch database upgrade --revision-type tenant --sql
       - name: Lint files
         run: ./eugene lint --ignore E9 alembic_output.sql -f md --accept-failures > lint.md

--- a/.github/workflows/lint-migrations.yml
+++ b/.github/workflows/lint-migrations.yml
@@ -1,0 +1,73 @@
+name: Eugene CI check
+
+env:
+  EUGENE_VERSION: "0.6.1"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lint-migration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11.2
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install python dependencies
+        run: |
+          export DISPATCH_LIGHT_BUILD=1
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Download eugene
+        run: |
+          curl -L  https://github.com/kaaveland/eugene/releases/download/$EUGENE_VERSION/eugene-x86_64-unknown-linux-musl -o eugene
+          chmod +x eugene
+      - name: Generate sql files
+        run: |
+          # Navigate to the git repository root, if not already there
+          cd "$(git rev-parse --show-toplevel)" || exit
+
+          # Perform git diff to check for changes in the specified directory
+          changed_files=$(git diff --name-only -- src/dispatch/database/revisions/tenant/versions)
+
+          # Filter for newly added files (*.py)
+          new_files=$(echo "$changed_files" | grep -E "^src/dispatch/database/revisions/tenant/versions/2024-06-12_.*\.py$")
+
+          # Check if there is exactly one new file and handle errors for multiple or no files
+          if [[ $(echo "$new_files" | wc -l) -ne 1 ]]; then
+            echo "Error: There should be exactly one new revision file. Found: $(echo "$new_files" | wc -l)"
+            exit 1
+          fi
+
+          new_file_path=$(echo "$new_files" | head -n 1)
+          new_revision_id=$(basename "$new_file_path" .py | cut -d'_' -f2)
+
+          # Get the most recent revision ID excluding the newly added one
+          old_file=$(git ls-files src/dispatch/database/revisions/tenant/versions | grep -oP '2024-06-12_\K[^.]+(?=\.py)' | grep -v "$new_revision_id" | sort -rV | head -n 1)
+
+          if [[ -z "$old_file" ]]; then
+            echo "Error: No old revision ID found"
+            exit 1
+          fi
+
+          old_revision_id=$(echo "$old_file")
+          dispatch database upgrade --revision-type tenant --revision="${old_revision_id}:${new_revision_id}" --sql
+      - name: Lint files
+        run: ./eugene lint --git-diff origin/main migration-scripts -f md --accept-failures > lint.md
+      - name: Post Comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COMMENT=$(cat lint.md)
+          gh pr comment ${{ github.event.pull_request.number }} --body "$COMMENT"

--- a/.github/workflows/lint-migrations.yml
+++ b/.github/workflows/lint-migrations.yml
@@ -37,8 +37,13 @@ jobs:
           chmod +x eugene
       - name: Generate sql files
         run: |
-          export DISPATCH_ENCRYPTION_KEY=supersecret
-          dispatch database upgrade --revision-type tenant  --sql
+          export LOG_LEVEL="ERROR"
+          export STATIC_DIR=""
+          export DATABASE_HOSTNAME="localhost"
+          export DATABASE_CREDENTIALS="dispatch:dispatch"
+          export DISPATCH_ENCRYPTION_KEY="NJHDWDJ3PbHT8h"
+          export DISPATCH_JWT_SECRET="foo"
+          dispatch database upgrade --revision-type tenant --sql
       - name: Lint files
         run: ./eugene lint alembic_output.sql -f md --accept-failures > lint.md
       - name: Post Comment

--- a/.github/workflows/lint-migrations.yml
+++ b/.github/workflows/lint-migrations.yml
@@ -1,5 +1,7 @@
 name: Eugene CI check
 
+on: pull_request
+
 env:
   EUGENE_VERSION: "0.6.1"
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
       - name: Set up Python 3.11
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - uses: actions/setup-node@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,10 +25,10 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v2
       - name: Set up Python 3.11
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11.2
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/src/dispatch/cli.py
+++ b/src/dispatch/cli.py
@@ -396,6 +396,8 @@ def drop_database(yes):
 def upgrade_database(tag, sql, revision, revision_type):
     """Upgrades database schema to newest version."""
     import sqlalchemy
+    from contextlib import redirect_stdout
+
     from alembic import command as alembic_command
     from alembic.config import Config as AlembicConfig
     from sqlalchemy import inspect
@@ -426,7 +428,12 @@ def upgrade_database(tag, sql, revision, revision_type):
                 path = config.ALEMBIC_TENANT_REVISION_PATH
 
             alembic_cfg.set_main_option("script_location", path)
-            alembic_command.upgrade(alembic_cfg, revision, sql=sql, tag=tag)
+            if sql:
+                with open("alembic_output.sql", "w") as sql_file:
+                    with redirect_stdout(sql_file):
+                        alembic_command.upgrade(alembic_cfg, revision, sql=sql, tag=tag)
+            else:
+                alembic_command.upgrade(alembic_cfg, revision, sql=sql, tag=tag)
         else:
             for path in [config.ALEMBIC_CORE_REVISION_PATH, config.ALEMBIC_TENANT_REVISION_PATH]:
                 alembic_cfg.set_main_option("script_location", path)

--- a/src/dispatch/database/revisions/core/env.py
+++ b/src/dispatch/database/revisions/core/env.py
@@ -1,4 +1,4 @@
-from alembic import context
+from alembic import context, script
 from sqlalchemy import engine_from_config, pool
 
 from dispatch.logging import logging
@@ -85,6 +85,10 @@ def run_migrations_offline():
     # Get the URL from the config
     url = config.get_main_option("sqlalchemy.url")
 
+    alembic_script = script.ScriptDirectory.from_config(config)
+
+    _, previous = list(alembic_script.walk_revisions(base='base', head='heads'))[:2]
+
     # Set the migration options
     context.configure(
         url=url,
@@ -92,11 +96,13 @@ def run_migrations_offline():
         include_schemas=True,
         include_object=include_object,
         literal_binds=True,  # Binds parameters with their string values
+        starting_rev=previous.revision,
     )
 
     # Start a transaction and run migrations
     with context.begin_transaction():
         context.run_migrations()
+
 
 
 if context.is_offline_mode():

--- a/src/dispatch/database/revisions/tenant/env.py
+++ b/src/dispatch/database/revisions/tenant/env.py
@@ -1,5 +1,5 @@
-import os
-from alembic import context
+from alembic import context, script
+
 from sqlalchemy import engine_from_config, pool, inspect
 
 
@@ -98,6 +98,10 @@ def run_migrations_offline():
     # Get the URL from the config
     url = config.get_main_option("sqlalchemy.url")
 
+    alembic_script = script.ScriptDirectory.from_config(config)
+
+    _, previous = list(alembic_script.walk_revisions(base='base', head='heads'))[:2]
+
     # Set the migration options
     context.configure(
         url=url,
@@ -105,6 +109,7 @@ def run_migrations_offline():
         include_schemas=True,
         include_object=include_object,
         literal_binds=True,  # Binds parameters with their string values
+        starting_rev=previous.revision,
     )
 
     # Start a transaction and run migrations


### PR DESCRIPTION
This PR adds a new type of linting for our alembic migration files.  It dumps all migrations to .sql files and then runs a subset of linting rules that looks for problematic locks and other issues. Currently, it only attempts to look at the last added revision, as we generally only have one migration per pr; I think this is probably reasonable. If we find value we can extend this a bit. 

Documentation reference: https://kaveland.no/eugene/introduction.html

Additionally, I have added several improvements to the actual migrations themselves based on the advice here: 
https://squawkhq.com/docs/web-frameworks/#alembic-and-sqlalchemy. This should help prevent migrations from locking up the database if we accidentally introduce a change that requires exclusivity. 