### PR TITLE
fix(db): make migration statement conditional

### DIFF
--- a/src/dispatch/database/revisions/tenant/versions/2024-11-04_928b725d64f6.py
+++ b/src/dispatch/database/revisions/tenant/versions/2024-11-04_928b725d64f6.py
@@ -52,7 +52,12 @@ def upgrade():
     if column_exists:
         op.drop_column("plugin_instance", "configuration")
 
-    op.execute("ALTER TABLE project DROP CONSTRAINT IF EXISTS project_stable_priority_id_fkey")
+    foreign_keys = inspector.get_foreign_keys("project")
+
+    constraint_name = "project_stable_priority_id_fkey"
+    constraint_exists = any(fk["name"] == constraint_name for fk in foreign_keys)
+    if constraint_exists:
+        op.drop_constraint(constraint_name, "project", type_="foreignkey")
     # ### end Alembic commands ###
 
 

--- a/src/dispatch/database/revisions/tenant/versions/2024-11-04_928b725d64f6.py
+++ b/src/dispatch/database/revisions/tenant/versions/2024-11-04_928b725d64f6.py
@@ -52,7 +52,7 @@ def upgrade():
     if column_exists:
         op.drop_column("plugin_instance", "configuration")
 
-    op.drop_constraint("project_stable_priority_id_fkey", "project", type_="foreignkey")
+    op.execute("ALTER TABLE project DROP CONSTRAINT IF EXISTS project_stable_priority_id_fkey")
     # ### end Alembic commands ###
 
 


### PR DESCRIPTION
Looks like a migration was realigning after some incident, but we do not have a foreign key constraint it's removing.

This PR makes the statement conditional.

When upgrading from [v20241011](https://github.com/Netflix/dispatch/releases/tag/v20241011) to latest:

### Before
```
# dispatch database upgrade
[..]
INFO:Running upgrade 3edb0476365a -> 928b725d64f6, Fixes automatic generation issues:/usr/local/lib/python3.11/site-packages/alembic/runtime/migration.py:run_migrations:618
Traceback (most recent call last):
[..]
  File "/usr/local/lib/python3.11/site-packages/dispatch/database/revisions/tenant/versions/2024-11-04_928b725d64f6.py", line 55, in upgrade
    op.drop_constraint("project_stable_priority_id_fkey", "project", type_="foreignkey")
[..]
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedObject) constraint "project_stable_priority_id_fkey" of relation "project" does not exist

[SQL: ALTER TABLE project DROP CONSTRAINT project_stable_priority_id_fkey]
(Background on this error at: http://sqlalche.me/e/13/f405)
```

### After
```
# dispatch database upgrade
[..]
INFO:Running upgrade 3edb0476365a -> 928b725d64f6, Fixes automatic generation issues:/usr/local/lib/python3.11/site-packages/alembic/runtime/migration.py:run_migrations:618
DEBUG:update 3edb0476365a to 928b725d64f6:/usr/local/lib/python3.11/site-packages/alembic/runtime/migration.py:update_to_step:861
INFO:Running upgrade 928b725d64f6 -> 575ca7d954a8, Adds incident summary to the incident table.:/usr/local/lib/python3.11/site-packages/alembic/runtime/migration.py:run_migrations:618
DEBUG:update 928b725d64f6 to 575ca7d954a8:/usr/local/lib/python3.11/site-packages/alembic/runtime/migration.py:update_to_step:861
INFO:Running upgrade 575ca7d954a8 -> 2d9e4d392ea4, Adding display name to the projct model:/usr/local/lib/python3.11/site-packages/alembic/runtime/migration.py:run_migrations:618
DEBUG:update 575ca7d954a8 to 2d9e4d392ea4:/usr/local/lib/python3.11/site-packages/alembic/runtime/migration.py:update_to_step:861
Success.
```
