### PR TITLE
bug(docker): Revert python version bump

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.0-slim-bullseye as sdist
+FROM python:3.11.4-slim-bullseye as sdist
 
 LABEL maintainer="oss@netflix.com"
 LABEL org.opencontainers.image.title="Dispatch PyPI Wheel"
@@ -56,7 +56,7 @@ RUN YARN_CACHE_FOLDER="$(mktemp -d)" \
     && mv /usr/src/dispatch/dist /dist
 
 # This is the image to be run
-FROM python:3.13.0-slim-bullseye
+FROM python:3.11.4-slim-bullseye
 
 LABEL maintainer="oss@dispatch.io"
 LABEL org.opencontainers.image.title="Dispatch"


### PR DESCRIPTION
The move to python 3.14 breaks the docker build. The srsly package doesn't have a compatible wheel with anything above 3.12 right now ([docs](https://github.com/explosion/srsly/releases/tag/v2.4.8)), and it's using deprecated methods, so it can't be built by 3.14 yet. Because of this, `docker build .` is broken on master.