### PR TITLE
Migrates to Slack file upload v2 API call

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -143,10 +143,11 @@ class SlackConversationPlugin(ConversationPlugin):
 
             # we try to upload the alert JSON to the case thread
             try:
-                client.files_upload(
-                    channels=conversation_id,
+                client.files_upload_v2(
+                    channel=signal_response.get(
+                        "id"
+                    ),  # we need the conversation ID not the name here
                     thread_ts=case.signal_thread_ts,
-                    filetype="json",
                     file=io.BytesIO(json.dumps(case.signal_instances[0].raw, indent=4).encode()),
                 )
             except SlackApiError as e:


### PR DESCRIPTION
## Changes

- Updated the Slack file upload method from `files_upload` to `files_upload_v2` in the `SlackConversationPlugin` class
- Changed parameter name from `channels` to `channel` to match the new API requirements
- Modified the channel value to use the conversation ID from `signal_response.get("id")` instead of using `conversation_id`
- Added a comment explaining that we need the conversation ID, not the name
- Removed the `filetype="json"` parameter as it's no longer needed in the v2 API

This change ensures compatibility with Slack's updated file upload API.

<img width="696" alt="Screenshot 2025-03-03 at 2 27 54 PM" src="https://github.com/user-attachments/assets/4a4a2eae-4288-428c-ac93-b5926e60b2fc" />