### PR TITLE
Updates case.signal_thread_ts after creating the alerts section

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -219,7 +219,7 @@ def create_signal_message(case_id: int, channel_id: str, db_session: Session) ->
     signal_metadata_blocks = [
         Section(text="*Alerts*"),
         Section(
-            text=f"We observed <{DISPATCH_UI_URL}/{first_instance_signal.project.organization.slug}/cases/{case.name}/signal/{first_instance_id}|{instances.count()} alerts> in this case. The first alert for this case can be seen below."
+            text=f"We observed <{DISPATCH_UI_URL}/{first_instance_signal.project.organization.slug}/cases/{case.name}/signal/{first_instance_id}|{instances.count()} alert(s)> in this case. The first alert for this case can be seen below."
         ),
     ]
 

--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -124,12 +124,14 @@ class SlackConversationPlugin(ConversationPlugin):
                 message = create_signal_message(
                     case_id=case.id, channel_id=conversation_id, db_session=db_session
                 )
-                send_message(
+                signal_response = send_message(
                     client=client,
                     conversation_id=conversation_id,
                     ts=case.signal_thread_ts,
                     blocks=message,
                 )
+                if signal_response:
+                    case.signal_thread_ts = signal_response.get("timestamp")
             except Exception as e:
                 logger.exception(f"Error generating signal message: {e}")
 


### PR DESCRIPTION
This pull request includes a change to the `create_threaded` method in the `dispatch_slack` plugin to handle the response from the `send_message` function and update the `signal_thread_ts` attribute of the `case` object accordingly. This change ensures the value of `signal_thread_ts` is the correct one when new alerts (aka signals) are ingested and the message needs to be updated with new counter.
<img width="701" alt="Screenshot 2024-10-04 at 1 18 24 PM" src="https://github.com/user-attachments/assets/1152351d-59d0-43db-81e9-d552ed2c4dfc">


Error handling and response management:

* [`src/dispatch/plugins/dispatch_slack/plugin.py`](diffhunk://#diff-84bac68ba28c626f61114b432a7c5b163f03541682e3efeb6d0dddc250a7caa8L127-R134): Modified the `create_threaded` method to capture the response from `send_message` and update `case.signal_thread_ts` if the response contains a timestamp.