### PR TITLE
Do not overwrite description field

### DIFF
--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -439,6 +439,7 @@ def case_escalated_status_flow(
     db_session: Session,
     incident_priority: IncidentType | None,
     incident_type: IncidentPriority | None,
+    incident_description: str | None,
 ):
     """Runs the case escalated transition flow."""
     # we set the escalated_at time
@@ -452,6 +453,7 @@ def case_escalated_status_flow(
         db_session=db_session,
         incident_priority=incident_priority,
         incident_type=incident_type,
+        incident_description=incident_description,
     )
 
 
@@ -749,6 +751,7 @@ def case_to_incident_escalate_flow(
     db_session: Session,
     incident_priority: IncidentPriority | None,
     incident_type: IncidentType,
+    incident_description: str | None,
 ):
     if case.incidents:
         return
@@ -758,7 +761,7 @@ def case_to_incident_escalate_flow(
     )
 
     description = (
-        f"{case.description}\n\n"
+        f"{incident_description if incident_description else case.description}\n\n"
         f"This incident was the result of escalating case {case.name} "
         f"in the {case.project.name} project. Check out the case in the Dispatch Web UI for additional context."
     )

--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -1277,6 +1277,7 @@ def handle_escalation_submission_event(
             project_id=case.project.id,
             name=form_data[DefaultBlockIds.incident_priority_select]["name"],
         )
+    incident_description = form_data.get(DefaultBlockIds.description_input, case.description)
 
     case_flows.case_escalated_status_flow(
         case=case,
@@ -1284,6 +1285,7 @@ def handle_escalation_submission_event(
         db_session=db_session,
         incident_priority=incident_priority,
         incident_type=incident_type,
+        incident_description=incident_description,
     )
     incident = case.incidents[0]
 


### PR DESCRIPTION
This PR fixes the following bug:
* When escalating a case via Slack, the user’s incident description is overwritten with the case description

How to test:
* In Slack, Report a case
* In the resulting case channel, type `/dispatch-escalate-case'
* Modify the description field and submit
* The new incident description should have the updated information as a prefix."