### PR TITLE
fix(db): ensure type is str before trying to deserialize

### DIFF
--- a/src/dispatch/database/service.py
+++ b/src/dispatch/database/service.py
@@ -536,7 +536,7 @@ def search_filter_sort_paginate(
     db_session,
     model,
     query_str: str = None,
-    filter_spec: str = None,
+    filter_spec: str | dict = None,
     page: int = 1,
     items_per_page: int = 5,
     sort_by: List[str] = None,
@@ -558,6 +558,8 @@ def search_filter_sort_paginate(
 
         tag_all_filters = []
         if filter_spec:
+            # some functions pass filter_spec as dictionary such as auth/views.py/get_users
+            # but most come from API as seraialized JSON
             if isinstance(filter_spec, str):
                 filter_spec = json.loads(filter_spec)
             query = apply_filter_specific_joins(model_cls, filter_spec, query)

--- a/src/dispatch/database/service.py
+++ b/src/dispatch/database/service.py
@@ -536,7 +536,7 @@ def search_filter_sort_paginate(
     db_session,
     model,
     query_str: str = None,
-    filter_spec: str | dict = None,
+    filter_spec: str | dict | None = None,
     page: int = 1,
     items_per_page: int = 5,
     sort_by: List[str] = None,

--- a/src/dispatch/database/service.py
+++ b/src/dispatch/database/service.py
@@ -558,7 +558,8 @@ def search_filter_sort_paginate(
 
         tag_all_filters = []
         if filter_spec:
-            filter_spec = json.loads(filter_spec)
+            if isinstance(filter_spec, str):
+                filter_spec = json.loads(filter_spec)
             query = apply_filter_specific_joins(model_cls, filter_spec, query)
             # if the filter_spec has the TagAll filter, we need to split the query up
             # and intersect all of the results


### PR DESCRIPTION
This pull request addresses a potential issue in the `search_filter_sort_paginate` function within the database service by ensuring that the `filter_spec` is of type `str` before attempting to deserialize it using `json.loads`.

#### Key Changes
- **Type Check for Deserialization**:
  - Added a type check to ensure `filter_spec` is a string before calling `json.loads`.
  - This prevents errors that could occur if `filter_spec` is not a string, enhancing the robustness of the deserialization process.

#### Files Changed
- **`src/dispatch/database/service.py`**: 
  - Modified the `search_filter_sort_paginate` function to include a type check for `filter_spec`.
  - Modified the type signature for `filter_spec` to reflect that it can be `None`, `str`, or a `dict`.
  - Added a comment to help future developers understand why the type check was added.