### PR TITLE
fix(ui): ensure empty details doesn't throw error

### DIFF
--- a/src/dispatch/static/dispatch/src/feedback/service/Table.vue
+++ b/src/dispatch/static/dispatch/src/feedback/service/Table.vue
@@ -59,7 +59,7 @@
               </v-tooltip>
             </template>
             <template #item.details="{ item }">
-              <span v-if="item.details">
+              <span v-if="item.details && item.details.length > 0">
                 Incidents: {{ item.details[0].num_incidents }}<br />
                 Cases: {{ item.details[0].num_cases }}<br />
                 Participants: {{ item.details[0].num_participants }}<br />


### PR DESCRIPTION
Fixes an error where empty details were throwing an error in the UI.