### PR TITLE
fix: case type query params get ignored on Report Case form

### DIFF
--- a/src/dispatch/static/dispatch/src/case/ReportSubmissionCard.vue
+++ b/src/dispatch/static/dispatch/src/case/ReportSubmissionCard.vue
@@ -103,8 +103,6 @@ import ProjectSelect from "@/project/ProjectSelect.vue"
 import DocumentApi from "@/document/api"
 import ProjectApi from "@/project/api"
 import AuthApi from "@/auth/api"
-import SearchUtils from "@/search/utils"
-import CaseTypeApi from "@/case/type/api"
 
 export default {
   setup() {

--- a/src/dispatch/static/dispatch/src/case/ReportSubmissionCard.vue
+++ b/src/dispatch/static/dispatch/src/case/ReportSubmissionCard.vue
@@ -260,32 +260,7 @@ export default {
     }
 
     if (this.$route.query.case_type) {
-      let filterOptions = {
-        q: "",
-        sortBy: ["name"],
-        descending: [false],
-        itemsPerPage: this.numItems,
-      }
-
-      if (this.project) {
-        filterOptions = {
-          filters: {
-            project: [this.project],
-            name: [this.$route.query.case_type],
-            enabled: ["true"],
-          },
-          ...filterOptions,
-        }
-      }
-
-      filterOptions = SearchUtils.createParametersFromTableOptions({ ...filterOptions })
-      CaseTypeApi.getAll(filterOptions).then((response) => {
-        if (response.data.items.length > 0) {
-          this.case_type = response.data.items[0]
-        } else {
-          this.case_type = this.$route.query.case_type
-        }
-      })
+      this.case_type = { name: this.$route.query.case_type }
     }
 
     if (this.$route.query.case_priority) {


### PR DESCRIPTION
This pattern matches the way Incident ReportSubmissionCard is set up since there isn't a "Load More" and fixes the issue where this.project isn't set in time for the evaluation