### PR TITLE
Adds comments to docker-compose.yml file to change default passwords

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "5432:5432"
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: dispatch
+      POSTGRES_PASSWORD: dispatch # Default password, change it
       POSTGRES_DB: dispatch
     volumes:
       - postgres-data:/var/lib/postgresql/data
@@ -21,7 +21,7 @@ services:
       - "5555:80"
     environment:
       PGADMIN_DEFAULT_EMAIL: dispatch@netflix.com
-      PGADMIN_DEFAULT_PASSWORD: admin
+      PGADMIN_DEFAULT_PASSWORD: admin # Default password, change it
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
This pull request includes minor changes to the `docker/docker-compose.yml` file. The changes add comments to the default passwords for PostgreSQL and pgAdmin, indicating that they should be changed.

* [`docker/docker-compose.yml`](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L10-R10): Added comments to the `POSTGRES_PASSWORD` and `PGADMIN_DEFAULT_PASSWORD` fields to indicate that the default passwords should be changed. [[1]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L10-R10) [[2]](diffhunk://#diff-423deb13b7c401b1a7f41ee91c77f722e11d2f317d6a66b546524e8a04cc8b03L24-R24)