### PR TITLE
If an error is already handled and logged, do not re-log that same error.

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -97,18 +97,18 @@ class SlackConversationPlugin(ConversationPlugin):
         if case.signal_instances:
             # we try to generate a GenAI signal analysis message
             try:
-                message = create_genai_signal_analysis_message(
+                if message := create_genai_signal_analysis_message(
                     case=case,
                     channel_id=conversation_id,
                     db_session=db_session,
                     client=client,
-                )
-                signal_response = send_message(
-                    client=client,
-                    conversation_id=conversation_id,
-                    ts=response["timestamp"],
-                    blocks=message,
-                )
+                ):
+                    signal_response = send_message(
+                        client=client,
+                        conversation_id=conversation_id,
+                        ts=response["timestamp"],
+                        blocks=message,
+                    )
             except Exception as e:
                 logger.exception(f"Error generating GenAI signal analysis message: {e}")
 


### PR DESCRIPTION
The `create_genai_signal_analysis_message()` function manages and logs edge cases where a signal summary isn't generated. When no summary is produced, the function returns an empty list. The result from `create_genai_signal_analysis_message()` is posted to a Slack channel. If the result is empty, Slack will generate an error. However, since this error has already been handled and logged, there is no need to log it again.