### PR TITLE
Bugfix/plugin metadata not set

### DIFF
--- a/src/dispatch/static/dispatch/src/plugin/PluginInstanceCombobox.vue
+++ b/src/dispatch/static/dispatch/src/plugin/PluginInstanceCombobox.vue
@@ -4,6 +4,8 @@
     :loading="loading"
     :items="items"
     item-title="plugin.slug"
+    item-value="plugin.slug"
+    @update:search="getFilteredData()"
     v-model:search="search"
     hide-selected
     :label="label"
@@ -39,14 +41,14 @@
 
 <script>
 import { cloneDeep, debounce } from "lodash"
-
+import SearchUtils from "@/search/utils"
 import PluginApi from "@/plugin/api"
 
 export default {
   name: "PluginCombobox",
   props: {
     modelValue: {
-      type: [Object],
+      type: Object,
       default: null,
     },
     type: {
@@ -78,7 +80,11 @@ export default {
   },
 
   created() {
-    this.plugin = cloneDeep(this.modelValue)
+    if (this.modelValue) {
+      if (this.modelValue.slug) {
+        this.plugin = cloneDeep(this.modelValue)
+      }
+    }
     this.fetchData()
   },
 
@@ -132,9 +138,19 @@ export default {
 
       let filterOptions = {
         q: this.search,
-        sortBy: ["slug"],
+        sortBy: ["Plugin.slug"],
         itemsPerPage: this.numItems,
         filter: JSON.stringify(filter),
+      }
+
+      if (this.project) {
+        filterOptions = {
+          ...filterOptions,
+          filters: {
+            project: [this.project],
+          },
+        }
+        filterOptions = SearchUtils.createParametersFromTableOptions({ ...filterOptions })
       }
 
       PluginApi.getAllInstances(filterOptions).then((response) => {
@@ -150,8 +166,8 @@ export default {
         this.loading = false
       })
     },
-    getFilteredData: debounce(function (options) {
-      this.fetchData(options)
+    getFilteredData: debounce(function () {
+      this.fetchData()
     }, 500),
   },
 

--- a/src/dispatch/static/dispatch/src/plugin/PluginInstanceCombobox.vue
+++ b/src/dispatch/static/dispatch/src/plugin/PluginInstanceCombobox.vue
@@ -80,10 +80,8 @@ export default {
   },
 
   created() {
-    if (this.modelValue) {
-      if (this.modelValue.slug) {
-        this.plugin = cloneDeep(this.modelValue)
-      }
+    if (this.modelValue && this.modelValue.slug) {
+      this.plugin = cloneDeep(this.modelValue)
     }
     this.fetchData()
   },

--- a/src/dispatch/static/dispatch/src/plugin/PluginMetadataInput.vue
+++ b/src/dispatch/static/dispatch/src/plugin/PluginMetadataInput.vue
@@ -122,10 +122,7 @@ export default {
   computed: {
     plugins: {
       get() {
-        console.log(`**** Getting plugins: ${JSON.stringify(this.modelValue)}`)
-        var x = cloneDeep(this.modelValue).map((x) => ({ ...x, ...{ plugin: { slug: x.slug } } }))
-        console.log(`**** Returning plugins: ${JSON.stringify(x)}`)
-        return x
+        return cloneDeep(this.modelValue).map((x) => ({ ...x, ...{ plugin: { slug: x.slug } } }))
       },
     },
   },

--- a/src/dispatch/static/dispatch/src/plugin/PluginMetadataInput.vue
+++ b/src/dispatch/static/dispatch/src/plugin/PluginMetadataInput.vue
@@ -122,7 +122,10 @@ export default {
   computed: {
     plugins: {
       get() {
-        return cloneDeep(this.modelValue).map((x) => ({ ...x, ...{ plugin: { slug: x.slug } } }))
+        console.log(`**** Getting plugins: ${JSON.stringify(this.modelValue)}`)
+        var x = cloneDeep(this.modelValue).map((x) => ({ ...x, ...{ plugin: { slug: x.slug } } }))
+        console.log(`**** Returning plugins: ${JSON.stringify(x)}`)
+        return x
       },
     },
   },
@@ -138,7 +141,7 @@ export default {
     },
     addItem(plugin_idx) {
       if (!this.plugins[plugin_idx].metadata) {
-        this.$set(this.plugins[plugin_idx], "metadata", [])
+        this.plugins[plugin_idx].metadata = []
       }
       this.plugins[plugin_idx].metadata.push({ key: "", value: "" })
       this.$emit("update:modelValue", this.plugins)
@@ -148,7 +151,7 @@ export default {
       this.$emit("update:modelValue", this.plugins)
     },
     setPlugin(event) {
-      this.$set(this.plugins, event.idx, event.plugin)
+      this.plugins[event.idx] = event.plugin
       this.plugins[event.idx].slug = event.plugin.plugin.slug
       this.$emit("update:modelValue", this.plugins)
     },


### PR DESCRIPTION
Fixes bug that would not allow setting item metadata for plugins added to case and incident types.

![image](https://github.com/Netflix/dispatch/assets/84562015/367973e3-4db4-4ed8-b97f-508cb02cf514)
