### PR TITLE
fix(test): adding rounding method to quantize

### DIFF
--- a/tests/incident_cost/test_incident_cost_service.py
+++ b/tests/incident_cost/test_incident_cost_service.py
@@ -109,7 +109,7 @@ def test_calculate_incident_response_cost_with_cost_model(
 ):
     """Tests that the incident cost is calculated correctly when a cost model is enabled."""
     from datetime import timedelta
-    from decimal import Decimal
+    from decimal import Decimal, ROUND_UP
     from dispatch.incident_cost.service import update_incident_response_cost, get_hourly_rate
     from dispatch.incident_cost_type import service as incident_cost_type_service
     from dispatch.participant_activity.service import (
@@ -154,8 +154,8 @@ def test_calculate_incident_response_cost_with_cost_model(
     ) * hourly_rate + orig_total_incident_cost
 
     assert cost
-    assert cost == Decimal(expected_incident_cost).quantize(cost)
-    assert cost == Decimal(incident.total_cost).quantize(cost)
+    assert cost == Decimal(expected_incident_cost).quantize(cost, rounding=ROUND_UP)
+    assert cost == Decimal(incident.total_cost).quantize(cost, rounding=ROUND_UP)
 
 
 def test_calculate_incident_response_cost_with_cost_model__no_enabled_plugins(


### PR DESCRIPTION
Occasionally `test_calculate_incident_response_cost_with_cost_model` will fail due to rounding. This PR fixes the rounding errors.