### PR TITLE
fix(plugin): allow dictionary in plugin metadata

### DIFF
--- a/src/dispatch/plugin/models.py
+++ b/src/dispatch/plugin/models.py
@@ -219,7 +219,7 @@ class PluginInstanceUpdate(PluginBase):
 
 class KeyValue(DispatchBase):
     key: str
-    value: str | List[str]
+    value: str | List[str] | dict
 
 
 class PluginMetadata(DispatchBase):


### PR DESCRIPTION
Allows a dictionary as an option for the plugin metadata value.