### PR TITLE
Adding notifications to dedicated channel cases

### DIFF
--- a/src/dispatch/case/messaging.py
+++ b/src/dispatch/case/messaging.py
@@ -6,21 +6,36 @@
 """
 import logging
 
-from dispatch.database.core import SessionLocal
-from dispatch.case.models import Case
+from sqlalchemy.orm import Session
+
+from dispatch.database.core import resolve_attr
+from dispatch.case.models import Case, CaseRead
 from dispatch.messaging.strings import (
     CASE_CLOSE_REMINDER,
     CASE_TRIAGE_REMINDER,
+    CASE_NOTIFICATION,
+    CASE_NOTIFICATION_COMMON,
+    CASE_NAME_WITH_ENGAGEMENT,
+    CASE_NAME_WITH_ENGAGEMENT_NO_SELF_JOIN,
+    CASE_NAME,
+    CASE_ASSIGNEE,
+    CASE_STATUS_CHANGE,
+    CASE_TYPE_CHANGE,
+    CASE_SEVERITY_CHANGE,
+    CASE_PRIORITY_CHANGE,
     MessageType,
 )
 from dispatch.config import DISPATCH_UI_URL
 from dispatch.plugin import service as plugin_service
+from dispatch.event import service as event_service
+from dispatch.notification import service as notification_service
 
+from .enums import CaseStatus
 
 log = logging.getLogger(__name__)
 
 
-def send_case_close_reminder(case: Case, db_session: SessionLocal) -> None:
+def send_case_close_reminder(case: Case, db_session: Session) -> None:
     """
     Sends a direct message to the assignee reminding them to close the case if possible.
     """
@@ -57,7 +72,7 @@ def send_case_close_reminder(case: Case, db_session: SessionLocal) -> None:
     log.debug(f"Case close reminder sent to {case.assignee.individual.email}.")
 
 
-def send_case_triage_reminder(case: Case, db_session: SessionLocal) -> None:
+def send_case_triage_reminder(case: Case, db_session: Session) -> None:
     """
     Sends a direct message to the assignee reminding them to triage the case if possible.
     """
@@ -93,3 +108,197 @@ def send_case_triage_reminder(case: Case, db_session: SessionLocal) -> None:
     )
 
     log.debug(f"Case triage reminder sent to {case.assignee.individual.email}.")
+
+
+def send_case_created_notifications(case: Case, db_session: Session):
+    """Sends case created notifications."""
+    notification_template = CASE_NOTIFICATION.copy()
+
+    if case.status != CaseStatus.closed:
+        if case.project.allow_self_join:
+            notification_template.insert(0, CASE_NAME_WITH_ENGAGEMENT)
+        else:
+            notification_template.insert(0, CASE_NAME_WITH_ENGAGEMENT_NO_SELF_JOIN)
+    else:
+        notification_template.insert(0, CASE_NAME)
+
+    case_description = (
+        case.description
+        if len(case.description) <= 500
+        else f"{case.description[:500]}..."
+    )
+
+    notification_kwargs = {
+        "name": case.name,
+        "title": case.title,
+        "description": case_description,
+        "visibility": case.visibility,
+        "status": case.status,
+        "type": case.case_type.name,
+        "type_description": case.case_type.description,
+        "severity": case.case_severity.name,
+        "severity_description": case.case_severity.description,
+        "priority": case.case_priority.name,
+        "priority_description": case.case_priority.description,
+        "reporter_fullname": case.reporter.individual.name,
+        "reporter_team": case.reporter.team,
+        "reporter_weblink": case.reporter.individual.weblink,
+        "assignee_fullname": case.assignee.individual.name,
+        "assignee_team": case.assignee.team,
+        "assignee_weblink": case.assignee.individual.weblink,
+        "document_weblink": resolve_attr(case, "case_document.weblink"),
+        "storage_weblink": resolve_attr(case, "storage.weblink"),
+        "ticket_weblink": resolve_attr(case, "ticket.weblink"),
+        "contact_fullname": case.assignee.individual.name,
+        "contact_weblink": case.assignee.individual.weblink,
+        "case_id": case.id,
+        "organization_slug": case.project.organization.slug,
+    }
+
+    notification_params = {
+        "text": "Case Notification",
+        "type": MessageType.case_notification,
+        "template": notification_template,
+        "kwargs": notification_kwargs,
+    }
+
+    notification_service.filter_and_send(
+        db_session=db_session,
+        project_id=case.project.id,
+        class_instance=case,
+        notification_params=notification_params,
+    )
+
+    event_service.log_case_event(
+        db_session=db_session,
+        source="Dispatch Core App",
+        description="Case notifications sent",
+        case_id=case.id,
+    )
+
+    log.debug("Case created notifications sent.")
+
+
+def send_case_update_notifications(
+    case: Case, previous_case: CaseRead, db_session: Session
+):
+    """Sends notifications about case changes."""
+    notification_text = "Case Notification"
+    notification_type = MessageType.case_notification
+    notification_template = CASE_NOTIFICATION_COMMON.copy()
+
+    change = False
+    if previous_case.status != case.status:
+        change = True
+        notification_template.append(CASE_STATUS_CHANGE)
+        if previous_case.case_type.name != case.case_type.name:
+            notification_template.append(CASE_TYPE_CHANGE)
+
+        if previous_case.case_severity.name != case.case_severity.name:
+            notification_template.append(CASE_SEVERITY_CHANGE)
+
+        if previous_case.case_priority.name != case.case_priority.name:
+            notification_template.append(CASE_PRIORITY_CHANGE)
+    else:
+        if case.status != CaseStatus.closed:
+            if previous_case.case_type.name != case.case_type.name:
+                change = True
+                notification_template.append(CASE_TYPE_CHANGE)
+
+            if previous_case.case_severity.name != case.case_severity.name:
+                change = True
+                notification_template.append(CASE_SEVERITY_CHANGE)
+
+            if previous_case.case_priority.name != case.case_priority.name:
+                change = True
+                notification_template.append(CASE_PRIORITY_CHANGE)
+
+    if not change:
+        # we don't need to send notifications
+        log.debug("Case updated notifications not sent. No changes were made.")
+        return
+
+    notification_template.append(CASE_ASSIGNEE)
+
+    # we send an update to the case conversation if the case is active or stable
+    if case.status != CaseStatus.closed:
+        case_conversation_notification_template = notification_template.copy()
+        case_conversation_notification_template.insert(0, CASE_NAME)
+
+        convo_plugin = plugin_service.get_active_instance(
+            db_session=db_session, project_id=case.project.id, plugin_type="conversation"
+        )
+        if convo_plugin:
+            convo_plugin.instance.send(
+                case.conversation.channel_id,
+                notification_text,
+                case_conversation_notification_template,
+                notification_type,
+                assignee_fullname=case.assignee.individual.name,
+                assignee_team=case.assignee.team,
+                assignee_weblink=case.assignee.individual.weblink,
+                case_priority_new=case.case_priority.name,
+                case_priority_old=previous_case.case_priority.name,
+                case_severity_new=case.case_severity.name,
+                case_severity_old=previous_case.case_severity.name,
+                case_status_new=case.status,
+                case_status_old=previous_case.status,
+                case_type_new=case.case_type.name,
+                case_type_old=previous_case.case_type.name,
+                name=case.name,
+                ticket_weblink=case.ticket.weblink,
+                title=case.title,
+                escalated_to_incident=case.incidents[0] if case.incidents else None,
+            )
+        else:
+            log.debug(
+                "Case updated notification not sent to case conversation. No conversation plugin enabled."  # noqa
+            )
+
+    # we send a notification to the notification conversations and emails
+    fyi_notification_template = notification_template.copy()
+    if case.status != CaseStatus.closed:
+        if case.project.allow_self_join:
+            fyi_notification_template.insert(0, CASE_NAME_WITH_ENGAGEMENT)
+        else:
+            fyi_notification_template.insert(0, CASE_NAME_WITH_ENGAGEMENT_NO_SELF_JOIN)
+    else:
+        fyi_notification_template.insert(0, CASE_NAME)
+
+    notification_kwargs = {
+        "assignee_fullname": case.assignee.individual.name,
+        "assignee_team": case.assignee.team,
+        "assignee_weblink": case.assignee.individual.weblink,
+        "contact_fullname": case.assignee.individual.name,
+        "contact_weblink": case.assignee.individual.weblink,
+        "case_id": case.id,
+        "case_priority_new": case.case_priority.name,
+        "case_priority_old": previous_case.case_priority.name,
+        "case_severity_new": case.case_severity.name,
+        "case_severity_old": previous_case.case_severity.name,
+        "case_status_new": case.status,
+        "case_status_old": previous_case.status,
+        "case_type_new": case.case_type.name,
+        "case_type_old": previous_case.case_type.name,
+        "name": case.name,
+        "organization_slug": case.project.organization.slug,
+        "ticket_weblink": resolve_attr(case, "ticket.weblink"),
+        "title": case.title,
+        "escalated_to_incident": case.incidents[0] if case.incidents else None,
+    }
+
+    notification_params = {
+        "text": notification_text,
+        "type": notification_type,
+        "template": fyi_notification_template,
+        "kwargs": notification_kwargs,
+    }
+
+    notification_service.filter_and_send(
+        db_session=db_session,
+        project_id=case.project.id,
+        class_instance=case,
+        notification_params=notification_params,
+    )
+
+    log.debug("Case updated notifications sent.")

--- a/src/dispatch/messaging/email/utils.py
+++ b/src/dispatch/messaging/email/utils.py
@@ -27,6 +27,7 @@ def get_template(message_type: MessageType, project_id: int):
         MessageType.incident_completed_form_notification: ("notification.mjml", None),
         MessageType.incident_executive_report: ("executive_report.mjml", None),
         MessageType.incident_notification: ("notification.mjml", None),
+        MessageType.case_notification: ("notification.mjml", None),
         MessageType.incident_participant_welcome: ("notification.mjml", None),
         MessageType.incident_tactical_report: ("tactical_report.mjml", None),
         MessageType.incident_task_reminder: (

--- a/src/dispatch/messaging/strings.py
+++ b/src/dispatch/messaging/strings.py
@@ -37,6 +37,7 @@ class MessageType(DispatchEnum):
     incident_tactical_report = "incident-tactical-report"
     incident_task_list = "incident-task-list"
     incident_task_reminder = "incident-task-reminder"
+    case_notification = "case-notification"
     case_status_reminder = "case-status-reminder"
     service_feedback = "service-feedback"
     task_add_to_incident = "task-add-to-incident"
@@ -201,7 +202,7 @@ INCIDENT_PARTICIPANT_SUGGESTED_READING_DESCRIPTION = """
 Dispatch thinks the following documents might be
 relevant to this incident.""".replace("\n", " ").strip()
 
-INCIDENT_NOTIFICATION_PURPOSES_FYI = """
+NOTIFICATION_PURPOSES_FYI = """
 This message is for notification purposes only.""".replace("\n", " ").strip()
 
 INCIDENT_TACTICAL_REPORT_DESCRIPTION = """
@@ -355,7 +356,7 @@ The incident priority has been changed from {{ incident_priority_old }} to {{ in
 INCIDENT_NAME_WITH_ENGAGEMENT = {
     "title": "{{name}} Incident Notification",
     "title_link": "{{ticket_weblink}}",
-    "text": INCIDENT_NOTIFICATION_PURPOSES_FYI,
+    "text": NOTIFICATION_PURPOSES_FYI,
     "buttons": [
         {
             "button_text": "Subscribe",
@@ -391,7 +392,7 @@ INCIDENT_NAME_WITH_ENGAGEMENT_NO_DESCRIPTION = {
 INCIDENT_NAME_WITH_ENGAGEMENT_NO_SELF_JOIN = {
     "title": "{{name}} Incident Notification",
     "title_link": "{{ticket_weblink}}",
-    "text": INCIDENT_NOTIFICATION_PURPOSES_FYI,
+    "text": NOTIFICATION_PURPOSES_FYI,
     "buttons": [
         {
             "button_text": "Subscribe",
@@ -401,10 +402,85 @@ INCIDENT_NAME_WITH_ENGAGEMENT_NO_SELF_JOIN = {
     ],
 }
 
+CASE_NAME = {
+    "title": "{{name}} Case Notification",
+    "title_link": "{{ticket_weblink}}",
+    "text": NOTIFICATION_PURPOSES_FYI,
+}
+
+CASE_NAME_WITH_ENGAGEMENT = {
+    "title": "{{name}} Case Notification",
+    "title_link": "{{ticket_weblink}}",
+    "text": NOTIFICATION_PURPOSES_FYI,
+    "buttons": [
+        {
+            "button_text": "Join",
+            "button_value": "{{organization_slug}}-{{incident_id}}",
+            "button_action": ConversationButtonActions.invite_user,
+        },
+    ],
+}
+
+CASE_NAME_WITH_ENGAGEMENT_NO_DESCRIPTION = {
+    "title": "{{name}}",
+    "title_link": "{{ticket_weblink}}",
+    "text": "{{ignore}}",
+    "buttons": [
+        {
+            "button_text": "Join",
+            "button_value": "{{organization_slug}}-{{incident_id}}",
+            "button_action": ConversationButtonActions.invite_user,
+        },
+    ],
+}
+
+CASE_NAME_WITH_ENGAGEMENT_NO_SELF_JOIN = {
+    "title": "{{name}} Case Notification",
+    "title_link": "{{ticket_weblink}}",
+    "text": NOTIFICATION_PURPOSES_FYI,
+}
+
+CASE_STATUS_CHANGE_DESCRIPTION = """
+The case status has been changed from {{ case_status_old }} to {{ case_status_new }}.""".replace(
+    "\n", " "
+).strip()
+
+CASE_TYPE_CHANGE_DESCRIPTION = """
+The case type has been changed from {{ case_type_old }} to {{ case_type_new }}.""".replace(
+    "\n", " "
+).strip()
+
+CASE_SEVERITY_CHANGE_DESCRIPTION = """
+The case severity has been changed from {{ case_severity_old }} to {{ case_severity_new }}.""".replace(
+    "\n", " "
+).strip()
+
+CASE_PRIORITY_CHANGE_DESCRIPTION = """
+The case priority has been changed from {{ case_priority_old }} to {{ case_priority_new }}.""".replace(
+    "\n", " "
+).strip()
+
+CASE_STATUS_CHANGE = {
+    "title": "Status Change",
+    "text": CASE_STATUS_CHANGE_DESCRIPTION,
+}
+
+CASE_TYPE_CHANGE = {"title": "Case Type Change", "text": CASE_TYPE_CHANGE_DESCRIPTION}
+
+CASE_SEVERITY_CHANGE = {
+    "title": "Severity Change",
+    "text": CASE_SEVERITY_CHANGE_DESCRIPTION,
+}
+
+CASE_PRIORITY_CHANGE = {
+    "title": "Priority Change",
+    "text": CASE_PRIORITY_CHANGE_DESCRIPTION,
+}
+
 INCIDENT_NAME = {
     "title": "{{name}} Incident Notification",
     "title_link": "{{ticket_weblink}}",
-    "text": INCIDENT_NOTIFICATION_PURPOSES_FYI,
+    "text": NOTIFICATION_PURPOSES_FYI,
 }
 
 INCIDENT_TITLE = {"title": "Title", "text": "{{title}}"}
@@ -668,6 +744,43 @@ CASE_TRIAGE_REMINDER = [
     CASE_TITLE,
     CASE_STATUS,
 ]
+
+CASE_ASSIGNEE_DESCRIPTION = """
+The Case Assignee is responsible for
+knowing the full context of the case.
+Contact them about any questions or concerns.""".replace("\n", " ").strip()
+
+CASE_REPORTER_DESCRIPTION = """
+The person who reported the case. Contact them if the report details need clarification.""".replace(
+    "\n", " "
+).strip()
+
+CASE_REPORTER = {
+    "title": "Reporter - {{reporter_fullname}}, {{reporter_team}}",
+    "title_link": "{{reporter_weblink}}",
+    "text": CASE_REPORTER_DESCRIPTION,
+}
+
+CASE_ASSIGNEE = {
+    "title": "Assignee - {{assignee_fullname}}, {{assignee_team}}",
+    "title_link": "{{assignee_weblink}}",
+    "text": CASE_ASSIGNEE_DESCRIPTION,
+}
+
+CASE_NOTIFICATION_COMMON = [CASE_TITLE]
+
+CASE_NOTIFICATION = CASE_NOTIFICATION_COMMON.copy()
+CASE_NOTIFICATION.extend(
+    [
+        INCIDENT_DESCRIPTION,
+        CASE_STATUS,
+        INCIDENT_TYPE,
+        INCIDENT_SEVERITY_FYI,
+        INCIDENT_PRIORITY_FYI,
+        CASE_REPORTER,
+        CASE_ASSIGNEE,
+    ]
+)
 
 
 INCIDENT_TASK_REMINDER = [


### PR DESCRIPTION
This PR adds notifications to dedicated channel cases, announcing updates in the channel and allows for both updates and new cases to be sent to an announcement conversation and/or email via search filters.

<img width="689" alt="image" src="https://github.com/Netflix/dispatch/assets/84562015/4121be04-f193-420b-a065-95a45c425327">
