### PR TITLE
fix(plugin): allow list of strings in plugin metadata

### DIFF
--- a/src/dispatch/plugin/models.py
+++ b/src/dispatch/plugin/models.py
@@ -219,7 +219,7 @@ class PluginInstanceUpdate(PluginBase):
 
 class KeyValue(DispatchBase):
     key: str
-    value: str
+    value: str | List[str]
 
 
 class PluginMetadata(DispatchBase):


### PR DESCRIPTION
Allows a list of strings as an option for the plugin metadata value.