### PR TITLE
fix(slack): using participant id for manual engagement 

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -402,18 +402,21 @@ def engage(
     """Handles the engage user action."""
     ack()
 
-    if form_data.get(DefaultBlockIds.participant_select):
-        user_email = client.users_info(user=form_data[DefaultBlockIds.participant_select]["value"])[
-            "user"
-        ]["profile"]["email"]
+    if form_data.get(DefaultBlockIds.description_input):
+        participant_id = form_data[DefaultBlockIds.participant_select]["value"]
+        participant = participant_service.get(db_session=db_session, participant_id=participant_id)
+        if participant:
+            user_email = participant.individual.email
+        else:
+            log.error(f"Participant not found for id {participant_id} when trying to engage user")
+            return
     else:
-        # TODO: log error
         return
 
     if form_data.get(DefaultBlockIds.description_input):
         engagement = form_data[DefaultBlockIds.description_input]
     else:
-        # TODO log error
+        log.warning("Engagement text not found")
         return
 
     case = case_service.get(db_session=db_session, case_id=context["subject"].id)

--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -402,7 +402,7 @@ def engage(
     """Handles the engage user action."""
     ack()
 
-    if form_data.get(DefaultBlockIds.description_input):
+    if form_data.get(DefaultBlockIds.participant_select):
         participant_id = form_data[DefaultBlockIds.participant_select]["value"]
         participant = participant_service.get(db_session=db_session, participant_id=participant_id)
         if participant:


### PR DESCRIPTION
This PR fixes the manual engagement by replacing the form_data lookup with the participant id.