### PR TITLE
Truncate GenAI prompt if this exceeds 128k tokens

### DIFF
--- a/requirements-base.in
+++ b/requirements-base.in
@@ -47,8 +47,8 @@ schemathesis
 sentry-asgi
 sentry-sdk==1.45.0
 sh
-slack_sdk
 slack-bolt
+slack_sdk
 slowapi
 spacy
 sqlalchemy-filters
@@ -57,6 +57,7 @@ sqlalchemy<1.4  # NOTE temporarily until https://github.com/kvesteri/sqlalchemy-
 statsmodels
 tabulate
 tenacity
+tiktoken
 uvicorn
 uvloop
 validators==0.18.2

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -4,14 +4,15 @@
 #
 #    pip-compile requirements-base.in
 #
+--index-url https://pypi.netflix.net/simple
 
 aiocache==0.12.3
     # via -r requirements-base.in
 aiofiles==24.1.0
     # via -r requirements-base.in
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.11.12
     # via -r requirements-base.in
 aiosignal==1.3.2
     # via aiohttp
@@ -38,9 +39,9 @@ blis==1.2.0
     # via thinc
 blockkit==1.5.2
     # via -r requirements-base.in
-boto3==1.36.13
+boto3==1.36.19
     # via -r requirements-base.in
-botocore==1.36.13
+botocore==1.36.19
     # via
     #   boto3
     #   s3transfer
@@ -127,7 +128,7 @@ frozenlist==1.5.0
     #   aiosignal
 google-api-core==2.24.1
     # via google-api-python-client
-google-api-python-client==2.160.0
+google-api-python-client==2.161.0
     # via -r requirements-base.in
 google-auth==2.38.0
     # via
@@ -139,7 +140,7 @@ google-auth-httplib2==0.2.0
     # via google-api-python-client
 google-auth-oauthlib==1.2.1
     # via -r requirements-base.in
-googleapis-common-protos==1.66.0
+googleapis-common-protos==1.67.0
     # via google-api-core
 graphql-core==3.2.6
     # via hypothesis-graphql
@@ -239,7 +240,7 @@ murmurhash==1.0.12
     #   preshed
     #   spacy
     #   thinc
-numpy==2.2.2
+numpy==2.2.3
     # via
     #   -r requirements-base.in
     #   blis
@@ -256,7 +257,7 @@ oauthlib[signedtoken]==3.2.2
     #   atlassian-python-api
     #   jira
     #   requests-oauthlib
-openai==1.61.0
+openai==1.62.0
     # via -r requirements-base.in
 packaging==24.2
     # via
@@ -363,6 +364,8 @@ pytz==2025.1
     #   pandas
 pyyaml==6.0.2
     # via schemathesis
+regex==2024.11.6
+    # via tiktoken
 requests==2.32.3
     # via
     #   -r requirements-base.in
@@ -378,6 +381,7 @@ requests==2.32.3
     #   schemathesis
     #   spacy
     #   starlette-testclient
+    #   tiktoken
     #   weasel
 requests-oauthlib==2.0.0
     # via
@@ -477,6 +481,8 @@ text-unidecode==1.3
     # via python-slugify
 thinc==8.3.4
     # via spacy
+tiktoken==0.8.0
+    # via -r requirements-base.in
 tomli==2.2.1
     # via schemathesis
 tomli-w==1.2.0

--- a/src/dispatch/ai/service.py
+++ b/src/dispatch/ai/service.py
@@ -44,29 +44,6 @@ def num_tokens_from_string(message: str, model: str) -> tuple[list[int], int, ti
     return tokenized_message, num_tokens, encoding
 
 
-# def num_tokens_from_string(message: str, model: str) -> int:
-#     """
-#     Calculate the number of tokens in a given string for a specified model.
-
-#     Args:
-#         message (str): The input string to be tokenized.
-#         model (str): The model name to use for tokenization.
-
-#     Returns:
-#         int: The number of tokens in the input string.
-#     """
-#     try:
-#         encoding = tiktoken.encoding_for_model(model)
-#     except KeyError:
-#         log.warning(
-#             f"We could not automatically map {model} to a tokeniser. Using o200k_base encoding."
-#         )
-#         # defaults to o200k_base encoding used in gpt-4o, gpt-4o-mini models
-#         encoding = tiktoken.get_encoding("o200k_base")
-
-#     return len(encoding.encode(message))
-
-
 def truncate_prompt(
     tokenized_prompt: list[int],
     num_tokens: int,

--- a/src/dispatch/ai/service.py
+++ b/src/dispatch/ai/service.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+import tiktoken
 from sqlalchemy.orm import Session
 
 from dispatch.case.enums import CaseResolutionReason
@@ -13,6 +14,80 @@ from dispatch.signal import service as signal_service
 from .exceptions import GenAIException
 
 log = logging.getLogger(__name__)
+
+MAX_TOKENS = 128000
+
+
+def num_tokens_from_string(message: str, model: str) -> tuple[list[int], int, tiktoken.Encoding]:
+    """
+    Calculate the number of tokens in a given string for a specified model.
+
+    Args:
+        message (str): The input string to be tokenized.
+        model (str): The model name to use for tokenization.
+
+    Returns:
+        tuple: A tuple containing a list of token integers, the number of tokens, and the encoding object.
+    """
+    try:
+        encoding = tiktoken.encoding_for_model(model)
+    except KeyError:
+        log.warning(
+            f"We could not automatically map {model} to a tokeniser. Using o200k_base encoding."
+        )
+        # defaults to o200k_base encoding used in gpt-4o, gpt-4o-mini models
+        encoding = tiktoken.get_encoding("o200k_base")
+
+    tokenized_message = encoding.encode(message)
+    num_tokens = len(tokenized_message)
+
+    return tokenized_message, num_tokens, encoding
+
+
+# def num_tokens_from_string(message: str, model: str) -> int:
+#     """
+#     Calculate the number of tokens in a given string for a specified model.
+
+#     Args:
+#         message (str): The input string to be tokenized.
+#         model (str): The model name to use for tokenization.
+
+#     Returns:
+#         int: The number of tokens in the input string.
+#     """
+#     try:
+#         encoding = tiktoken.encoding_for_model(model)
+#     except KeyError:
+#         log.warning(
+#             f"We could not automatically map {model} to a tokeniser. Using o200k_base encoding."
+#         )
+#         # defaults to o200k_base encoding used in gpt-4o, gpt-4o-mini models
+#         encoding = tiktoken.get_encoding("o200k_base")
+
+#     return len(encoding.encode(message))
+
+
+def truncate_prompt(
+    tokenized_prompt: list[int],
+    num_tokens: int,
+    encoding: tiktoken.Encoding,
+) -> str:
+    """
+    Truncate the tokenized prompt to ensure it does not exceed the maximum number of tokens.
+
+    Args:
+        tokenized_prompt (list[int]): The tokenized input prompt to be truncated.
+        num_tokens (int): The number of tokens in the input prompt.
+        encoding (tiktoken.Encoding): The encoding object used for tokenization.
+
+    Returns:
+        str: The truncated prompt as a string.
+    """
+    excess_tokens = num_tokens - MAX_TOKENS
+    truncated_tokenized_prompt = tokenized_prompt[:-excess_tokens]
+    truncated_prompt = encoding.decode(truncated_tokenized_prompt)
+    log.warning(f"GenAI prompt truncated to fit within {MAX_TOKENS} tokens.")
+    return truncated_prompt
 
 
 def generate_case_signal_historical_context(case: Case, db_session: Session) -> str:
@@ -169,28 +244,35 @@ def generate_case_signal_summary(case: Case, db_session: Session) -> dict[str, s
         log.warning(message)
         raise GenAIException(message)
 
-    # we generate the analysis
-    response = genai_plugin.instance.chat_completion(
-        prompt=f"""
+    # we generate the prompt
+    prompt = f"""
+    <prompt>
+    {signal_instance.signal.genai_prompt}
+    </prompt>
 
-        <prompt>
-        {signal_instance.signal.genai_prompt}
-        </prompt>
+    <current_event>
+    {str(signal_instance.raw)}
+    </current_event>
 
-        <current_event>
-        {str(signal_instance.raw)}
-        </current_event>
+    <runbook>
+    {signal_instance.signal.runbook}
+    </runbook>
 
-        <runbook>
-        {signal_instance.signal.runbook}
-        </runbook>
+    <historical_context>
+    {historical_context}
+    </historical_context>
+    """
 
-        <historical_context>
-        {historical_context}
-        </historical_context>
-
-        """
+    tokenized_prompt, num_tokens, encoding = num_tokens_from_string(
+        prompt, genai_plugin.instance.configuration.chat_completion_model
     )
+
+    # we check if the prompt exceeds the token limit
+    if num_tokens > MAX_TOKENS:
+        prompt = truncate_prompt(tokenized_prompt, num_tokens, encoding)
+
+    # we generate the analysis
+    response = genai_plugin.instance.chat_completion(prompt=prompt)
 
     try:
         summary = json.loads(response.replace("```json", "").replace("```", "").strip())
@@ -267,6 +349,14 @@ def generate_incident_summary(incident: Incident, db_session: Session) -> str:
 
             {pir_doc}
         """
+
+        tokenized_prompt, num_tokens, encoding = num_tokens_from_string(
+            prompt, genai_plugin.instance.configuration.chat_completion_model
+        )
+
+        # we check if the prompt exceeds the token limit
+        if num_tokens > MAX_TOKENS:
+            prompt = truncate_prompt(tokenized_prompt, num_tokens, encoding)
 
         summary = genai_plugin.instance.chat_completion(prompt=prompt)
 


### PR DESCRIPTION
### Requirements Changes
- Added `tiktoken` package to requirements
- Updated several package versions:
  - `aiohappyeyeballs` from 2.4.4 to 2.4.6
  - `aiohttp` from 3.11.11 to 3.11.12
  - `boto3` from 1.36.13 to 1.36.19
  - `botocore` from 1.36.13 to 1.36.19
  - `google-api-python-client` from 2.160.0 to 2.161.0
  - `numpy` from 2.2.2 to 2.2.3
  - `openai` from 1.61.0 to 1.62.0

### Functional Changes in `src/dispatch/ai/service.py`

1. **New Constants**
- Added `MAX_TOKENS = 128000` constant

2. **New Functions**
- Added `num_tokens_from_string(message: str, model: str) -> tuple[list[int], int, tiktoken.Encoding]`
  - Calculates token count for a given string using specified model
  - Returns tokenized message, token count, and encoding object
  
- Added `truncate_prompt(tokenized_prompt: list[int], num_tokens: int, encoding: tiktoken.Encoding) -> str`
  - Truncates prompts that exceed the maximum token limit
  - Returns truncated prompt as string

3. **Modified Functions**
- Updated `generate_case_signal_summary`
  - Added token counting and truncation logic
  - Separated prompt construction from API call
  
- Updated `generate_incident_summary`
  - Added token counting and truncation logic before making API calls

### Key Improvements
1. Token Management: Added functionality to handle large prompts by checking and truncating them if they exceed token limits
2. Better Error Handling: Improved logging for tokenization issues
3. Code Organization: Separated prompt construction from API calls for better maintainability

The changes primarily focus on managing token limits in AI prompts and updating dependencies to their latest versions.