### PR TITLE
Truncate the case resolution reason text due to Slack limit

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -38,6 +38,7 @@ from dispatch.signal.models import (
     assoc_signal_instance_entities,
 )
 from dispatch.signal.enums import SignalEngagementStatus
+from dispatch.plugins.dispatch_slack.config import MAX_SECTION_TEXT_LENGTH
 
 
 def map_priority_color(color: str) -> str:
@@ -114,7 +115,9 @@ def create_case_message(case: Case, channel_id: str) -> list[Block]:
         blocks.extend(
             [
                 Section(text=f"*Resolution reason* \n {case.resolution_reason}"),
-                Section(text=f"*Resolution description* \n {case.resolution}"[:3000]),
+                Section(
+                    text=f"*Resolution description* \n {case.resolution}"[:MAX_SECTION_TEXT_LENGTH]
+                ),
                 Actions(
                     elements=[
                         Button(

--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -114,7 +114,7 @@ def create_case_message(case: Case, channel_id: str) -> list[Block]:
         blocks.extend(
             [
                 Section(text=f"*Resolution reason* \n {case.resolution_reason}"),
-                Section(text=f"*Resolution description* \n {case.resolution}"),
+                Section(text=f"*Resolution description* \n {case.resolution}"[:3000]),
                 Actions(
                     elements=[
                         Button(

--- a/src/dispatch/plugins/dispatch_slack/config.py
+++ b/src/dispatch/plugins/dispatch_slack/config.py
@@ -3,6 +3,9 @@ from pydantic import Field, SecretStr
 from dispatch.config import BaseConfigurationModel
 
 
+MAX_SECTION_TEXT_LENGTH = 3000
+
+
 class SlackConfiguration(BaseConfigurationModel):
     """Slack configuration description."""
 

--- a/src/dispatch/plugins/dispatch_slack/fields.py
+++ b/src/dispatch/plugins/dispatch_slack/fields.py
@@ -25,6 +25,7 @@ from dispatch.incident.type import service as incident_type_service
 from dispatch.incident.priority import service as incident_priority_service
 from dispatch.incident.severity import service as incident_severity_service
 from dispatch.signal.models import Signal
+from dispatch.plugins.dispatch_slack.config import MAX_SECTION_TEXT_LENGTH
 
 
 class DefaultBlockIds(DispatchEnum):
@@ -328,7 +329,7 @@ def title_input(
             placeholder=placeholder,
             initial_value=initial_value,
             action_id=action_id,
-            max_length=3000,
+            max_length=MAX_SECTION_TEXT_LENGTH,
         ),
         label=label,
         block_id=block_id,
@@ -351,7 +352,7 @@ def description_input(
             initial_value=initial_value,
             multiline=True,
             action_id=action_id,
-            max_length=3000,
+            max_length=MAX_SECTION_TEXT_LENGTH,
         ),
         block_id=block_id,
         label=label,
@@ -373,7 +374,7 @@ def resolution_input(
             initial_value=initial_value,
             multiline=True,
             action_id=action_id,
-            max_length=3000,
+            max_length=MAX_SECTION_TEXT_LENGTH,
         ),
         block_id=block_id,
         label=label,

--- a/src/dispatch/plugins/dispatch_slack/fields.py
+++ b/src/dispatch/plugins/dispatch_slack/fields.py
@@ -299,7 +299,9 @@ def project_select(
 ):
     """Creates a project select."""
     projects = [
-        {"text": p.name, "value": p.id} for p in project_service.get_all(db_session=db_session) if p.enabled
+        {"text": p.name, "value": p.id}
+        for p in project_service.get_all(db_session=db_session)
+        if p.enabled
     ]
     return static_select_block(
         placeholder="Select Project",
@@ -326,6 +328,7 @@ def title_input(
             placeholder=placeholder,
             initial_value=initial_value,
             action_id=action_id,
+            max_length=3000,
         ),
         label=label,
         block_id=block_id,
@@ -348,6 +351,7 @@ def description_input(
             initial_value=initial_value,
             multiline=True,
             action_id=action_id,
+            max_length=3000,
         ),
         block_id=block_id,
         label=label,
@@ -369,6 +373,7 @@ def resolution_input(
             initial_value=initial_value,
             multiline=True,
             action_id=action_id,
+            max_length=3000,
         ),
         block_id=block_id,
         label=label,


### PR DESCRIPTION
Slack has a 3000 character limit on section text, so we're truncating the resolution text in case it is longer.