### PR TITLE
Add Classic Cost Model for Cases and Calculate case costs using both cost models in parallel.

### DIFF
--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseCostBarChartCard.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseCostBarChartCard.vue
@@ -95,7 +95,7 @@ export default {
     series() {
       let series = { name: "cost", data: [] }
       forEach(this.modelValue, function (value) {
-        series.data.push(sumBy(value, "total_cost"))
+        series.data.push(sumBy(value, "total_cost_new"))
       })
 
       return [series]

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseDialogFilter.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseDialogFilter.vue
@@ -187,7 +187,8 @@ export default {
           "tags",
           "title",
           "triage_at",
-          "total_cost",
+          "total_cost_classic",
+          "total_cost_new",
         ],
       }
 

--- a/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
+++ b/src/dispatch/static/dispatch/src/dashboard/case/CaseOverview.vue
@@ -31,18 +31,25 @@
           sup-title="Cases Escalated"
         />
       </v-col>
-      <v-col cols="12" sm="6" lg="6">
+      <v-col cols="12" sm="6" lg="4">
         <stat-widget
           icon="mdi-clock"
           :title="toNumberString(totalHours)"
           sup-title="Total Hours (New to Closed)"
         />
       </v-col>
-      <v-col cols="12" sm="6" lg="6">
+      <v-col cols="12" sm="6" lg="4">
         <stat-widget
           icon="mdi-currency-usd"
-          :title="toUSD(totalCasesCost)"
-          sup-title="Total Cases Cost"
+          :title="toUSD(totalCasesCostClassic)"
+          sup-title="Total Cases Cost (Classic)"
+        />
+      </v-col>
+      <v-col cols="12" sm="6" lg="4">
+        <stat-widget
+          icon="mdi-currency-usd"
+          :title="toUSD(totalCasesCostNew)"
+          sup-title="Total Cases Cost (New)"
         />
       </v-col>
       <!-- Widgets Ends -->
@@ -240,12 +247,16 @@ export default {
         return differenceInHours(parseISO(endTime), parseISO(item.reported_at))
       })
     },
-    totalCasesCost() {
-      let total_cost = sumBy(this.items, "total_cost")
+    totalCasesCostClassic() {
+      let total_cost = sumBy(this.items, "total_cost_classix")
+      return total_cost ? total_cost : 0
+    },
+    totalCasesCostNew() {
+      let total_cost = sumBy(this.items, "total_cost_new")
       return total_cost ? total_cost : 0
     },
     averageCaseCost() {
-      return this.totalCasesCost / this.totalCases
+      return this.totalCasesCostNew / this.totalCases
     },
     defaultUserProjects: {
       get() {

--- a/tests/case_cost/test_case_cost_service.py
+++ b/tests/case_cost/test_case_cost_service.py
@@ -190,28 +190,148 @@ def test_update_case_participant_activities__no_enabled_plugins(
     assert not activities
 
 
-def test_calculate_case_response_cost(case, session, participant_activity):
-    """Tests that the case response cost is calculated correctly."""
+def test_get_engagement_multiplier():
+    """Tests that engagement multipliers are returned correctly for different roles."""
+    from dispatch.participant_role.models import ParticipantRoleType
+    from dispatch.case_cost.service import get_engagement_multiplier
+
+    assert get_engagement_multiplier(ParticipantRoleType.assignee) == 1
+    assert get_engagement_multiplier(ParticipantRoleType.reporter) == 0.5
+    assert get_engagement_multiplier(ParticipantRoleType.participant) == 0.5
+    assert get_engagement_multiplier(ParticipantRoleType.observer) == 0
+
+
+def test_calculate_case_response_cost(case, session, participant_activity, case_cost_type):
+    """Tests that the case response cost is calculated correctly for both models."""
     from dispatch.case_cost.service import (
         calculate_case_response_cost,
         calculate_response_cost,
         get_hourly_rate,
     )
+    from dispatch.case.enums import CostModelType
 
-    # Set up participant activity.
+    # Set up participant activity
     participant_activity.case = case
 
-    # Assert that the response cost was calculated correctly.
-    response_cost = calculate_case_response_cost(case=case, db_session=session)
-    assert response_cost == calculate_response_cost(
+    # Set up cost types for both models
+    case_cost_type.model_type = CostModelType.new
+    case_cost_type.project = case.project
+
+    # Calculate costs using both models
+    costs = calculate_case_response_cost(case=case, db_session=session)
+
+    # Assert both models returned costs
+    assert CostModelType.new in costs
+    assert CostModelType.classic in costs
+
+    # Verify new model cost calculation
+    expected_cost = calculate_response_cost(
         hourly_rate=get_hourly_rate(case.project),
         total_response_time_seconds=(
             participant_activity.ended_at - participant_activity.started_at
         ).total_seconds(),
     )
+    assert costs[CostModelType.new] == expected_cost
 
 
-def test_update_case_response_cost(case, session, participant_activity, case_cost_type):
+def test_calculate_case_response_cost_classic(
+    case, session, participant, participant_role, case_cost_type
+):
+    """Tests that the classic cost model calculates costs correctly."""
+    from datetime import datetime, timedelta, timezone
+    import math
+    from dispatch.case_cost.service import (
+        calculate_case_response_cost_classic,
+        get_hourly_rate,
+    )
+    from dispatch.participant_role.models import ParticipantRoleType
+    from dispatch.case.enums import CostModelType
+
+    # Set up timestamps with exact timing
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    one_hour_ago = (now - timedelta(hours=1)).replace(microsecond=0)
+    case.created_at = one_hour_ago.replace(tzinfo=None)
+
+    # Set up participant role with exact timing
+    participant_role.role = ParticipantRoleType.assignee  # Full engagement multiplier
+    participant_role.assumed_at = one_hour_ago.replace(tzinfo=None)
+    participant_role.renounced_at = now.replace(tzinfo=None)  # Set exact end time
+
+    # Set up participant
+    participant.participant_roles = [participant_role]
+    case.participants.append(participant)
+
+    # Set up cost type for classic model
+    case_cost_type.model_type = CostModelType.classic
+    case_cost_type.project = case.project
+
+    # Calculate cost
+    cost = calculate_case_response_cost_classic(case=case, db_session=session)
+
+    # Verify cost calculation
+    hourly_rate = get_hourly_rate(case.project)
+    expected_cost = math.ceil(hourly_rate)  # Cost for 1 hour with full engagement
+    assert cost > 0
+    assert cost == expected_cost  # Should be exactly the hourly rate for 1 hour at full engagement
+
+
+def test_get_participant_role_time_seconds(case, participant_role):
+    """Tests that participant role time is calculated correctly."""
+    from datetime import datetime, timedelta, timezone
+    from dispatch.case_cost.service import get_participant_role_time_seconds
+    from dispatch.participant_role.models import ParticipantRoleType
+
+    # Set up test times with exact 1 hour difference
+    now = datetime.now(timezone.utc).replace(microsecond=0, tzinfo=None)
+    one_hour_ago = (now - timedelta(hours=1)).replace(microsecond=0)
+
+    # Set up participant role for full engagement test with exact timing
+    participant_role.role = ParticipantRoleType.assignee
+    participant_role.assumed_at = one_hour_ago
+    participant_role.renounced_at = now  # Set exact end time instead of None
+
+    # Test full engagement role (assignee)
+    time_seconds = get_participant_role_time_seconds(case=case, participant_role=participant_role)
+    assert time_seconds > 0
+    assert time_seconds <= 3600  # Should not exceed 1 hour
+
+    # Set up participant role for no engagement test
+    participant_role.role = ParticipantRoleType.observer
+
+    # Test no engagement role (observer)
+    time_seconds = get_participant_role_time_seconds(case=case, participant_role=participant_role)
+    assert time_seconds == 0
+
+
+def test_get_total_participant_roles_time_seconds(case, participant, participant_role):
+    """Tests that total participant role time is calculated correctly."""
+    from datetime import datetime, timedelta, timezone
+    from dispatch.case_cost.service import get_total_participant_roles_time_seconds
+    from dispatch.participant_role.models import ParticipantRoleType
+
+    # Set up test times with exact 1 hour difference
+    now = datetime.now(timezone.utc).replace(microsecond=0, tzinfo=None)
+    one_hour_ago = (now - timedelta(hours=1)).replace(microsecond=0)
+
+    # Set up participant role with exact timing
+    participant_role.role = ParticipantRoleType.assignee
+    participant_role.assumed_at = one_hour_ago
+    participant_role.renounced_at = now  # Set exact end time instead of None
+
+    # Add role to participant and participant to case
+    participant.participant_roles = [participant_role]
+    case.participants.append(participant)
+
+    # Calculate total time
+    total_time = get_total_participant_roles_time_seconds(case=case)
+
+    assert total_time > 0
+    assert total_time <= 3600  # Should not exceed 1 hour
+
+
+def test_update_case_response_cost(
+    case, session, participant_activity, case_cost_type, cost_model_activity
+):
     """Tests that the case response cost is created correctly."""
     from dispatch.case.enums import CostModelType
     from dispatch.case_cost.service import update_case_response_cost
@@ -220,15 +340,18 @@ def test_update_case_response_cost(case, session, participant_activity, case_cos
     # Set up participant activity
     participant_activity.case = case
 
-    # Set up default case cost type
-    for cost_type in case_cost_type_service.get_all(db_session=session):
-        cost_type.model_type = None
-    case_cost_type.project = case.project
+    # Set up cost types for both models
     case_cost_type.model_type = CostModelType.new
+    case_cost_type.project = case.project
+
+    # Set up case type cost model
+    case.case_type.cost_model.enabled = True
+    case.case_type.cost_model.activities = [cost_model_activity]
 
     # Assert that costs were calculated
     results = update_case_response_cost(case=case, db_session=session)
     assert results[CostModelType.new] > 0
+    assert results[CostModelType.classic] >= 0
 
 
 def test_update_case_response_cost__fail_no_cost_types(case, session):


### PR DESCRIPTION
This PR implements the classic cost model functionality for cases, mirroring the existing incident cost model while adapting for case-specific concepts.

# Changes

## Core Implementation
Added role-based engagement multipliers for case roles:
 * Owner: 1.0 (equivalent to incident commander)
 * Reporter: 0.5
 * Participant: 0.5
 * Observer: 0 (no cost calculation)

Implemented time calculation functions that handle case status transitions:
 * New/Triage: Active time tracking
 * Closed: Cost calculation stops at closed_at
 * Escalated: Cost calculation stops at escalated_at

## Cost Calculation
 * Both cost models (new and classic) now run in parallel
 * Results are returned as a dictionary with both cost calculations
 * Time calculations account for 8-hour workdays when cases extend beyond 24 hours

## Testing
The implementation includes tests for:
 * Role engagement multiplier accuracy
 * Time calculation edge cases
 * Cost calculation verification
 * Classic Cost Model integration
 * Status transition handling

## Migration
No migration required. The classic model will begin calculating costs for cases automatically while maintaining the existing new model calculations.