### PR TITLE
fix(ui): increasing type selector length

### DIFF
--- a/src/dispatch/static/dispatch/src/incident/type/IncidentTypeSelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/type/IncidentTypeSelect.vue
@@ -58,7 +58,7 @@ export default {
       loading: false,
       items: [],
       more: false,
-      numItems: 5,
+      numItems: 50,
       total: 0,
       lastProjectId: null,
       error: null,

--- a/tests/static/e2e/report-submission.spec.ts
+++ b/tests/static/e2e/report-submission.spec.ts
@@ -43,19 +43,19 @@ test.describe("Authenticated Dispatch App", () => {
           "'Incident Report: Description' not visible on page after submission of incident report."
         )
         .toBeVisible()
-    }),
-    test("The 'Load More' selector should be visible when there are more than 5 options in Type combobox.", async ({
-      reportIncidentPage,
-    }) => {
-      await reportIncidentPage.goto()
-      await reportIncidentPage.typeDropdown.click()
-
-      // Soft check that the 'Load More' selector is available upon opening the Project dropdown
-      await expect
-        .soft(
-          reportIncidentPage.loadMore,
-          "The 'Load More' selector should be visible when there are more than 5 options in Type combobox."
-        )
-        .toBeVisible()
     })
+    // test("The 'Load More' selector should be visible when there are more than 5 options in Type combobox.", async ({
+    //   reportIncidentPage,
+    // }) => {
+    //   await reportIncidentPage.goto()
+    //   await reportIncidentPage.typeDropdown.click()
+
+    //   // Soft check that the 'Load More' selector is available upon opening the Project dropdown
+    //   await expect
+    //     .soft(
+    //       reportIncidentPage.loadMore,
+    //       "The 'Load More' selector should be visible when there are more than 5 options in Type combobox."
+    //     )
+    //     .toBeVisible()
+    // })
 })


### PR DESCRIPTION
This PR fixes the incident type dropdown look ahead since the validator looks at the item list for validation.