### PR TITLE
feat(ui/ux): add oncall service name to oncall shift feedback table

### DIFF
--- a/src/dispatch/service/service.py
+++ b/src/dispatch/service/service.py
@@ -21,6 +21,11 @@ def get_by_external_id(*, db_session, external_id: str) -> Optional[Service]:
     return db_session.query(Service).filter(Service.external_id == external_id).first()
 
 
+def get_all_by_external_ids(*, db_session, external_ids: List[str]) -> Optional[List[Service]]:
+    """Gets a service by external id (e.g. PagerDuty service id) and project id."""
+    return db_session.query(Service).filter(Service.external_id.in_(external_ids)).all()
+
+
 def get_by_name(*, db_session, project_id: int, name: str) -> Optional[Service]:
     """Gets a service by its name."""
     return (

--- a/src/dispatch/service/views.py
+++ b/src/dispatch/service/views.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, Body, HTTPException, status
+from fastapi import APIRouter, Body, HTTPException, status, Query
 from pydantic.error_wrappers import ErrorWrapper, ValidationError
+from typing import List
 
 from sqlalchemy.exc import IntegrityError
 
@@ -9,7 +10,14 @@ from dispatch.exceptions import ExistsError
 from dispatch.models import PrimaryKey
 
 from .models import ServiceCreate, ServicePagination, ServiceRead, ServiceUpdate
-from .service import get, create, update, delete, get_by_external_id_and_project_name
+from .service import (
+    get,
+    create,
+    update,
+    delete,
+    get_by_external_id_and_project_name,
+    get_all_by_external_ids,
+)
 
 
 router = APIRouter()
@@ -19,6 +27,15 @@ router = APIRouter()
 def get_services(common: CommonParameters):
     """Retrieves all services."""
     return search_filter_sort_paginate(model="Service", **common)
+
+
+@router.get("/externalids", response_model=List[ServiceRead])
+def get_services_by_external_ids(
+    db_session: DbSession,
+    ids: List[str] = Query(..., alias="ids[]"),
+):
+    """Retrieves all services given list of external ids."""
+    return get_all_by_external_ids(db_session=db_session, external_ids=ids)
 
 
 @router.post("", response_model=ServiceRead)

--- a/src/dispatch/static/dispatch/src/feedback/service/Table.vue
+++ b/src/dispatch/static/dispatch/src/feedback/service/Table.vue
@@ -70,9 +70,9 @@
                 {{ item.project.name }}
               </v-chip>
             </template>
-            <template #item.schedule="{ item }">
+            <template #item.service="{ item }">
               <v-chip size="small" :color="item.project.color">
-                {{ item.schedule }}
+                {{ item.service }}
               </v-chip>
             </template>
             <template #item.data-table-actions="{ item }">
@@ -124,7 +124,7 @@ export default {
         { title: "Rating", value: "rating", sortable: true },
         { title: "Feedback", value: "feedback", sortable: true },
         { title: "Details", value: "details", sortable: true },
-        { title: "Service", value: "schedule", sortable: false },
+        { title: "Service", value: "service", sortable: false },
         { title: "Project", value: "project.name", sortable: false },
         { title: "Created At", value: "created_at", sortable: true },
         { title: "", key: "data-table-actions", sortable: false, align: "end" },

--- a/src/dispatch/static/dispatch/src/feedback/service/Table.vue
+++ b/src/dispatch/static/dispatch/src/feedback/service/Table.vue
@@ -70,6 +70,11 @@
                 {{ item.project.name }}
               </v-chip>
             </template>
+            <template #item.schedule="{ item }">
+              <v-chip size="small" :color="item.project.color">
+                {{ item.schedule }}
+              </v-chip>
+            </template>
             <template #item.data-table-actions="{ item }">
               <v-menu location="right" origin="overlap">
                 <template #activator="{ props }">
@@ -119,6 +124,7 @@ export default {
         { title: "Rating", value: "rating", sortable: true },
         { title: "Feedback", value: "feedback", sortable: true },
         { title: "Details", value: "details", sortable: true },
+        { title: "Service", value: "schedule", sortable: false },
         { title: "Project", value: "project.name", sortable: false },
         { title: "Created At", value: "created_at", sortable: true },
         { title: "", key: "data-table-actions", sortable: false, align: "end" },

--- a/src/dispatch/static/dispatch/src/feedback/service/store.js
+++ b/src/dispatch/static/dispatch/src/feedback/service/store.js
@@ -57,6 +57,7 @@ const actions = {
       .then((response) => {
         commit("SET_TABLE_LOADING", false)
         commit("SET_TABLE_ROWS", response.data)
+        console.log(`The response data is JSON: ${JSON.stringify(response.data)}`)
       })
       .catch(() => {
         commit("SET_TABLE_LOADING", false)

--- a/src/dispatch/static/dispatch/src/service/api.js
+++ b/src/dispatch/static/dispatch/src/service/api.js
@@ -7,6 +7,10 @@ export default {
     return API.get(`${resource}`, { params: { ...options } })
   },
 
+  getAllByIds(ids) {
+    return API.get(`${resource}/externalids`, { params: { ids } })
+  },
+
   get(serviceId) {
     return API.get(`${resource}/${serviceId}`)
   },


### PR DESCRIPTION
This PR adds the oncall service name to the oncall shift feedback table (instead of showing the schedule id). Additionally, users can filter by the oncall service.

<img width="1393" alt="image" src="https://github.com/user-attachments/assets/def9ee0d-7f18-4052-bee4-0500d36dd47f">
