### PR TITLE
fix(conversation): fixing bookmarks without resource.name

### DIFF
--- a/src/dispatch/conversation/flows.py
+++ b/src/dispatch/conversation/flows.py
@@ -405,14 +405,22 @@ def add_conversation_bookmark(
     title: str | None = None,
 ):
     """Adds a conversation bookmark."""
-    if not resource or not hasattr(resource, "name"):
+    if not resource:
         log.warning("No conversation bookmark added since no resource available for subject.")
         return
 
-    if not subject.conversation:
-        log.warning(
-            f"Conversation bookmark {resource.name.lower()} not added. No conversation available."
+    resource_name = (
+        resource.name.lower()
+        if hasattr(resource, "name")
+        else (
+            deslug_and_capitalize_resource_type(resource.resource_type)
+            if hasattr(resource, "resource_type")
+            else title if title else "untitled resource"
         )
+    )
+
+    if not subject.conversation:
+        log.warning(f"Conversation bookmark {resource_name} not added. No conversation available.")
         return
 
     plugin = plugin_service.get_active_instance(
@@ -422,7 +430,7 @@ def add_conversation_bookmark(
     )
     if not plugin:
         log.warning(
-            f"Conversation bookmark {resource.name.lower()} not added. No conversation plugin enabled."
+            f"Conversation bookmark {resource_name} not added. No conversation plugin enabled."
         )
         return
 
@@ -437,7 +445,7 @@ def add_conversation_bookmark(
             )
             if resource
             else log.warning(
-                f"{resource.name} bookmark not added. No {resource.name.lower()} available for subject.."
+                f"{resource_name} bookmark not added. No {resource_name} available for subject.."
             )
         )
     except Exception as e:
@@ -445,7 +453,7 @@ def add_conversation_bookmark(
             subject=subject,
             db_session=db_session,
             source="Dispatch Core App",
-            description=f"Adding the {resource.name.lower()} bookmark failed. Reason: {e}",
+            description=f"Adding the {resource_name} bookmark failed. Reason: {e}",
         )
         log.exception(e)
 


### PR DESCRIPTION
This pull request addresses an issue in the `add_conversation_bookmark` function where bookmarks could not be added if the `resource` object lacked a `name` attribute. The changes ensure that a bookmark can still be created by using alternative identifiers when `resource.name` is unavailable.

#### Changes Made
- **Refactored Resource Name Handling**: 
  - Introduced a new logic to determine `resource_name` when `resource.name` is not present. It now checks for `resource.resource_type` and uses `deslug_and_capitalize_resource_type` to generate a name. If neither is available, it defaults to the provided `title` or "untitled resource".
- **Updated Log Messages**:
  - Modified log messages to use `resource_name` instead of directly accessing `resource.name`, ensuring consistent and meaningful logging even when `resource.name` is absent.
- **Code Adjustments**:
  - Adjusted the conditional checks and log messages throughout the function to accommodate the new `resource_name` logic.