### PR TITLE
fix(ui): fixes broken resize component

### DIFF
--- a/src/dispatch/static/dispatch/package-lock.json
+++ b/src/dispatch/static/dispatch/package-lock.json
@@ -32,6 +32,7 @@
         "@vue-flow/minimap": "^1.2.0",
         "@vueuse/core": "^10.5.0",
         "@vueuse/integrations": "^10.6.1",
+        "@wdns/vuetify-resize-drawer": "^3.2.0",
         "apexcharts": "^3.44.0",
         "axios": "^0.21.4",
         "d3-force": "^3.0.0",
@@ -56,7 +57,6 @@
         "vue3-apexcharts": "^1.4.4",
         "vue3-markdown-it": "^1.0.10",
         "vuetify": "^3.4.3",
-        "vuetify3-resize-drawer": "^2.1.1",
         "vuex": "^4.1.0",
         "vuex-map-fields": "^1.4.1"
       },
@@ -2844,6 +2844,25 @@
         "@vue/composition-api": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@wdns/vuetify-resize-drawer": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@wdns/vuetify-resize-drawer/-/vuetify-resize-drawer-3.2.0.tgz",
+      "integrity": "sha512-JfPDrV9G/6k6fCLLIurET6jdDIzEVSvjrqxoVeWhxTVUuS+Cs4oJga7wWNRgFTZdqfyZT8Id2aUDCEHYCjcQQg==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/webdevnerdstuff"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/WebDevNerdStuff"
+        }
+      ],
+      "dependencies": {
+        "vue": "^3.5.12",
+        "vuetify": "^3.7.2"
       }
     },
     "node_modules/@yr/monotone-cubic-spline": {
@@ -7780,26 +7799,6 @@
         "webpack-plugin-vuetify": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vuetify3-resize-drawer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/vuetify3-resize-drawer/-/vuetify3-resize-drawer-2.1.1.tgz",
-      "integrity": "sha512-CvYce3NAjiALTcK9JClrXeygXY3rZiE3kaNvvVD/JJgHSA6i9S2yxkgr6ryNJLnmtCB5DGtmHY5sHxbF5y534Q==",
-      "deprecated": "The Vuetify 3 Resize Drawer component has been changed and moved to the WebDevNerdStuff org @wdns. Please update your packages to it's new location. https://www.npmjs.com/package/@wdns/vuetify-resize-drawer",
-      "funding": [
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/webdevnerdstuff"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/WebDevNerdStuff"
-        }
-      ],
-      "dependencies": {
-        "vue": "^3.3.4",
-        "vuetify": "^3.3.19"
       }
     },
     "node_modules/vuex": {

--- a/src/dispatch/static/dispatch/package.json
+++ b/src/dispatch/static/dispatch/package.json
@@ -51,6 +51,7 @@
     "@vue-flow/minimap": "^1.2.0",
     "@vueuse/core": "^10.5.0",
     "@vueuse/integrations": "^10.6.1",
+    "@wdns/vuetify-resize-drawer": "^3.2.0",
     "apexcharts": "^3.44.0",
     "axios": "^0.21.4",
     "d3-force": "^3.0.0",
@@ -75,7 +76,6 @@
     "vue3-apexcharts": "^1.4.4",
     "vue3-markdown-it": "^1.0.10",
     "vuetify": "^3.4.3",
-    "vuetify3-resize-drawer": "^2.1.1",
     "vuex": "^4.1.0",
     "vuex-map-fields": "^1.4.1"
   },

--- a/src/dispatch/static/dispatch/src/incident/EditSheet.vue
+++ b/src/dispatch/static/dispatch/src/incident/EditSheet.vue
@@ -2,6 +2,8 @@
   <v-form @submit.prevent v-slot="{ isValid }">
     <VResizeDrawer
       location="right"
+      handle-position="border"
+      handle-border-width="2"
       :width="navigation.width"
       ref="drawer"
       :permanent="$vuetify.display.mdAndDown"

--- a/src/dispatch/static/dispatch/src/main.js
+++ b/src/dispatch/static/dispatch/src/main.js
@@ -10,7 +10,7 @@ import "@formkit/themes/genesis"
 //   : null
 
 import { plugin, defaultConfig } from "@formkit/vue"
-import VResizeDrawer from "vuetify3-resize-drawer"
+import VResizeDrawer from "@wdns/vuetify-resize-drawer"
 
 import "roboto-fontface/css/roboto/roboto-fontface.css"
 import "font-awesome/css/font-awesome.css"


### PR DESCRIPTION
Fixes the deprecated resize drawer to point to updated library. This allows the incident pane to be correctly resized.
 
<img width="387" alt="image" src="https://github.com/user-attachments/assets/2a41f960-388c-42c4-9b25-939686394a33">
