### PR TITLE
Migrate from using default case cost type to assigning cost type by cost model.

### DIFF
--- a/src/dispatch/case/enums.py
+++ b/src/dispatch/case/enums.py
@@ -13,3 +13,10 @@ class CaseResolutionReason(DispatchEnum):
     user_acknowledge = "User Acknowledged"
     mitigated = "Mitigated"
     escalated = "Escalated"
+
+
+class CostModelType(DispatchEnum):
+    """Type of cost model used to calculate costs."""
+
+    new = "new"
+    classic = "classic"

--- a/src/dispatch/case/enums.py
+++ b/src/dispatch/case/enums.py
@@ -18,5 +18,5 @@ class CaseResolutionReason(DispatchEnum):
 class CostModelType(DispatchEnum):
     """Type of cost model used to calculate costs."""
 
-    new = "new"
-    classic = "classic"
+    new = "New"
+    classic = "Classic"

--- a/src/dispatch/case_cost/scheduled.py
+++ b/src/dispatch/case_cost/scheduled.py
@@ -6,15 +6,14 @@ from sqlalchemy.orm import Session
 
 from dispatch.decorators import scheduled_project_task, timer
 from dispatch.case import service as case_service
-from dispatch.case.enums import CaseStatus
-from dispatch.case_cost_type import service as case_cost_type_service
+from dispatch.case.enums import CaseStatus, CostModelType
 from dispatch.project.models import Project
 from dispatch.scheduler import scheduler
 
 from .service import (
     calculate_case_response_cost,
     update_case_response_cost,
-    get_or_create_default_case_response_cost,
+    get_or_create_case_response_cost_by_model_type,
 )
 
 
@@ -26,16 +25,6 @@ log = logging.getLogger(__name__)
 @scheduled_project_task
 def calculate_cases_response_cost(db_session: Session, project: Project):
     """Calculates and saves the response cost for all cases."""
-    response_cost_type = case_cost_type_service.get_default(
-        db_session=db_session, project_id=project.id
-    )
-
-    if response_cost_type is None:
-        log.warning(
-            f"A default cost type for response cost doesn't exist in the {project.name} project and organization {project.organization.name}. Response costs for cases won't be calculated."
-        )
-        return
-
     cases = case_service.get_all_by_status(
         db_session=db_session, project_id=project.id, statuses=[CaseStatus.new, CaseStatus.triage]
     )
@@ -43,8 +32,9 @@ def calculate_cases_response_cost(db_session: Session, project: Project):
     for case in cases:
         try:
             # we get the response cost for the given case
-            case_response_cost = get_or_create_default_case_response_cost(case, db_session)
-
+            case_response_cost = get_or_create_case_response_cost_by_model_type(
+                case=case, db_session=db_session, model_type=CostModelType.new
+            )
             # we don't need to update the cost of closed cases if they already have a response cost and this was updated after the case was closed
             if case.status == CaseStatus.closed:
                 if case_response_cost:

--- a/src/dispatch/case_cost/service.py
+++ b/src/dispatch/case_cost/service.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 import logging
 import math
-from typing import List, Optional
+from typing import Optional
 
 from dispatch.database.core import SessionLocal
 from dispatch.cost_model.models import CostModelActivity
@@ -9,7 +9,7 @@ from dispatch.case import service as case_service
 from dispatch.case.models import Case
 from dispatch.case.type.models import CaseType
 from dispatch.case_cost_type import service as case_cost_type_service
-from dispatch.case_cost_type.models import CaseCostTypeRead
+from dispatch.case.enums import CostModelType
 from dispatch.participant import service as participant_service
 from dispatch.participant.models import ParticipantRead
 from dispatch.participant_activity import service as participant_activity_service
@@ -29,7 +29,7 @@ def get(*, db_session, case_cost_id: int) -> Optional[CaseCost]:
     return db_session.query(CaseCost).filter(CaseCost.id == case_cost_id).one_or_none()
 
 
-def get_by_case_id(*, db_session, case_id: int) -> List[Optional[CaseCost]]:
+def get_by_case_id(*, db_session, case_id: int) -> list[Optional[CaseCost]]:
     """Gets case costs by their case id."""
     return db_session.query(CaseCost).filter(CaseCost.case_id == case_id).all()
 
@@ -47,7 +47,7 @@ def get_by_case_id_and_case_cost_type_id(
     )
 
 
-def get_all(*, db_session) -> List[Optional[CaseCost]]:
+def get_all(*, db_session) -> list[Optional[CaseCost]]:
     """Gets all case costs."""
     return db_session.query(CaseCost)
 
@@ -114,62 +114,38 @@ def calculate_response_cost(hourly_rate, total_response_time_seconds) -> int:
     return math.ceil((total_response_time_seconds / SECONDS_IN_HOUR) * hourly_rate)
 
 
-def get_default_case_response_cost(case: Case, db_session: SessionLocal) -> Optional[CaseCost]:
-    response_cost_type = case_cost_type_service.get_default(
-        db_session=db_session, project_id=case.project.id
-    )
-
-    if not response_cost_type:
-        log.warning(
-            f"A default cost type for response cost doesn't exist in the {case.project.name} project and organization {case.project.organization.name}. Response costs for case {case.name} won't be calculated."
-        )
-        return None
-
-    return get_by_case_id_and_case_cost_type_id(
-        db_session=db_session,
-        case_id=case.id,
-        case_cost_type_id=response_cost_type.id,
-    )
-
-
-def get_or_create_default_case_response_cost(
-    case: Case, db_session: SessionLocal
+def get_or_create_case_response_cost_by_model_type(
+    case: Case, model_type: str, db_session: SessionLocal
 ) -> Optional[CaseCost]:
-    """Gets or creates the default case cost for a case.
-
-    The default case cost is the cost associated with the participant effort in a case's response.
-    """
-    response_cost_type = case_cost_type_service.get_default(
-        db_session=db_session, project_id=case.project.id
+    """Gets a case response cost for a specific model type."""
+    # Find the cost type matching the requested model type for the project
+    response_cost_type = case_cost_type_service.get_or_create_response_cost_type(
+        db_session=db_session, project_id=case.project.id, model_type=model_type
     )
 
     if not response_cost_type:
         log.warning(
-            f"A default cost type for response cost doesn't exist in the {case.project.name} project and organization {case.project.organization.name}. Response costs for case {case.name} won't be calculated."
+            f"A default cost type for model type {model_type} doesn't exist and could not be created in the {case.project.name} project. "
+            f"Response costs for case {case.name} won't be calculated for this model."
         )
         return None
 
-    case_response_cost = get_by_case_id_and_case_cost_type_id(
-        db_session=db_session,
-        case_id=case.id,
-        case_cost_type_id=response_cost_type.id,
+    # Retrieve or create the case cost for the given case and cost type
+    case_cost = get_by_case_id_and_case_cost_type_id(
+        db_session=db_session, case_id=case.id, case_cost_type_id=response_cost_type.id
     )
+    if not case_cost:
+        case_cost = CaseCostCreate(
+            case=case, case_cost_type=response_cost_type, amount=0, project=case.project
+        )
+        case_cost = create(db_session=db_session, case_cost_in=case_cost)
 
-    if not case_response_cost:
-        # we create the response cost if it doesn't exist
-        case_cost_type = CaseCostTypeRead.from_orm(response_cost_type)
-        case_cost_in = CaseCostCreate(case_cost_type=case_cost_type, project=case.project)
-        case_response_cost = create(db_session=db_session, case_cost_in=case_cost_in)
-        case.case_costs.append(case_response_cost)
-        db_session.add(case)
-        db_session.commit()
-
-    return case_response_cost
+    return case_cost
 
 
 def fetch_case_events(
     case: Case, activity: CostModelActivity, oldest: str, db_session: SessionLocal
-) -> List[Optional[tuple[datetime.timestamp, str]]]:
+) -> list[Optional[tuple[datetime.timestamp, str]]]:
     """Fetches case events for a given case and cost model activity.
 
     Args:
@@ -179,7 +155,7 @@ def fetch_case_events(
         db_session: The database session.
 
     Returns:
-        List[Optional[tuple[datetime.timestamp, str]]]: A list of tuples containing the timestamp and user_id of each event.
+        list[Optional[tuple[datetime.timestamp, str]]]: A list of tuples containing the timestamp and user_id of each event.
     """
 
     plugin_instance = plugin_service.get_active_instance_by_slug(
@@ -238,7 +214,9 @@ def update_case_participant_activities(
     # Used for determining whether we've previously calculated the case cost.
     current_time = datetime.now(tz=timezone.utc).replace(tzinfo=None)
 
-    case_response_cost = get_or_create_default_case_response_cost(case=case, db_session=db_session)
+    case_response_cost = get_or_create_case_response_cost_by_model_type(
+        case=case, db_session=db_session, model_type=CostModelType.new
+    )
     if not case_response_cost:
         log.warning(
             f"Cannot calculate case response cost for case {case.name}. No default case response cost type created or found."
@@ -289,20 +267,18 @@ def update_case_participant_activities(
 
 
 def calculate_case_response_cost(case: Case, db_session: SessionLocal) -> int:
-    """Calculates the response cost of a given case."""
-    # Iterate through all the listed activities and aggregate the total participant response time spent on the case.
+    """Calculates case response cost."""
     participants_total_response_time = timedelta(0)
-    particpant_activities = (
+    participant_activities = (
         participant_activity_service.get_all_case_participant_activities_for_case(
             db_session=db_session, case_id=case.id
         )
     )
-    for participant_activity in particpant_activities:
+    for participant_activity in participant_activities:
         participants_total_response_time += (
             participant_activity.ended_at - participant_activity.started_at
         )
 
-    # Calculate the cost based on the total participant response time.
     hourly_rate = get_hourly_rate(case.project)
     amount = calculate_response_cost(
         hourly_rate=hourly_rate,
@@ -311,32 +287,36 @@ def calculate_case_response_cost(case: Case, db_session: SessionLocal) -> int:
     return amount
 
 
-def update_case_response_cost(case: Case, db_session: SessionLocal) -> int:
-    """Updates the response cost of a given case.
+def update_case_response_cost(case: Case, db_session: SessionLocal) -> dict[str, int]:
+    """Updates the response cost of a given case using the cost model.
 
-    This function logs all case participant activities since the last case cost update and recalculates the case response cost based on all logged participant activities.
+    This function logs all case participant activities since the last case cost update and
+    recalculates the case response cost using the new cost model.
 
     Args:
-        case_id: The case id.
+        case: The case to update costs for.
         db_session: The database session.
 
     Returns:
-        int: The case response cost in dollars.
+        dict[str, int]: Dictionary containing costs from both models {'new': new_cost, 'classic': classic_cost}
     """
-    # We update the case participant activities before calculating the case response cost
+    # Update case participant activities before calculating costs
     update_case_participant_activities(case=case, db_session=db_session)
-    amount = calculate_case_response_cost(case=case, db_session=db_session)
-    case_response_cost = get_or_create_default_case_response_cost(case=case, db_session=db_session)
 
-    if not case_response_cost:
-        log.warning(f"Cannot calculate case response cost for case {case.name}.")
-        return 0
+    results = {}
 
-    # We update the cost amount only if the case cost has changed
-    if case_response_cost.amount != amount:
-        case_response_cost.amount = amount
-        case.case_costs.append(case_response_cost)
-        db_session.add(case)
-        db_session.commit()
+    # Calculate and update new model cost
+    new_amount = calculate_case_response_cost(case=case, db_session=db_session)
+    new_cost = get_or_create_case_response_cost_by_model_type(
+        case=case, model_type=CostModelType.new, db_session=db_session
+    )
 
-    return case_response_cost.amount
+    if new_cost:
+        if new_cost.amount != new_amount:
+            new_cost.amount = new_amount
+            case.case_costs.append(new_cost)
+            db_session.add(case)
+            db_session.commit()
+        results[CostModelType.new] = new_cost.amount
+
+    return results

--- a/src/dispatch/case_cost_type/models.py
+++ b/src/dispatch/case_cost_type/models.py
@@ -3,11 +3,10 @@ from typing import List, Optional
 from pydantic import Field
 
 from sqlalchemy import Column, Integer, String, Boolean
-from sqlalchemy.event import listen
 
 from sqlalchemy_utils import TSVectorType, JSONType
 
-from dispatch.database.core import Base, ensure_unique_default_per_project
+from dispatch.database.core import Base
 from dispatch.models import (
     DispatchBase,
     NameStr,
@@ -27,16 +26,13 @@ class CaseCostType(Base, TimeStampMixin, ProjectMixin):
     description = Column(String)
     category = Column(String)
     details = Column(JSONType, nullable=True)
-    default = Column(Boolean, default=False)
     editable = Column(Boolean, default=True)
+    model_type = Column(String, nullable=True)
 
     # full text search capabilities
     search_vector = Column(
         TSVectorType("name", "description", weights={"name": "A", "description": "B"})
     )
-
-
-listen(CaseCostType.default, "set", ensure_unique_default_per_project)
 
 
 # Pydantic Models
@@ -46,8 +42,8 @@ class CaseCostTypeBase(DispatchBase):
     category: Optional[str] = Field(None, nullable=True)
     details: Optional[dict] = {}
     created_at: Optional[datetime]
-    default: Optional[bool]
     editable: Optional[bool]
+    model_type: Optional[str] = Field(None, nullable=False)
 
 
 class CaseCostTypeCreate(CaseCostTypeBase):

--- a/src/dispatch/database/revisions/tenant/versions/2025-03-04_da444de005a6.py
+++ b/src/dispatch/database/revisions/tenant/versions/2025-03-04_da444de005a6.py
@@ -1,0 +1,49 @@
+"""empty message
+
+Revision ID: da444de005a6
+Revises: 2f18776252bb
+Create Date: 2025-03-04 10:06:46.787201
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "da444de005a6"
+down_revision = "2f18776252bb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("case_cost_type", sa.Column("model_type", sa.String(), nullable=True))
+
+    # Update 'model_type' to 'New' where 'default' is true
+    op.execute(
+        """
+        UPDATE case_cost_type
+        SET model_type = 'New'
+        WHERE "default" = true
+        """
+    )
+
+    op.drop_column("case_cost_type", "default")
+    # ### end Alembic commands ###
+
+
+def downgrade():
+    op.add_column(
+        "case_cost_type",
+        sa.Column("default", sa.Boolean(), server_default=False),
+    )
+    op.execute(
+        """
+        UPDATE case_cost_type
+        SET "default" = true
+        WHERE model_type = 'New'
+        """
+    )
+    op.drop_column("case_cost_type", "model_type")
+    # ### end Alembic commands ###

--- a/src/dispatch/static/dispatch/src/case_cost_type/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/case_cost_type/NewEditSheet.vue
@@ -71,11 +71,12 @@
                 </v-tooltip>
                 <v-radio-group v-model="response_case_cost_type" disabled>
                   <v-radio
-                    v-for="modelType in ['New', 'Classic', 'None']"
+                    v-for="modelType in ['New', 'Classic']"
                     :key="modelType"
                     :label="modelType"
                     :value="modelType"
                   />
+                  <v-radio :key="null" label="None" :value="null" />
                 </v-radio-group>
               </v-col>
               <v-col cols="12">

--- a/src/dispatch/static/dispatch/src/case_cost_type/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/case_cost_type/NewEditSheet.vue
@@ -55,11 +55,28 @@
                 <case-cost-type-category-select v-model="category" />
               </v-col>
               <v-col cols="12">
-                <v-checkbox
-                  v-model="default_case_cost_type"
-                  label="Default"
-                  hint="Check this if this case cost type should be the default."
-                />
+                <v-tooltip max-width="500px" open-delay="50" location="bottom">
+                  <template #activator="{ props }">
+                    <div class="text-body-1 ml-1 mt-2">
+                      Response Cost Model Type
+                      <v-icon v-bind="props"> mdi-information-outline </v-icon>
+                    </div>
+                  </template>
+                  <span>
+                    The response cost model type is used to identify if the cost type is linked to
+                    response cost calculation under either the new or classic cost model. If the
+                    value is set to none, this cost is not related to response costs and is intended
+                    for manual cost entry.
+                  </span>
+                </v-tooltip>
+                <v-radio-group v-model="response_case_cost_type" disabled>
+                  <v-radio
+                    v-for="modelType in ['New', 'Classic', 'None']"
+                    :key="modelType"
+                    :label="modelType"
+                    :value="modelType"
+                  />
+                </v-radio-group>
               </v-col>
               <v-col cols="12">
                 <v-checkbox
@@ -108,7 +125,7 @@ export default {
       "dialogs.showCreateEdit",
     ]),
     ...mapFields("case_cost_type", {
-      default_case_cost_type: "selected.default",
+      response_case_cost_type: "selected.model_type",
     }),
   },
 

--- a/src/dispatch/static/dispatch/src/case_cost_type/Table.vue
+++ b/src/dispatch/static/dispatch/src/case_cost_type/Table.vue
@@ -42,8 +42,8 @@
             :loading="loading"
             loading-text="Loading... Please wait"
           >
-            <template #item.default="{ value }">
-              <v-checkbox-btn :model-value="value" disabled />
+            <template #item.model_type="{ value }">
+              <v-checkbox-btn :model-value="value != null" disabled />
             </template>
             <template #item.editable="{ value }">
               <v-checkbox-btn :model-value="value" disabled />
@@ -105,7 +105,7 @@ export default {
         { title: "Description", value: "description", sortable: false },
         { title: "Category", value: "category", sortable: false },
         { title: "Details", value: "details", sortable: false },
-        { title: "Default", value: "default", sortable: true },
+        { title: "Response Cost Type", value: "model_type", sortable: true },
         { title: "Editable", value: "editable", sortable: true },
         { title: "Created At", value: "created_at", sortable: true },
         { title: "", key: "data-table-actions", sortable: false, align: "end" },

--- a/src/dispatch/static/dispatch/src/case_cost_type/store.js
+++ b/src/dispatch/static/dispatch/src/case_cost_type/store.js
@@ -11,7 +11,7 @@ const getDefaultSelectedState = () => {
     description: null,
     category: null,
     details: {},
-    model_type: "None",
+    model_type: null,
     project: null,
     editable: true,
     loading: false,

--- a/src/dispatch/static/dispatch/src/case_cost_type/store.js
+++ b/src/dispatch/static/dispatch/src/case_cost_type/store.js
@@ -11,7 +11,7 @@ const getDefaultSelectedState = () => {
     description: null,
     category: null,
     details: {},
-    default: false,
+    model_type: "None",
     project: null,
     editable: true,
     loading: false,

--- a/tests/case_type/test_case_type_service.py
+++ b/tests/case_type/test_case_type_service.py
@@ -58,6 +58,7 @@ def test_update_cost_model(session, case, case_type, cost_model, case_cost, case
     from dispatch.case.type.service import update
     from dispatch.case_cost import service as case_cost_service
     from dispatch.case_cost_type import service as case_cost_type_service
+    from dispatch.case.enums import CostModelType
     from dispatch.case.type.models import CaseTypeUpdate
     import datetime
 
@@ -72,10 +73,10 @@ def test_update_cost_model(session, case, case_type, cost_model, case_cost, case
     case.project = case_type.project
 
     for cost_type in case_cost_type_service.get_all(db_session=session):
-        cost_type.default = False
+        cost_type.model_type = None
 
     case_cost_type.project = case_type.project
-    case_cost_type.default = True
+    case_cost_type.model_type = CostModelType.new
 
     case_cost.project = case_type.project
     case_cost.case_id = case.id
@@ -92,7 +93,9 @@ def test_update_cost_model(session, case, case_type, cost_model, case_cost, case
     assert case_type.name == name
 
     # Assert that the case cost was updated
-    case_cost = case_cost_service.get_default_case_response_cost(db_session=session, case=case)
+    case_cost = case_cost_service.get_or_create_case_response_cost_by_model_type(
+        db_session=session, case=case, model_type=CostModelType.new
+    )
     assert case_cost
     assert case_cost.updated_at > current_time
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,6 +16,7 @@ from faker.providers import misc
 from pytz import UTC
 
 from dispatch.auth.models import DispatchUser, DispatchUserOrganization, hash_password  # noqa
+from dispatch.case.enums import CostModelType
 from dispatch.case.models import Case, CaseRead
 from dispatch.case.priority.models import CasePriority
 from dispatch.case.severity.models import CaseSeverity
@@ -1196,8 +1197,8 @@ class CaseCostTypeFactory(BaseFactory):
     description = FuzzyText()
     category = FuzzyText()
     details = {}
-    default = Faker().pybool()
     editable = Faker().pybool()
+    model_type = CostModelType.new
 
     class Meta:
         """Factory Configuration."""


### PR DESCRIPTION
Prerequisite for implementing parallel cost model execution for cases, allowing both the new cost model and classic cost model to run simultaneously and maintain separate cost records.

In this PR, we:
 *  replace the `cost_type` `default` column with a `cost_model_type` column:
     *  model_type=new is the response cost type associated with the new cost model
     *  model_type=classic is the response cost type associated with the classic cost model
     *  model_type=None is a cost type that is not associated with response time. This would cover manually-added costs accumulated over the course of the incident.
*  Update scheduler code to create a case response cost type and case response costs if none exist.
*  Update the UI to indicate which cost types are tied to response costs.

<img width="1022" alt="Screenshot 2025-03-05 at 2 38 02 PM" src="https://github.com/user-attachments/assets/0c07af8b-fc8c-4c2a-a80d-7da033b0bbca" />
<img width="538" alt="Screenshot 2025-03-05 at 2 38 13 PM" src="https://github.com/user-attachments/assets/f71bc396-3fab-49ec-87fb-3ef2f532bcf0" />
