### PR TITLE
fix(slack): do not set dedicated channel to true in create_channel_button_click()

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -1554,9 +1554,6 @@ def create_channel_button_click(
     db_session: Session,
 ):
     ack()
-    case = case_service.get(db_session=db_session, case_id=context["subject"].id)
-    case.dedicated_channel = True
-    db_session.commit()
 
     blocks = [
         Section(text="Migrate the thread conversation to a dedicated channel?"),


### PR DESCRIPTION
Setting `dedicated_channel` to `True` before the create case channel modal has been submitted can lead to non-dedicated channels to be archived when cases are closed if the modal is cancelled.