### PR TITLE
bugfix: Fix python.yml to enable coverage per file

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -48,7 +48,7 @@ jobs:
           pip install pytest-cov
           pytest --junitxml=junit/test-results.xml --cov=dispatch --cov-report=json:coverage.json --cov-report=xml --cov-report=html
       - name: Coverage per file
-        # All modified files should meet the minimum code coverage requirement.
+        # All files should meet the minimum code coverage requirement.
         run: |
           export ALL_FILES=$(find . -name "*.py" -not -path "./.venv/*" | sed 's|^\./||')          
           export FAILED_COVERAGE_PER_FILE=$(python -c "import json;files=json.load(open('coverage.json'))['files'];covs=map(lambda k, v: (k, v['summary']['percent_covered_display']),files.keys(),files.values()); f=filter(lambda cov:int(cov[1])< ${{ env.COVERAGE_SINGLE }} ,covs); print('\n'.join('{:<68}{:>3}%'.format(k,v) for k,v in f))")
@@ -57,7 +57,7 @@ jobs:
           files=($(comm -12 <(for X in "${ALL_FILES}"; do echo "${X}"; done|sort) <(for X in "${FAILED_COVERAGE_FILES}"; do echo "${X}"; done|sort)))
 
           if [[ ${#files[@]} > 0 ]]; then
-            echo "FAIL Recommended file test coverage of ${{ env.COVERAGE_SINGLE }}% not reached. All modified files must meet the minimum code coverage requirement."
+            echo "FAIL Recommended file test coverage of ${{ env.COVERAGE_SINGLE }}% not reached. All files must meet the minimum code coverage requirement."
 
             for f in "${files[@]}"; do
               echo $FAILED_COVERAGE_PER_FILE | grep $f

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -50,11 +50,11 @@ jobs:
       - name: Coverage per file
         # All modified files should meet the minimum code coverage requirement.
         run: |
-          export MODIFIED_FILES=$(git diff origin/master...HEAD --name-only | grep -E '\.py$')
-          export FAILED_COVERAGE_PER_FILE=$(python -c "import json;files=json.load(open('coverage.json'))['files'];covs=map(lambda k, v: (k, v['summary']['percent_covered_display']),files.keys(),files.values()); f=filter(lambda cov:int(cov[1])< ${{ env.COVERAGE_SINGLE }}% ,covs); print('\n'.join('{:<68}{:>3}%'.format(k,v) for k,v in f))")
+          export ALL_FILES=$(find . -name "*.py" -not -path "./.venv/*" | sed 's|^\./||')          
+          export FAILED_COVERAGE_PER_FILE=$(python -c "import json;files=json.load(open('coverage.json'))['files'];covs=map(lambda k, v: (k, v['summary']['percent_covered_display']),files.keys(),files.values()); f=filter(lambda cov:int(cov[1])< ${{ env.COVERAGE_SINGLE }} ,covs); print('\n'.join('{:<68}{:>3}%'.format(k,v) for k,v in f))")
           export FAILED_COVERAGE_FILES=(); while IFS= read -r line; do FAILED_COVERAGE_FILES+=("${line%%[[:space:]]*}");done <<< "$FAILED_COVERAGE_PER_FILE"
 
-          files=($(comm -12 <(for X in "${MODIFIED_FILES}"; do echo "${X}"; done|sort) <(for X in "${FAILED_COVERAGE_FILES}"; do echo "${X}"; done|sort)))
+          files=($(comm -12 <(for X in "${ALL_FILES}"; do echo "${X}"; done|sort) <(for X in "${FAILED_COVERAGE_FILES}"; do echo "${X}"; done|sort)))
 
           if [[ ${#files[@]} > 0 ]]; then
             echo "FAIL Recommended file test coverage of ${{ env.COVERAGE_SINGLE }}% not reached. All modified files must meet the minimum code coverage requirement."

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -50,11 +50,11 @@ jobs:
       - name: Coverage per file
         # All modified files should meet the minimum code coverage requirement.
         run: |
-          export MODIFIED_FILES=$(git diff master...HEAD --name-only | grep -E '\.py$')
-          export FAILED_COVERAGE_PER_FILE=$(python -c "import json;files=json.load(open('coverage.json'))['files'];covs=map(lambda k, v: (k, v['summary']['percent_covered_display']),files.keys(),files.values()); f=filter(lambda cov:int(cov[1])<50,covs); print('\n'.join('{:<68}{:>3}%'.format(k,v) for k,v in f))")
-          export FAILED_COVERAGE_FILES=(); echo "$FAILED_COVERAGE_PER_FILE" | while read -r line; do FAILED_COVERAGE_FILES+=${line%%[[:space:]]*};done
+          export MODIFIED_FILES=$(git diff origin/master...HEAD --name-only | grep -E '\.py$')
+          export FAILED_COVERAGE_PER_FILE=$(python -c "import json;files=json.load(open('coverage.json'))['files'];covs=map(lambda k, v: (k, v['summary']['percent_covered_display']),files.keys(),files.values()); f=filter(lambda cov:int(cov[1])< ${{ env.COVERAGE_SINGLE }}% ,covs); print('\n'.join('{:<68}{:>3}%'.format(k,v) for k,v in f))")
+          export FAILED_COVERAGE_FILES=(); while IFS= read -r line; do FAILED_COVERAGE_FILES+=("${line%%[[:space:]]*}");done <<< "$FAILED_COVERAGE_PER_FILE"
 
-          files=($(comm -12 <(for X in "${MODIFIED_FILES}"; do echo "${X}"; done|sort) <(for X in "${FAILED_COVERAGE_FILENAMES}"; do echo "${X}"; done|sort)))
+          files=($(comm -12 <(for X in "${MODIFIED_FILES}"; do echo "${X}"; done|sort) <(for X in "${FAILED_COVERAGE_FILES}"; do echo "${X}"; done|sort)))
 
           if [[ ${#files[@]} > 0 ]]; then
             echo "FAIL Recommended file test coverage of ${{ env.COVERAGE_SINGLE }}% not reached. All modified files must meet the minimum code coverage requirement."


### PR DESCRIPTION
If you open python coverage per file in a pull request you will see that it didn't check for coverage per file.
[Check coverage per file](https://github.com/Netflix/dispatch/actions/runs/9793998855/job/27043112314?pr=4917)

I fixed it, and now it should work well.