### PR TITLE
feat(slack): adds ability to remove users from channel

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/enums.py
+++ b/src/dispatch/plugins/dispatch_slack/enums.py
@@ -22,6 +22,7 @@ class SlackAPIPostEndpoints(DispatchEnum):
     conversations_archive = "conversations.archive"
     conversations_create = "conversations.create"
     conversations_invite = "conversations.invite"
+    conversations_kick = "conversations.kick"
     conversations_rename = "conversations.rename"
     conversations_set_topic = "conversations.setTopic"
     conversations_set_purpose = "conversations.setPurpose"

--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -56,6 +56,7 @@ from .service import (
     get_user_info_by_id,
     get_user_profile_by_email,
     is_user,
+    kick_member_from_channel,
     rename_conversation,
     resolve_user,
     send_ephemeral_message,
@@ -387,6 +388,15 @@ class SlackConversationPlugin(ConversationPlugin):
         """Sets the conversation description."""
         client = create_slack_client(self.configuration)
         return set_conversation_description(client, conversation_id, description)
+
+    def kick_user(self, conversation_id: str, user_email: str):
+        """Kicks a user from a conversation."""
+        client = create_slack_client(self.configuration)
+        user_id = resolve_user(client, user_email).get("id")
+        if user_id:
+            return kick_member_from_channel(
+                client=client, conversation_id=conversation_id, user_id=user_id
+            )
 
     def add_bookmark(self, conversation_id: str, weblink: str, title: str):
         """Adds a bookmark to the conversation."""

--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -56,7 +56,7 @@ from .service import (
     get_user_info_by_id,
     get_user_profile_by_email,
     is_user,
-    kick_member_from_channel,
+    remove_member_from_channel,
     rename_conversation,
     resolve_user,
     send_ephemeral_message,
@@ -389,12 +389,12 @@ class SlackConversationPlugin(ConversationPlugin):
         client = create_slack_client(self.configuration)
         return set_conversation_description(client, conversation_id, description)
 
-    def kick_user(self, conversation_id: str, user_email: str):
-        """Kicks a user from a conversation."""
+    def remove_user(self, conversation_id: str, user_email: str):
+        """Removes a user from a conversation."""
         client = create_slack_client(self.configuration)
         user_id = resolve_user(client, user_email).get("id")
         if user_id:
-            return kick_member_from_channel(
+            return remove_member_from_channel(
                 client=client, conversation_id=conversation_id, user_id=user_id
             )
 

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -348,8 +348,8 @@ def add_conversation_bookmark(
     )
 
 
-def kick_member_from_channel(client: WebClient, conversation_id: str, user_id: str) -> None:
-    """Kicks a user from a channel."""
+def remove_member_from_channel(client: WebClient, conversation_id: str, user_id: str) -> None:
+    """Removes a user from a channel."""
     return make_call(
         client, SlackAPIPostEndpoints.conversations_kick, channel=conversation_id, user=user_id
     )

--- a/src/dispatch/plugins/dispatch_slack/service.py
+++ b/src/dispatch/plugins/dispatch_slack/service.py
@@ -348,6 +348,13 @@ def add_conversation_bookmark(
     )
 
 
+def kick_member_from_channel(client: WebClient, conversation_id: str, user_id: str) -> None:
+    """Kicks a user from a channel."""
+    return make_call(
+        client, SlackAPIPostEndpoints.conversations_kick, channel=conversation_id, user=user_id
+    )
+
+
 def create_conversation(client: WebClient, name: str, is_private: bool = False) -> dict:
     """Make a new Slack conversation."""
     response = make_call(


### PR DESCRIPTION
This PR provides a way for the Slack plugin to remove users from a Dispatch-managed channel. Partially addresses DNRPLAT-122.