### PR TITLE
fix(ui): filter incident type by selected project

### DIFF
--- a/src/dispatch/static/dispatch/src/incident/type/IncidentTypeSelect.vue
+++ b/src/dispatch/static/dispatch/src/incident/type/IncidentTypeSelect.vue
@@ -120,12 +120,15 @@ export default {
         sortBy: ["name"],
         descending: [false],
         itemsPerPage: this.numItems,
+        enabled: ["true"],
       }
 
       if (this.project) {
-        filterOptions.filters = {
-          project_id: this.project_id,
-          enabled: ["true"],
+        filterOptions = {
+          ...filterOptions,
+          filters: {
+            project: [this.project],
+          },
         }
       }
 


### PR DESCRIPTION
Fixes a bug that doesn't properly filter the incident type for the selected project.