### PR TITLE
Removes subqueries to ensure pagination works

### DIFF
--- a/src/dispatch/case/models.py
+++ b/src/dispatch/case/models.py
@@ -104,14 +104,10 @@ class Case(Base, TimeStampMixin, ProjectMixin):
 
     # relationships
     assignee_id = Column(Integer, ForeignKey("participant.id", ondelete="CASCADE"))
-    assignee = relationship(
-        Participant, foreign_keys=[assignee_id], lazy="subquery", post_update=True
-    )
+    assignee = relationship(Participant, foreign_keys=[assignee_id], post_update=True)
 
     reporter_id = Column(Integer, ForeignKey("participant.id", ondelete="CASCADE"))
-    reporter = relationship(
-        Participant, foreign_keys=[reporter_id], lazy="subquery", post_update=True
-    )
+    reporter = relationship(Participant, foreign_keys=[reporter_id], post_update=True)
 
     case_type = relationship("CaseType", backref="case")
     case_type_id = Column(Integer, ForeignKey("case_type.id"))

--- a/src/dispatch/incident/models.py
+++ b/src/dispatch/incident/models.py
@@ -197,14 +197,10 @@ class Incident(Base, TimeStampMixin, ProjectMixin):
     )
 
     commander_id = Column(Integer, ForeignKey("participant.id"))
-    commander = relationship(
-        "Participant", foreign_keys=[commander_id], lazy="subquery", post_update=True
-    )
+    commander = relationship("Participant", foreign_keys=[commander_id], post_update=True)
 
     reporter_id = Column(Integer, ForeignKey("participant.id"))
-    reporter = relationship(
-        "Participant", foreign_keys=[reporter_id], lazy="subquery", post_update=True
-    )
+    reporter = relationship("Participant", foreign_keys=[reporter_id], post_update=True)
 
     liaison_id = Column(Integer, ForeignKey("participant.id"))
     liaison = relationship("Participant", foreign_keys=[liaison_id], post_update=True)


### PR DESCRIPTION
This PR fixes the empty commander, assignee, and reporter fields when paginating through cases and incidents using the API.