### PR TITLE
Fixes selection ordering and includes project when filtering

### DIFF
--- a/src/dispatch/static/dispatch/src/case/TableFilterDialog.vue
+++ b/src/dispatch/static/dispatch/src/case/TableFilterDialog.vue
@@ -21,13 +21,13 @@
             <project-combobox v-model="local_project" label="Projects" />
           </v-list-item>
           <v-list-item>
-            <case-type-combobox v-model="local_case_type" />
+            <case-type-combobox :project="local_project" v-model="local_case_type" />
           </v-list-item>
           <v-list-item>
-            <case-severity-combobox v-model="local_case_severity" />
+            <case-severity-combobox :project="local_project" v-model="local_case_severity" />
           </v-list-item>
           <v-list-item>
-            <case-priority-combobox v-model="local_case_priority" />
+            <case-priority-combobox :project="local_project" v-model="local_case_priority" />
           </v-list-item>
           <v-list-item>
             <case-status-multi-select v-model="local_status" />

--- a/src/dispatch/static/dispatch/src/case/priority/CasePriorityCombobox.vue
+++ b/src/dispatch/static/dispatch/src/case/priority/CasePriorityCombobox.vue
@@ -25,13 +25,13 @@
     </template>
     <template #chip="{ item, props }">
       <v-chip v-bind="props">
-        <span v-if="!project"> {{ item.raw.project.name }}/ </span>{{ item.raw.name }}
+        <span>{{ item.raw.project.name }}/</span>{{ item.raw.name }}
       </v-chip>
     </template>
     <template #item="data">
       <v-list-item v-bind="data.props" :title="null">
         <v-list-item-title>
-          <span v-if="!project">{{ data.item.raw.project.name }}/</span>{{ data.item.raw.name }}
+          <span>{{ data.item.raw.project.name }}/</span>{{ data.item.raw.name }}
         </v-list-item-title>
         <v-list-item-subtitle :title="data.item.raw.description">
           {{ data.item.raw.description }}
@@ -111,18 +111,9 @@ export default {
       this.loading = "error"
       let filterOptions = {
         q: this.search,
-        sortBy: ["name"],
-        descending: [false],
+        sortBy: ["project_id", "name"],
+        descending: [false, false],
         itemsPerPage: this.numItems,
-      }
-
-      if (this.project) {
-        filterOptions = {
-          ...filterOptions,
-          filters: {
-            project: [this.project],
-          },
-        }
       }
 
       let enabledFilter = [
@@ -134,8 +125,19 @@ export default {
         },
       ]
 
+      if (this.project && this.project.length > 0) {
+        const project_ids = this.project.map((p) => p.id)
+        enabledFilter.push({
+          model: "CasePriority",
+          field: "project_id",
+          op: "in",
+          value: project_ids,
+        })
+      }
+
       filterOptions = SearchUtils.createParametersFromTableOptions(
         { ...filterOptions },
+        "CasePriority",
         enabledFilter
       )
 
@@ -160,6 +162,12 @@ export default {
 
   created() {
     this.fetchData()
+    this.$watch(
+      (vm) => [vm.project],
+      () => {
+        this.fetchData()
+      }
+    )
   },
 }
 </script>

--- a/src/dispatch/static/dispatch/src/case/priority/CasePrioritySelect.vue
+++ b/src/dispatch/static/dispatch/src/case/priority/CasePrioritySelect.vue
@@ -121,6 +121,7 @@ export default {
 
       filterOptions = SearchUtils.createParametersFromTableOptions(
         { ...filterOptions },
+        "CasePriority",
         enabledFilter
       )
 

--- a/src/dispatch/static/dispatch/src/case/severity/CaseSeverityCombobox.vue
+++ b/src/dispatch/static/dispatch/src/case/severity/CaseSeverityCombobox.vue
@@ -25,13 +25,13 @@
     </template>
     <template #chip="{ item, props }">
       <v-chip v-bind="props">
-        <span v-if="!project"> {{ item.raw.project.name }}/ </span>{{ item.raw.name }}
+        <span>{{ item.raw.project.name }}/</span>{{ item.raw.name }}
       </v-chip>
     </template>
     <template #item="data">
       <v-list-item v-bind="data.props" :title="null">
         <v-list-item-title>
-          <span v-if="!project">{{ data.item.raw.project.name }}/</span>{{ data.item.raw.name }}
+          <span>{{ data.item.raw.project.name }}/</span>{{ data.item.raw.name }}
         </v-list-item-title>
         <v-list-item-subtitle :title="data.item.raw.description">
           {{ data.item.raw.description }}
@@ -112,18 +112,9 @@ export default {
       this.loading = "error"
       let filterOptions = {
         q: this.search,
-        sortBy: ["name"],
-        descending: [false],
+        sortBy: ["project_id", "name"],
+        descending: [false, false],
         itemsPerPage: this.numItems,
-      }
-
-      if (this.project) {
-        filterOptions = {
-          ...filterOptions,
-          filters: {
-            project: [this.project],
-          },
-        }
       }
 
       let enabledFilter = [
@@ -135,8 +126,19 @@ export default {
         },
       ]
 
+      if (this.project && this.project.length > 0) {
+        const project_ids = this.project.map((p) => p.id)
+        enabledFilter.push({
+          model: "CaseSeverity",
+          field: "project_id",
+          op: "in",
+          value: project_ids,
+        })
+      }
+
       filterOptions = SearchUtils.createParametersFromTableOptions(
         { ...filterOptions },
+        "CaseSeverity",
         enabledFilter
       )
 
@@ -161,6 +163,12 @@ export default {
 
   created() {
     this.fetchData()
+    this.$watch(
+      (vm) => [vm.project],
+      () => {
+        this.fetchData()
+      }
+    )
   },
 }
 </script>

--- a/src/dispatch/static/dispatch/src/case/severity/CaseSeveritySelect.vue
+++ b/src/dispatch/static/dispatch/src/case/severity/CaseSeveritySelect.vue
@@ -104,6 +104,7 @@ export default {
 
       filterOptions = SearchUtils.createParametersFromTableOptions(
         { ...filterOptions },
+        "CaseSeverity",
         enabledFilter
       )
 

--- a/src/dispatch/static/dispatch/src/case/type/CaseTypeCombobox.vue
+++ b/src/dispatch/static/dispatch/src/case/type/CaseTypeCombobox.vue
@@ -25,13 +25,13 @@
     </template>
     <template #chip="{ item, props }">
       <v-chip v-bind="props">
-        <span v-if="!project"> {{ item.raw.project.name }}/ </span>{{ item.raw.name }}
+        <span>{{ item.raw.project.name }}/</span>{{ item.raw.name }}
       </v-chip>
     </template>
     <template #item="data">
       <v-list-item v-bind="data.props" :title="null">
         <v-list-item-title>
-          <span v-if="!project">{{ data.item.raw.project.name }}/</span>{{ data.item.raw.name }}
+          <span>{{ data.item.raw.project.name }}/</span>{{ data.item.raw.name }}
         </v-list-item-title>
         <v-list-item-subtitle :title="data.item.raw.description">
           {{ data.item.raw.description }}
@@ -79,7 +79,7 @@ export default {
       loading: false,
       items: [],
       more: false,
-      numItems: 5,
+      numItems: 15,
       search: null,
     }
   },
@@ -104,7 +104,7 @@ export default {
 
   methods: {
     loadMore() {
-      this.numItems = this.numItems + 5
+      this.numItems = this.numItems + 10
       this.fetchData()
     },
     fetchData() {
@@ -113,18 +113,9 @@ export default {
 
       let filterOptions = {
         q: this.search,
-        sortBy: ["name"],
-        descending: [false],
+        sortBy: ["project_id", "name"],
+        descending: [false, false],
         itemsPerPage: this.numItems,
-      }
-
-      if (this.project) {
-        filterOptions = {
-          ...filterOptions,
-          filters: {
-            project: [this.project],
-          },
-        }
       }
 
       let enabledFilter = [
@@ -136,8 +127,19 @@ export default {
         },
       ]
 
+      if (this.project && this.project.length > 0) {
+        const project_ids = this.project.map((p) => p.id)
+        enabledFilter.push({
+          model: "CaseType",
+          field: "project_id",
+          op: "in",
+          value: project_ids,
+        })
+      }
+
       filterOptions = SearchUtils.createParametersFromTableOptions(
         { ...filterOptions },
+        "CaseType",
         enabledFilter
       )
 
@@ -162,6 +164,12 @@ export default {
 
   created() {
     this.fetchData()
+    this.$watch(
+      (vm) => [vm.project],
+      () => {
+        this.fetchData()
+      }
+    )
   },
 }
 </script>

--- a/src/dispatch/static/dispatch/src/incident/TableFilterDialog.vue
+++ b/src/dispatch/static/dispatch/src/incident/TableFilterDialog.vue
@@ -21,13 +21,19 @@
             <project-combobox v-model="local_project" label="Projects" />
           </v-list-item>
           <v-list-item>
-            <incident-type-combobox v-model="local_incident_type" />
+            <incident-type-combobox :project="local_project" v-model="local_incident_type" />
           </v-list-item>
           <v-list-item>
-            <incident-severity-combobox v-model="local_incident_severity" />
+            <incident-severity-combobox
+              :project="local_project"
+              v-model="local_incident_severity"
+            />
           </v-list-item>
           <v-list-item>
-            <incident-priority-combobox v-model="local_incident_priority" />
+            <incident-priority-combobox
+              :project="local_project"
+              v-model="local_incident_priority"
+            />
           </v-list-item>
           <v-list-item>
             <incident-status-multi-select v-model="local_status" />

--- a/src/dispatch/static/dispatch/src/incident/priority/IncidentPriorityCombobox.vue
+++ b/src/dispatch/static/dispatch/src/incident/priority/IncidentPriorityCombobox.vue
@@ -25,13 +25,13 @@
     </template>
     <template #chip="{ item, props }">
       <v-chip v-bind="props">
-        <span v-if="!project"> {{ item.raw.project.name }}/ </span>{{ item.raw.name }}
+        <span>{{ item.raw.project.name }}/</span>{{ item.raw.name }}
       </v-chip>
     </template>
     <template #item="{ props, item }">
       <v-list-item v-bind="props" :title="null">
         <v-list-item-title>
-          <span v-if="!project">{{ item.raw.project.name }}/</span>{{ item.raw.name }}
+          <span>{{ item.raw.project.name }}/</span>{{ item.raw.name }}
         </v-list-item-title>
         <v-list-item-subtitle :title="item.raw.description">
           {{ item.raw.description }}
@@ -111,18 +111,9 @@ export default {
       this.loading = "error"
       let filterOptions = {
         q: this.search,
-        sortBy: ["name"],
-        descending: [false],
+        sortBy: ["project_id", "name"],
+        descending: [false, false],
         itemsPerPage: this.numItems,
-      }
-
-      if (this.project) {
-        filterOptions = {
-          ...filterOptions,
-          filters: {
-            project: [this.project],
-          },
-        }
       }
 
       let enabledFilter = [
@@ -134,8 +125,19 @@ export default {
         },
       ]
 
+      if (this.project && this.project.length > 0) {
+        const project_ids = this.project.map((p) => p.id)
+        enabledFilter.push({
+          model: "IncidentPriority",
+          field: "project_id",
+          op: "in",
+          value: project_ids,
+        })
+      }
+
       filterOptions = SearchUtils.createParametersFromTableOptions(
         { ...filterOptions },
+        "IncidentPriority",
         enabledFilter
       )
 
@@ -160,6 +162,12 @@ export default {
 
   created() {
     this.fetchData()
+    this.$watch(
+      (vm) => [vm.project],
+      () => {
+        this.fetchData()
+      }
+    )
   },
 }
 </script>

--- a/src/dispatch/static/dispatch/src/incident/priority/IncidentPrioritySelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/priority/IncidentPrioritySelect.vue
@@ -110,6 +110,7 @@ export default {
 
       filterOptions = SearchUtils.createParametersFromTableOptions(
         { ...filterOptions },
+        "IncidentPriority",
         enabledFilter
       )
 

--- a/src/dispatch/static/dispatch/src/incident/severity/IncidentSeverityCombobox.vue
+++ b/src/dispatch/static/dispatch/src/incident/severity/IncidentSeverityCombobox.vue
@@ -25,13 +25,13 @@
     </template>
     <template #chip="{ item, props }">
       <v-chip v-bind="props">
-        <span v-if="!project"> {{ item.raw.project.name }}/ </span>{{ item.raw.name }}
+        <span>{{ item.raw.project.name }}/</span>{{ item.raw.name }}
       </v-chip>
     </template>
     <template #item="{ props, item }">
       <v-list-item v-bind="props" :title="null">
         <v-list-item-title>
-          <span v-if="!project">{{ item.raw.project.name }}/</span>{{ item.raw.name }}
+          <span>{{ item.raw.project.name }}/</span>{{ item.raw.name }}
         </v-list-item-title>
         <v-list-item-subtitle :title="item.raw.description">
           {{ item.raw.description }}
@@ -112,18 +112,9 @@ export default {
       this.loading = "error"
       let filterOptions = {
         q: this.search,
-        sortBy: ["name"],
-        descending: [false],
+        sortBy: ["project_id", "name"],
+        descending: [false, false],
         itemsPerPage: this.numItems,
-      }
-
-      if (this.project) {
-        filterOptions = {
-          ...filterOptions,
-          filters: {
-            project: [this.project],
-          },
-        }
       }
 
       let enabledFilter = [
@@ -135,8 +126,19 @@ export default {
         },
       ]
 
+      if (this.project && this.project.length > 0) {
+        const project_ids = this.project.map((p) => p.id)
+        enabledFilter.push({
+          model: "IncidentSeverity",
+          field: "project_id",
+          op: "in",
+          value: project_ids,
+        })
+      }
+
       filterOptions = SearchUtils.createParametersFromTableOptions(
         { ...filterOptions },
+        "IncidentSeverity",
         enabledFilter
       )
 
@@ -161,6 +163,12 @@ export default {
 
   created() {
     this.fetchData()
+    this.$watch(
+      (vm) => [vm.project],
+      () => {
+        this.fetchData()
+      }
+    )
   },
 }
 </script>

--- a/src/dispatch/static/dispatch/src/incident/severity/IncidentSeveritySelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/severity/IncidentSeveritySelect.vue
@@ -105,6 +105,7 @@ export default {
 
       filterOptions = SearchUtils.createParametersFromTableOptions(
         { ...filterOptions },
+        "IncidentSeverity",
         enabledFilter
       )
 

--- a/src/dispatch/static/dispatch/src/incident/type/IncidentTypeMultiSelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/type/IncidentTypeMultiSelect.vue
@@ -96,6 +96,7 @@ export default {
 
     filterOptions = SearchUtils.createParametersFromTableOptions(
       { ...filterOptions },
+      "IncidentType",
       enabledFilter
     )
 

--- a/src/dispatch/static/dispatch/src/search/utils.js
+++ b/src/dispatch/static/dispatch/src/search/utils.js
@@ -27,7 +27,7 @@ export default {
     return options, queryParams
   },
   createParametersFromTableOptions(options, model, rawFilters) {
-    let [sortBy, descending] = this.createSortExpression(options.sortBy, model)
+    let [sortBy, descending] = this.createSortExpression(options.sortBy, options.descending)
     let expression = this.createFilterExpression(options.filters, model)
     delete options.filters
     delete options.sortBy

--- a/src/dispatch/static/dispatch/src/service/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/service/NewEditSheet.vue
@@ -226,7 +226,11 @@ export default {
       },
     ]
 
-    filterOptions = SearchUtils.createParametersFromTableOptions({ ...filterOptions }, typeFilter)
+    filterOptions = SearchUtils.createParametersFromTableOptions(
+      { ...filterOptions },
+      "Plugin",
+      typeFilter
+    )
 
     PluginApi.getAllInstances(filterOptions).then((response) => {
       this.loading = false

--- a/src/dispatch/static/dispatch/src/workflow/WorkflowSelect.vue
+++ b/src/dispatch/static/dispatch/src/workflow/WorkflowSelect.vue
@@ -88,6 +88,7 @@ export default {
 
       filterOptions = SearchUtils.createParametersFromTableOptions(
         { ...filterOptions },
+        "Workflow",
         enabledFilter
       )
 


### PR DESCRIPTION
This PR fixes the sorting on selection controls and ensures filtering by project. We also ensure all calls to `createParametersFromTableOptions` are properly formatted with a model when passing a raw filter and corrected the sorting order paramater of `createSortExpression`.