### PR TITLE
fix(slack): verify email before resolving

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -469,8 +469,8 @@ class SlackConversationPlugin(ConversationPlugin):
         for member_id in member_ids:
             if is_user(config=self.configuration, user_id=member_id):
                 user = get_user_info_by_id(client, member_id)
-                if user:
-                    member_emails.append(user["profile"]["email"])
+                if user and (profile := user.get("profile")) and (email := profile.get("email")):
+                    member_emails.append(email)
 
         return member_emails
 


### PR DESCRIPTION
If a bot is not caught in `is_bot`, there will be no email to resolve in `user`, so we will skip this user.