### PR TITLE
Improves warning text when there are no users to engage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     hooks:
       - id: tests
         name: run tests
-        entry: pytest -v
+        entry: pytest -v tests/
         language: system
         types: [python]
         stages: [push]

--- a/src/dispatch/signal/flows.py
+++ b/src/dispatch/signal/flows.py
@@ -193,7 +193,7 @@ def engage_signal_identity(db_session: Session, signal_instance: SignalInstance)
                     validated_email = validate_email(entity.value, check_deliverability=False)
                 except EmailNotValidError as e:
                     log.warning(
-                        f"Discovered entity value in Signal {signal_instance.signal.id} that did not appear to be a valid email: {e}"
+                        f"Discovered entity value in signal {signal_instance.signal.name} (id: {signal_instance.signal.id}) that did not appear to be a valid email: {e}"
                     )
                 else:
                     users_to_engage.append(
@@ -205,7 +205,7 @@ def engage_signal_identity(db_session: Session, signal_instance: SignalInstance)
 
     if not users_to_engage:
         log.warning(
-            f"Engagement configured for Signal {signal_instance.signal.id} but no users found in instance: {signal_instance.id}."
+            f"Engagement configured for signal {signal_instance.signal.name} (id: {signal_instance.signal.id}), but no users found in instance with id {signal_instance.id}."
         )
         return
 


### PR DESCRIPTION
This pull request includes several changes to improve logging messages and streamline test execution. The most important changes involve updating log messages in the `engage_signal_identity` function and modifying the test entry in the pre-commit configuration.

### Logging Improvements:
* [`src/dispatch/signal/flows.py`](diffhunk://#diff-7c970d67d7312044b55dff3c0e55201b519ced4431a0ee3a4d6d9b4a3b35e40eL196-R196): Updated log messages in the `engage_signal_identity` function to include the signal name along with its ID for better clarity. [[1]](diffhunk://#diff-7c970d67d7312044b55dff3c0e55201b519ced4431a0ee3a4d6d9b4a3b35e40eL196-R196) [[2]](diffhunk://#diff-7c970d67d7312044b55dff3c0e55201b519ced4431a0ee3a4d6d9b4a3b35e40eL208-R208)

### Test Configuration:
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L41-R41): Modified the test entry to specify the `tests/` directory when running `pytest`.