### PR TITLE
Truncate the GenAI analysis message if it exceeds Block Kit's maximum length of 3000 characters

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -353,6 +353,9 @@ def create_genai_signal_message_metadata_blocks(
     """
     if isinstance(message, dict):
         message = json_to_slack_format(message)
+
+    # Truncate the message if it exceeds Block Kit's maximum length
+    message = (message[:3000] + "..") if len(message) > 3000 else message
     signal_metadata_blocks.append(
         Section(text=f":magic_wand: *GenAI Alert Analysis*\n\n{message}"),
     )

--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -355,7 +355,7 @@ def create_genai_signal_message_metadata_blocks(
         message = json_to_slack_format(message)
 
     # Truncate the message if it exceeds Block Kit's maximum length
-    message = message[:3000] if len(message) > 3000 else message
+    message = message[:2997] + "..." if len(message) > 3000 else message
     signal_metadata_blocks.append(
         Section(text=f":magic_wand: *GenAI Alert Analysis*\n\n{message}"),
     )

--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -355,7 +355,7 @@ def create_genai_signal_message_metadata_blocks(
         message = json_to_slack_format(message)
 
     # Truncate the message if it exceeds Block Kit's maximum length
-    message = (message[:3000] + "..") if len(message) > 3000 else message
+    message = message[:3000] if len(message) > 3000 else message
     signal_metadata_blocks.append(
         Section(text=f":magic_wand: *GenAI Alert Analysis*\n\n{message}"),
     )


### PR DESCRIPTION
This PR fixes a bug where the GenAI analysis message exceeds 3000 characters. Block Kit can only render text sections with a maximum of 3000 characters.