### PR TITLE
Turns off unfurling links and adds conversation link to help tips

### DIFF
--- a/src/dispatch/incident/messaging.py
+++ b/src/dispatch/incident/messaging.py
@@ -1176,6 +1176,7 @@ def send_incident_management_help_tips_message(incident: Incident, db_session: S
             "executive_report_command": executive_report_command,
             "tactical_report_command": tactical_report_command,
             "update_command": update_command,
+            "conversation_weblink": resolve_attr(incident, "conversation.weblink"),
         }
     ]
 

--- a/src/dispatch/messaging/strings.py
+++ b/src/dispatch/messaging/strings.py
@@ -318,7 +318,7 @@ INCIDENT_CLOSED_RATING_FEEDBACK_DESCRIPTION = """
 Thanks for participating in the {{name}} ("{{title}}") incident. We would appreciate if you could rate your experience and provide feedback."""
 
 INCIDENT_MANAGEMENT_HELP_TIPS_MESSAGE_DESCRIPTION = """
-Hey, I see you're the Incident Commander for {{name}} ("{{title}}"). Here are a few things to consider when managing the incident:
+Hey, I see you're the Incident Commander for <{{conversation_weblink}}|{{name}}> ("{{title}}"). Here are a few things to consider when managing the incident:
 \n • Keep the incident and its status up to date using the Slack `{{update_command}}` command.
 \n • Invite incident participants and team oncalls by mentioning them in the incident channel or using the Slack `{{engage_oncall_command}}` command.
 \n • Keep incident participants and stakeholders informed by creating tactical and executive reports using the `{{tactical_report_command}}` and `{{executive_report_command}}` commands.

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -420,6 +420,7 @@ def send_message(
         text=text,
         thread_ts=ts,
         blocks=blocks,
+        unfurl_links=False,
     )
 
     if persist:


### PR DESCRIPTION
This PR turns off unfurling links, to avoid this kind of bad preview. In addition, there is now a link to the conversation in the incident management tips message.

<img width="307" alt="image" src="https://github.com/Netflix/dispatch/assets/84562015/4521c8f1-d437-4bab-bd33-a736149d984e">

<img width="613" alt="image" src="https://github.com/Netflix/dispatch/assets/84562015/ddd81e1c-e39d-4f27-8e84-287674f5e772">

