### PR TITLE
(fix) get_signal_filter arg name is signal_filter_id

### DIFF
--- a/src/dispatch/signal/views.py
+++ b/src/dispatch/signal/views.py
@@ -241,7 +241,7 @@ def update_filter(
     signal_filter_in: SignalFilterUpdate,
 ):
     """Updates an existing signal filter."""
-    signal_filter = get_signal_filter(db_session=db_session, signal_id=signal_filter_id)
+    signal_filter = get_signal_filter(db_session=db_session, signal_filter_id=signal_filter_id)
     if not signal_filter:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,


### PR DESCRIPTION
typo in the signal filter update flow: `get_signal_filter() got an unexpected keyword argument 'signal_id'`