### PR TITLE
fix: user update from CLI threw AttributeError

### DIFF
--- a/src/dispatch/auth/service.py
+++ b/src/dispatch/auth/service.py
@@ -221,10 +221,6 @@ def update(*, db_session, user: DispatchUser, user_in: UserUpdate) -> DispatchUs
         if field in update_data:
             setattr(user, field, update_data[field])
 
-    if user_in.password:
-        password = bytes(user_in.password, "utf-8")
-        user.password = password
-
     if user_in.organizations:
         roles = []
 


### PR DESCRIPTION
In #5711, the UserUpdate class no longer has the [password attribute](https://github.com/Netflix/dispatch/pull/5711/files#diff-15d6b1465c4dfa6598f562b0f3fa0f30d72ad4af62906e1b2363e62c4bc1e467L168) but the update function still checked for it and `dispatch user update -o` would throw an error.

Validated that user create (UI) and password reset (CLI) still functions.