### PR TITLE
Disables tabs in incident edit until populated

### DIFF
--- a/src/dispatch/static/dispatch/src/incident/EditSheet.vue
+++ b/src/dispatch/static/dispatch/src/incident/EditSheet.vue
@@ -32,7 +32,7 @@
           </template>
         </v-list-item>
       </template>
-      <v-tabs color="primary" fixed-tabs v-model="tab">
+      <v-tabs color="primary" fixed-tabs v-model="tab" :disabled="id == null">
         <v-tab value="details"> Details </v-tab>
         <v-tab value="resources"> Resources </v-tab>
         <v-tab value="participants"> Participants </v-tab>


### PR DESCRIPTION
This PR makes the tabs in the incident edit pane disabled until the incident data is returned and populated, preventing the tabs from appearing blank.