### PR TITLE
Add oncall display name when sending option to page the oncall

### DIFF
--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -294,11 +294,17 @@ def case_new_create_flow(
     elif case.event:
         # no one has been paged, inform the channel that they can
         # engage the oncall if the priority changes
-        oncall_service = service_service.get_by_external_id(
-            db_session=db_session,
-            external_id=case.case_type.oncall_service.external_id,
-        )
-        oncall_name = oncall_service.name if oncall_service else "the relevant team"
+        oncall_name = "the relevant team"
+
+        try:
+            if case.case_type and case.case_type.oncall_service:
+                oncall_service = service_service.get_by_external_id(
+                    db_session=db_session,
+                    external_id=case.case_type.oncall_service.external_id,
+                )
+                oncall_name = oncall_service.name
+        except Exception as e:
+            log.error(f"Failed to get oncall service: {e}. Falling back to default oncall_name string.")
 
         send_event_paging_message(case, db_session, oncall_name)
 

--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -294,7 +294,13 @@ def case_new_create_flow(
     elif case.event:
         # no one has been paged, inform the channel that they can
         # engage the oncall if the priority changes
-        send_event_paging_message(case, db_session)
+        oncall_service = service_service.get_by_external_id(
+            db_session=db_session,
+            external_id=case.case_type.oncall_service.external_id,
+        )
+        oncall_name = oncall_service.name if oncall_service else "the relevant team"
+
+        send_event_paging_message(case, db_session, oncall_name)
 
     if case and case.case_type.auto_close:
         # we transition the case to the closed state if its case type has auto close enabled

--- a/src/dispatch/case/messaging.py
+++ b/src/dispatch/case/messaging.py
@@ -377,7 +377,7 @@ def send_case_welcome_participant_message(
     log.debug(f"Welcome ephemeral message sent to {participant_email}.")
 
 
-def send_event_paging_message(case: Case, db_session: Session):
+def send_event_paging_message(case: Case, db_session: Session, oncall_name: str):
     """
     Sends a message to the case conversation channel to notify the reporter that they can engage
     with oncall if they need immediate assistance.
@@ -400,7 +400,7 @@ def send_event_paging_message(case: Case, db_session: Session):
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"This event was reported and the team will respond during normal business hours. If you end up needing immediate assistance, you can engage the oncall with `{engage_oncall_command}`.",
+                "text": f"This event was reported and the team will respond during normal business hours. If you end up needing immediate assistance, you can engage `{oncall_name}` with `{engage_oncall_command}` and selecting the 'Page' option.",
             },
         },
     ]

--- a/src/dispatch/case/messaging.py
+++ b/src/dispatch/case/messaging.py
@@ -377,7 +377,7 @@ def send_case_welcome_participant_message(
     log.debug(f"Welcome ephemeral message sent to {participant_email}.")
 
 
-def send_event_paging_message(case: Case, db_session: Session, oncall_name: str):
+def send_event_paging_message(case: Case, db_session: Session, oncall_name: str) -> None:
     """
     Sends a message to the case conversation channel to notify the reporter that they can engage
     with oncall if they need immediate assistance.


### PR DESCRIPTION
This pull request enhances the event paging message functionality by dynamically including the on-call team's name in the notification. The changes ensure better clarity for users by specifying the relevant team to contact for immediate assistance.

Example:
<img width="735" alt="image" src="https://github.com/user-attachments/assets/e1b0a24a-f65d-4d4e-9db5-da9fe6019aff" />