### PR TITLE
Propose additional security check to auth/views.py

### DIFF
--- a/src/dispatch/auth/views.py
+++ b/src/dispatch/auth/views.py
@@ -146,6 +146,14 @@ def update_user(
     user_in: UserUpdate,
     current_user: CurrentUser,
 ):
+    """Check if Current_user is Owner and is trying to edit another user"""
+    current_user_organization_role = current_user.get_organization_role(organization)
+    if current_user_organization_role != "Owner" and current_user.id != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=[{"msg": "A user that is not an Owner is trying to update another user."}],
+        )
+    
     """Update a user."""
     user = get(db_session=db_session, user_id=user_id)
     if not user:

--- a/src/dispatch/auth/views.py
+++ b/src/dispatch/auth/views.py
@@ -153,7 +153,6 @@ def update_user(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=[{"msg": "A user that is not an Owner is trying to update another user."}],
         )
-    
     """Update a user."""
     user = get(db_session=db_session, user_id=user_id)
     if not user:

--- a/src/dispatch/auth/views.py
+++ b/src/dispatch/auth/views.py
@@ -148,7 +148,7 @@ def update_user(
 ):
     """Check if Current_user is Owner and is trying to edit another user"""
     current_user_organization_role = current_user.get_organization_role(organization)
-    if current_user_organization_role != "Owner" and current_user.id != user_id:
+    if current_user_organization_role != UserRoles.owner and current_user.id != user_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=[{"msg": "A user that is not an Owner is trying to update another user."}],


### PR DESCRIPTION
Hi,

There is an IDOR vulnerability that allows any user to edit another user (via the Experimental Features button), by simply changing the user ID in the path and in the HTTP request. This happens because the application is missing a security check (when "role" is not provided in the PUT HTTP Request's body)

This additional security check will cause the application to return a 403 Forbidden if a user that is not an "Owner" is trying to edit another user, essentially remediating an IDOR vulnerability.