### PR TITLE
fix(utils): adding docker type to github utils

### DIFF
--- a/utils/github_utils.py
+++ b/utils/github_utils.py
@@ -99,6 +99,7 @@ def release_notes(pull_request_number: int) -> NoReturn:
         "techdebt": "",
         "tests": "",
         "improvement": "",
+        "docker": "",
     }
 
     click.echo(f"Fetching list of merged PRs since #{pull_request_number}...")


### PR DESCRIPTION
This PR adds the "docker" type to the possible list of PR labels in the github utils.