### PR TITLE
bugfix(Slack/case): returning case name to thread message

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -93,6 +93,7 @@ def create_case_message(case: Case, channel_id: str) -> list[Block]:
     )
 
     blocks = [
+        Context(elements=[f"* {case.name} - Case Details*"]),
         Section(
             text=title,
             accessory=Button(

--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -6,6 +6,7 @@ from blockkit import (
     Button,
     Context,
     Divider,
+    MarkdownText,
     Message,
     Section,
 )
@@ -93,7 +94,7 @@ def create_case_message(case: Case, channel_id: str) -> list[Block]:
     )
 
     blocks = [
-        Context(elements=[f"* {case.name} - Case Details*"]),
+        Context(elements=[MarkdownText(text=f"* {case.name} - Case Details*")]),
         Section(
             text=title,
             accessory=Button(


### PR DESCRIPTION
Returns the case name in the case threads that was erroneously removed in https://github.com/Netflix/dispatch/pull/5267. 

![image](https://github.com/user-attachments/assets/879e3b1a-57c2-48a4-ab87-29bd90d2135b)
