### PR TITLE
bugfix: get_session() contextmgr usage in consume_signals()

### DIFF
--- a/src/dispatch/cli.py
+++ b/src/dispatch/cli.py
@@ -827,8 +827,8 @@ def consume_signals():
     from dispatch.database.core import get_session, get_organization_session
 
     install_plugins()
-    db_session = get_session()
-    organizations = get_all_organizations(db_session=db_session)
+    with get_session() as session:
+        organizations = get_all_organizations(db_session=session)
 
     log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Resolves:

```
AttributeError-'_GeneratorContextManager' object has no attribute 'query'
```

on

```python
    install_plugins()
    db_session = get_session()
    organizations = get_all_organizations(db_session=db_session)

---> 

def get_all(*, db_session) -> List[Optional[Organization]]:
    """Gets all organizations."""
    return db_session.query(Organization)   <---
```