### PR TITLE
Don't retry adding users if they are already in the channel.

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -103,6 +103,9 @@ def should_retry(exception: Exception) -> bool:
     """
     match exception:
         case SlackApiError():
+            # Don't retry for re-adding users in channel.
+            if exception.response["error"] == SlackAPIErrorCode.USER_IN_CHANNEL:
+                return False
             # Retry if it's not a fatal error
             return exception.response["error"] != SlackAPIErrorCode.FATAL_ERROR
         case TimeoutError() | Timeout():


### PR DESCRIPTION
Don't retry adding users if they are already in the channel.

`make_call()` has a `retry` decorator which retries a failed api call. We do not want to retry handled errors.