### PR TITLE
Fixing selects when not yet loaded

### DIFF
--- a/src/dispatch/static/dispatch/src/case/priority/CasePrioritySelect.vue
+++ b/src/dispatch/static/dispatch/src/case/priority/CasePrioritySelect.vue
@@ -143,9 +143,15 @@ export default {
     project: {
       handler(newProject) {
         if (newProject?.id !== this.lastProjectId) {
-          this.lastProjectId = newProject?.id
-          this.resetSelection()
-          this.fetchData()
+          // Check if we're moving to a valid project (not null)
+          if (this.lastProjectId) {
+            this.lastProjectId = newProject.id
+            this.resetSelection()
+            this.fetchData()
+          } else {
+            // If new project is null/undefined, just update lastProjectId
+            this.lastProjectId = null
+          }
         }
         this.validatePriority()
       },

--- a/src/dispatch/static/dispatch/src/case/type/CaseTypeSelect.vue
+++ b/src/dispatch/static/dispatch/src/case/type/CaseTypeSelect.vue
@@ -172,9 +172,15 @@ export default {
     project: {
       handler(newProject) {
         if (newProject?.id !== this.lastProjectId) {
-          this.lastProjectId = newProject?.id
-          this.resetSelection()
-          this.fetchData()
+          // Check if we're moving to a valid project (not null)
+          if (this.lastProjectId) {
+            this.lastProjectId = newProject.id
+            this.resetSelection()
+            this.fetchData()
+          } else {
+            // If new project is null/undefined, just update lastProjectId
+            this.lastProjectId = null
+          }
         }
         this.validateType()
       },

--- a/src/dispatch/static/dispatch/src/incident/priority/IncidentPrioritySelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/priority/IncidentPrioritySelect.vue
@@ -133,10 +133,17 @@ export default {
     project: {
       handler(newProject) {
         if (newProject?.id !== this.lastProjectId) {
-          this.lastProjectId = newProject?.id
-          this.resetSelection()
-          this.fetchData()
+          // Check if we're moving to a valid project (not null)
+          if (this.lastProjectId) {
+            this.lastProjectId = newProject.id
+            this.resetSelection()
+            this.fetchData()
+          } else {
+            // If new project is null/undefined, just update lastProjectId
+            this.lastProjectId = null
+          }
         }
+
         this.validatePriority()
       },
       deep: true,

--- a/src/dispatch/static/dispatch/src/incident/type/IncidentTypeSelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/type/IncidentTypeSelect.vue
@@ -86,9 +86,15 @@ export default {
     project: {
       handler(newProject) {
         if (newProject?.id !== this.lastProjectId) {
-          this.lastProjectId = newProject?.id
-          this.clearSelection()
-          this.fetchData()
+          // Check if we're moving to a valid project (not null)
+          if (this.lastProjectId) {
+            this.lastProjectId = newProject.id
+            this.resetSelection()
+            this.fetchData()
+          } else {
+            // If new project is null/undefined, just update lastProjectId
+            this.lastProjectId = null
+          }
         }
       },
     },


### PR DESCRIPTION
We need to check that the last project exists to account for situations where we are loading in existing data. 