### PR TITLE
Fix docstring for get_definition and get_document routes

### DIFF
--- a/src/dispatch/definition/views.py
+++ b/src/dispatch/definition/views.py
@@ -25,7 +25,7 @@ def get_definitions(common: CommonParameters):
 
 @router.get("/{definition_id}", response_model=DefinitionRead)
 def get_definition(db_session: DbSession, definition_id: PrimaryKey):
-    """Update a definition."""
+    """Get a definition."""
     definition = get(db_session=db_session, definition_id=definition_id)
     if not definition:
         raise HTTPException(

--- a/src/dispatch/document/views.py
+++ b/src/dispatch/document/views.py
@@ -18,7 +18,7 @@ def get_documents(common: CommonParameters):
 
 @router.get("/{document_id}", response_model=DocumentRead)
 def get_document(db_session: DbSession, document_id: PrimaryKey):
-    """Update a document."""
+    """Get a document."""
     document = get(db_session=db_session, document_id=document_id)
     if not document:
         raise HTTPException(


### PR DESCRIPTION
This PR fixes the docstring for the `get_definition` and `get_document` routes.