### PR TITLE
Enable removal of signal filters from signal definition.

### DIFF
--- a/src/dispatch/signal/service.py
+++ b/src/dispatch/signal/service.py
@@ -493,7 +493,7 @@ def update(*, db_session: Session, signal: Signal, signal_in: SignalUpdate) -> S
         filter.id for filter in signal_in.filters
     )
 
-    if signal_in.filters or is_filters_updated:
+    if is_filters_updated:
         filters = []
         for f in signal_in.filters:
             signal_filter = get_signal_filter_by_name_or_raise(

--- a/src/dispatch/signal/service.py
+++ b/src/dispatch/signal/service.py
@@ -489,9 +489,9 @@ def update(*, db_session: Session, signal: Signal, signal_in: SignalUpdate) -> S
 
         signal.engagements = engagements
 
-    is_filters_updated = set(filter.id for filter in signal.filters) != set(
+    is_filters_updated = {filter.id for filter in signal.filters} != {
         filter.id for filter in signal_in.filters
-    )
+    }
 
     if is_filters_updated:
         filters = []

--- a/src/dispatch/signal/service.py
+++ b/src/dispatch/signal/service.py
@@ -489,7 +489,11 @@ def update(*, db_session: Session, signal: Signal, signal_in: SignalUpdate) -> S
 
         signal.engagements = engagements
 
-    if signal_in.filters:
+    is_filters_updated = set(filter.id for filter in signal.filters) != set(
+        filter.id for filter in signal_in.filters
+    )
+
+    if signal_in.filters or is_filters_updated:
         filters = []
         for f in signal_in.filters:
             signal_filter = get_signal_filter_by_name_or_raise(
@@ -604,7 +608,6 @@ def create_instance(
             case_type_in=signal_instance_in.case_type,
         )
         signal_instance.case_type = case_type
-
 
     db_session.add(signal_instance)
     db_session.commit()

--- a/tests/signal/test_signal_service.py
+++ b/tests/signal/test_signal_service.py
@@ -43,6 +43,54 @@ def test_update(session, project, signal):
     assert signal.name == name
 
 
+def test_update__add_filter(session, signal, signal_filter):
+    from dispatch.signal.models import SignalUpdate, SignalFilterRead
+    from dispatch.signal.service import update
+
+    signal_filter.project = signal.project
+
+    signal_in = SignalUpdate(
+        id=signal.id,
+        name=signal.name,
+        project=signal.project,
+        owner="example.com",
+        external_id="foo",
+        filters=[SignalFilterRead.from_orm(signal_filter)],
+    )
+    signal = update(
+        db_session=session,
+        signal=signal,
+        signal_in=signal_in,
+    )
+    assert len(signal.filters) == 1
+
+
+def test_update__delete_filter(session, signal, signal_filter):
+    from dispatch.signal.models import SignalUpdate
+    from dispatch.signal.service import update
+
+    # Set up conditions to delete a signal filter.
+    signal_filter.project = signal.project
+    signal.filters.append(signal_filter)
+
+    assert len(signal.filters) == 1
+
+    signal_in = SignalUpdate(
+        id=signal.id,
+        name=signal.name,
+        project=signal.project,
+        owner="example.com",
+        external_id="foo",
+        filters=[],
+    )
+    signal = update(
+        db_session=session,
+        signal=signal,
+        signal_in=signal_in,
+    )
+    assert len(signal.filters) == 0
+
+
 def test_delete(session, signal):
     from dispatch.signal.service import delete, get
 


### PR DESCRIPTION
This PR fixes a bug where the user is unable to delete signal filters from the signal definition.