### PR TITLE
security: Do not render blocks in Jinja message templates

### DIFF
--- a/src/dispatch/messaging/email/filters.py
+++ b/src/dispatch/messaging/email/filters.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import markdown
 from jinja2 import FileSystemLoader
-from jinja2.sandbox import SandboxedEnvironment
+from jinja2.sandbox import ImmutableSandboxedEnvironment
 from markupsafe import Markup
 from dispatch import config
 
@@ -11,11 +11,10 @@ here = os.path.dirname(os.path.realpath(__file__))
 
 
 autoescape = bool(config.DISPATCH_ESCAPE_HTML)
-env = SandboxedEnvironment(loader=FileSystemLoader(here), autoescape=autoescape)
+env = ImmutableSandboxedEnvironment(loader=FileSystemLoader(here), autoescape=autoescape)
 
 
 def safe_format_datetime(value):
-    print("safe format datetime", value)
     try:
         return datetime.fromisoformat(value).strftime("%A, %B %d, %Y")
     except (ValueError, TypeError):

--- a/src/dispatch/messaging/email/filters.py
+++ b/src/dispatch/messaging/email/filters.py
@@ -4,58 +4,29 @@ from datetime import datetime
 import markdown
 from jinja2 import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
-from jinja2.ext import Extension
 from markupsafe import Markup
 from dispatch import config
 
 here = os.path.dirname(os.path.realpath(__file__))
 
 
-class SkipAllBlocksExtension(Extension):
-    """Jinja2 extension that skips rendering and execution of all blocks."""
-
-    def __init__(self, environment):
-        super(SkipAllBlocksExtension, self).__init__(environment)
-        environment.extend(skip_blocks=[])
-
-    def filter_stream(self, stream):
-        block_level = 0
-        skip_level = 0
-        in_endblock = False
-
-        for token in stream:
-            if token.type == "block_begin":
-                block_level += 1
-                skip_level = block_level
-
-            if token.value == "endblock":
-                in_endblock = True
-
-            if skip_level == 0:
-                yield token
-
-            if token.type == "block_end":
-                if in_endblock:
-                    in_endblock = False
-                    block_level -= 1
-
-                    if skip_level == block_level + 1:
-                        skip_level = 0
-
-
 autoescape = bool(config.DISPATCH_ESCAPE_HTML)
-env = SandboxedEnvironment(
-    loader=FileSystemLoader(here), extensions=[SkipAllBlocksExtension], autoescape=autoescape
-)
+env = SandboxedEnvironment(loader=FileSystemLoader(here), autoescape=autoescape)
 
 
-def format_datetime(value):
-    return datetime.fromisoformat(value).strftime("%A, %B %d, %Y")
+def safe_format_datetime(value):
+    print("safe format datetime", value)
+    try:
+        return datetime.fromisoformat(value).strftime("%A, %B %d, %Y")
+    except (ValueError, TypeError):
+        return ""
 
 
-def format_markdown(value):
-    return Markup(markdown.markdown(value))
+def safe_format_markdown(value):
+    if not isinstance(value, str):
+        return ""
+    return Markup(markdown.markdown(value, output_format="html5", extensions=["extra"]))
 
 
-env.filters["datetime"] = format_datetime
-env.filters["markdown"] = format_markdown
+env.filters["datetime"] = safe_format_datetime
+env.filters["markdown"] = safe_format_markdown

--- a/src/dispatch/messaging/email/filters.py
+++ b/src/dispatch/messaging/email/filters.py
@@ -6,13 +6,49 @@ from jinja2 import (
     Environment,
     FileSystemLoader,
 )
+from jinja2.ext import Extension
 from markupsafe import Markup
 from dispatch import config
 
 here = os.path.dirname(os.path.realpath(__file__))
 
+
+class SkipAllBlocksExtension(Extension):
+    """Jinja2 extension that skips rendering and execution of all blocks."""
+
+    def __init__(self, environment):
+        super(SkipAllBlocksExtension, self).__init__(environment)
+        environment.extend(skip_blocks=[])
+
+    def filter_stream(self, stream):
+        block_level = 0
+        skip_level = 0
+        in_endblock = False
+
+        for token in stream:
+            if token.type == "block_begin":
+                block_level += 1
+                skip_level = block_level
+
+            if token.value == "endblock":
+                in_endblock = True
+
+            if skip_level == 0:
+                yield token
+
+            if token.type == "block_end":
+                if in_endblock:
+                    in_endblock = False
+                    block_level -= 1
+
+                    if skip_level == block_level + 1:
+                        skip_level = 0
+
+
 autoescape = bool(config.DISPATCH_ESCAPE_HTML)
-env = Environment(loader=FileSystemLoader(here), autoescape=autoescape)
+env = Environment(
+    loader=FileSystemLoader(here), extensions=[SkipAllBlocksExtension], autoescape=autoescape
+)
 
 
 def format_datetime(value):

--- a/src/dispatch/messaging/email/filters.py
+++ b/src/dispatch/messaging/email/filters.py
@@ -2,10 +2,8 @@ import os
 from datetime import datetime
 
 import markdown
-from jinja2 import (
-    Environment,
-    FileSystemLoader,
-)
+from jinja2 import FileSystemLoader
+from jinja2.sandbox import SandboxedEnvironment
 from jinja2.ext import Extension
 from markupsafe import Markup
 from dispatch import config
@@ -46,7 +44,7 @@ class SkipAllBlocksExtension(Extension):
 
 
 autoescape = bool(config.DISPATCH_ESCAPE_HTML)
-env = Environment(
+env = SandboxedEnvironment(
     loader=FileSystemLoader(here), extensions=[SkipAllBlocksExtension], autoescape=autoescape
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ from .factories import (
     DefinitionFactory,
     DispatchUserFactory,
     DocumentFactory,
+    EmailTemplateFactory,
     EntityFactory,
     EntityTypeFactory,
     EventFactory,
@@ -583,6 +584,11 @@ def incident_cost_type(session):
 @pytest.fixture
 def incident_cost_types(session):
     return [IncidentCostTypeFactory(), IncidentCostTypeFactory()]
+
+
+@pytest.fixture
+def email_template(session):
+    return EmailTemplateFactory()
 
 
 @pytest.fixture

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -26,6 +26,8 @@ from dispatch.conference.models import Conference
 from dispatch.conversation.models import Conversation
 from dispatch.definition.models import Definition
 from dispatch.document.models import Document
+from dispatch.email_templates.models import EmailTemplates
+from dispatch.email_templates.enums import EmailTemplateTypes
 from dispatch.entity.models import Entity
 from dispatch.entity_type.models import EntityType
 from dispatch.event.models import Event
@@ -1214,6 +1216,22 @@ class IncidentCostTypeFactory(BaseFactory):
         """Factory Configuration."""
 
         model = IncidentCostType
+
+
+class EmailTemplateFactory(BaseFactory):
+    """Email Template Factory."""
+
+    # Columns
+    email_template_type = EmailTemplateTypes.welcome
+    welcome_text = "Welcome to Incident {{title}} "
+    welcome_body = "{{title}} Incident\n{{description}}"
+    components = ["title", "description"]
+    enabled = True
+
+    class Meta:
+        """Factory Configuration."""
+
+        model = EmailTemplates
 
 
 class NotificationFactory(BaseFactory):

--- a/tests/messaging/test_messaging.py
+++ b/tests/messaging/test_messaging.py
@@ -50,11 +50,11 @@ def test_render_message_template__disable_code_execution():
 
     message_template = [
         {
-            "title": "{{title}}",
-            "body": "{% if True %} {{body}} {% endif %}",
+            "title": "{{ title }}",
+            "body": "{% for i in [].append(123) }...{% endfor %}",
         }
     ]
-    kwargs = {"title": "Test Title", "body": "Test Body"}
+    kwargs = {"title": "Test Title"}
 
     rendered = render_message_template(message_template, **kwargs)
 

--- a/tests/messaging/test_messaging.py
+++ b/tests/messaging/test_messaging.py
@@ -1,0 +1,81 @@
+def test_render_message_template():
+    """Tests the render_message_template function.
+
+    The message template should be filled with the kwargs values, and the datetime field should be properly formatted.
+    """
+    from dispatch.messaging.email.utils import render_message_template
+    from datetime import datetime, UTC
+
+    message_template = [
+        {
+            "title": "{{title}}",
+            "text": "{{body}}",
+            "datetime": "{{datetime | datetime}}",
+        }
+    ]
+    kwargs = {
+        "title": "Test Title",
+        "body": "Test Body",
+        "datetime": datetime.now(UTC).isoformat(),
+    }
+
+    rendered = render_message_template(message_template, **kwargs)
+
+    assert rendered
+    assert rendered[0].get("title") == kwargs.get("title")
+    assert rendered[0].get("text") == kwargs.get("body")
+    assert rendered[0].get("datetime")
+
+
+def test_render_message_template__failed_filter():
+    """Tests that render_message_template fails when the input does not adhere to the datetime filter rules."""
+    from dispatch.messaging.email.utils import render_message_template
+
+    message_template = [
+        {
+            "datetime": "{{datetime | datetime}}",
+        }
+    ]
+    kwargs = {"datetime": "1234"}
+
+    rendered = render_message_template(message_template, **kwargs)
+
+    assert rendered
+    assert not rendered[0].get("datetime")
+
+
+def test_render_message_template__disable_code_execution():
+    """Tests that render_message_template does not execute scripts in user input."""
+    from dispatch.messaging.email.utils import render_message_template
+
+    message_template = [
+        {
+            "title": "{{title}}",
+            "body": "{% if True %} {{body}} {% endif %}",
+        }
+    ]
+    kwargs = {"title": "Test Title", "body": "Test Body"}
+
+    rendered = render_message_template(message_template, **kwargs)
+
+    assert rendered
+    assert rendered[0].get("title") == kwargs.get("title")
+    assert rendered[0].get("body") == message_template[0].get("body")
+
+
+def test_generate_welcome_message__default():
+    """Tests the generate_welcome_message function."""
+    from dispatch.messaging.strings import generate_welcome_message
+
+    assert generate_welcome_message(None)
+
+
+def test_generate_welcome_message__email_template(email_template):
+    """Tests the generate_welcome_message function with an email template."""
+    from dispatch.messaging.strings import generate_welcome_message
+
+    welcome_message = generate_welcome_message(email_template)
+
+    assert welcome_message
+    assert welcome_message[0].get("title") == email_template.welcome_text
+    assert welcome_message[0].get("text") == email_template.welcome_body

--- a/tests/messaging/test_messaging.py
+++ b/tests/messaging/test_messaging.py
@@ -51,7 +51,7 @@ def test_render_message_template__disable_code_execution():
     message_template = [
         {
             "title": "{{ title }}",
-            "body": "{% for i in [].append(123) }...{% endfor %}",
+            "body": "{% for i in [].append(123) %}...{% endfor %}",
         }
     ]
     kwargs = {"title": "Test Title"}


### PR DESCRIPTION
This PR prevents Jinja blocks from being executed. This occurs when messages are rendered.