### PR TITLE
fix(ui): only disable project if editing existing case or incident

### DIFF
--- a/src/dispatch/static/dispatch/src/case/DetailsTab.vue
+++ b/src/dispatch/static/dispatch/src/case/DetailsTab.vue
@@ -62,7 +62,7 @@
         />
       </v-col>
       <v-col cols="6">
-        <project-select v-model="project" disabled />
+        <project-select v-model="project" :disabled="project_disabled" />
       </v-col>
       <v-col cols="6">
         <case-type-select v-model="case_type" :project="project" />
@@ -239,6 +239,9 @@ export default {
       "selected.triage_at",
       "selected.visibility",
     ]),
+    project_disabled(item) {
+      return item.id != null
+    },
   },
 }
 </script>

--- a/src/dispatch/static/dispatch/src/incident/DetailsTab.vue
+++ b/src/dispatch/static/dispatch/src/incident/DetailsTab.vue
@@ -56,7 +56,7 @@
         />
       </v-col>
       <v-col cols="6">
-        <project-select v-model="project" disabled />
+        <project-select v-model="project" :disabled="project_disabled" />
       </v-col>
       <v-col cols="6">
         <incident-type-select v-model="incident_type" :project="project" />
@@ -189,6 +189,9 @@ export default {
       "selected.title",
       "selected.visibility",
     ]),
+    project_disabled(item) {
+      return item.id != null
+    },
   },
 }
 </script>


### PR DESCRIPTION
This PR fixes the New button to allow project selection when creating a new case or incident, but keeps the project selector disabled when editing an existing case or incident.