### PR TITLE
fix(slack): truncate description if too large

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -87,6 +87,10 @@ def create_case_message(case: Case, channel_id: str) -> list[Block]:
         if variant := case.signal_instances[0].signal.variant:
             fields.append(f"*Variant* \n {variant}")
 
+    case_description = (
+        case.description if len(case.description) <= 2500 else f"{case.description[:2500]}..."
+    )
+
     blocks = [
         Section(
             text=title,
@@ -96,7 +100,7 @@ def create_case_message(case: Case, channel_id: str) -> list[Block]:
                 url=f"{DISPATCH_UI_URL}/{case.project.organization.slug}/cases/{case.name}",
             ),
         ),
-        Section(text=f"*Description* \n {case.description}"),
+        Section(text=f"*Description* \n {case_description}"),
         Section(fields=fields),
         Section(text="*Actions*"),
     ]

--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -2447,12 +2447,18 @@ def handle_report_incident_submission_event(
     # Create the incident
     incident = incident_service.create(db_session=db_session, incident_in=incident_in)
 
+    incident_description = (
+        incident.description
+        if len(incident.description) <= 2500
+        else f"{incident.description[:2500]}..."
+    )
+
     blocks = [
         Section(
             text="This is a confirmation that you have reported an incident with the following information. You will be invited to an incident Slack conversation shortly."
         ),
         Section(text=f"*Title*\n {incident.title}"),
-        Section(text=f"*Description*\n {incident.description}"),
+        Section(text=f"*Description*\n {incident_description}"),
         Section(
             fields=[
                 MarkdownText(


### PR DESCRIPTION
Fixes an issue when the description is too large and exceeds the maximum length for a section text block in Slack (3000 characters). Fixes DNRPLAT-96.