### PR TITLE
fix(slack): ensure only one slash in tags

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -249,6 +249,11 @@ def handle_tag_search_action(
     }
 
     if "/" in query_str:
+        # first check to make sure there's only one slash
+        if query_str.count("/") > 1:
+            ack()
+            return
+
         tag_type, query_str = query_str.split("/")
         filter_spec["and"].append(
             {"model": "TagType", "op": "==", "field": "name", "value": tag_type}


### PR DESCRIPTION
Ensures only one slash in tag input before trying to unpack. Fixes DISDEV-315.

#### Fix now just ignores extra slashes
https://github.com/user-attachments/assets/19511ddb-e24f-43e1-b791-2353b9da5b1a

#### Previously would show error
https://github.com/user-attachments/assets/b8f63370-7df5-49cb-a140-6fdde626aff4