### PR TITLE
Update Docker images from Buster to Bullseye.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.4-slim-buster as sdist
+FROM python:3.11.4-slim-bullseye as sdist
 
 LABEL maintainer="oss@netflix.com"
 LABEL org.opencontainers.image.title="Dispatch PyPI Wheel"
@@ -56,7 +56,7 @@ RUN YARN_CACHE_FOLDER="$(mktemp -d)" \
     && mv /usr/src/dispatch/dist /dist
 
 # This is the image to be run
-FROM python:3.11.4-slim-buster
+FROM python:3.11.4-slim-bullseye
 
 LABEL maintainer="oss@dispatch.io"
 LABEL org.opencontainers.image.title="Dispatch"
@@ -84,7 +84,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget gnupg \
     && rm -rf /var/lib/apt/lists/*
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 RUN wget --quiet -O - https://deb.nodesource.com/setup_12.x | bash -


### PR DESCRIPTION
Bullseye support is expected through August 31, 2026, according to https://www.debian.org/releases/bullseye/.