### PR TITLE
Update slack_wait_strategy return type hint

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -32,7 +32,7 @@ class SlackRetryException(Exception):
     def get_wait_time(self) -> int:
         return self.wait_time
 
-def slack_wait_strategy(retry_state: RetryCallState) -> [float, int]:
+def slack_wait_strategy(retry_state: RetryCallState) -> float | int:
     """Determines the wait time for the Slack retry strategy"""
     exc = retry_state.outcome.exception()
 


### PR DESCRIPTION
I messed up when I recommended the return type. This format is correct.