### PR TITLE
fix(ui): make content scrollable when bottom sheet is visible

### DIFF
--- a/src/dispatch/static/dispatch/src/case/BulkEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/case/BulkEditSheet.vue
@@ -5,6 +5,7 @@
     persistent
     no-click-animation
     :retain-focus="false"
+    scroll-strategy="none"
   >
     <handoff-dialog />
     <closed-dialog />

--- a/src/dispatch/static/dispatch/src/incident/BulkEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/incident/BulkEditSheet.vue
@@ -5,6 +5,7 @@
     persistent
     no-click-animation
     :retain-focus="false"
+    scroll-strategy="none"
   >
     <handoff-dialog />
     <v-card :loading="bulkEditLoading" rounded="0">


### PR DESCRIPTION
Previously, after selecting an incident or case, the content was no longer scrollable due to the bottom sheet appearing. This fixes that scroll lock. Fixes DNRPLAT-94