### PR TITLE
fix(ui): oncall select should default to single select

### DIFF
--- a/src/dispatch/static/dispatch/src/feedback/service/TableFilterDialog.vue
+++ b/src/dispatch/static/dispatch/src/feedback/service/TableFilterDialog.vue
@@ -19,6 +19,7 @@
             :health-metrics="true"
             :project="local_project"
             label="Oncall service"
+            :multiple="true"
           />
         </v-list-item>
       </v-list>

--- a/src/dispatch/static/dispatch/src/service/ServiceSelect.vue
+++ b/src/dispatch/static/dispatch/src/service/ServiceSelect.vue
@@ -14,7 +14,7 @@
     no-filter
     clearable
     chips
-    multiple
+    :multiple="multiple"
     closable-chips
   >
     <template #append-item>
@@ -58,6 +58,10 @@ export default {
       default: null,
     },
     healthMetrics: {
+      type: Boolean,
+      default: false,
+    },
+    multiple: {
       type: Boolean,
       default: false,
     },


### PR DESCRIPTION
This PR makes the oncall selector single-select by default. Only the oncall feedback filter dialog needs multiple-select, so adding a prop for that use case.