### PR TITLE
(bugfix/case) Toggle the classic case costs on by default.

### DIFF
--- a/src/dispatch/static/dispatch/src/case/CostsTab.vue
+++ b/src/dispatch/static/dispatch/src/case/CostsTab.vue
@@ -87,7 +87,7 @@ export default {
   },
 
   data: () => ({
-    model: "New",
+    model: "Classic",
   }),
 
   setup() {


### PR DESCRIPTION
In the cases landing page, the case costs reflect the classic cost model by default. This should be reflected in the case costs tab as well. 