### PR TITLE
fix(slack): Case engage oncall language

### DIFF
--- a/src/dispatch/case/messaging.py
+++ b/src/dispatch/case/messaging.py
@@ -400,7 +400,7 @@ def send_event_paging_message(case: Case, db_session: Session, oncall_name: str)
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"This event was reported and the team will respond during normal business hours. If you end up needing immediate assistance, you can engage `{oncall_name}` with `{engage_oncall_command}` and selecting the 'Page' option.",
+                "text": f"""This event was reported and the team will respond during normal business hours. If you end up needing immediate assistance, you can engage `{oncall_name}` by typing and sending the command `{engage_oncall_command}` within this channel, and, in the resulting dialog box, selecting the "Page" option."""
             },
         },
     ]

--- a/src/dispatch/case/messaging.py
+++ b/src/dispatch/case/messaging.py
@@ -400,7 +400,7 @@ def send_event_paging_message(case: Case, db_session: Session, oncall_name: str)
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"""This event was reported and the team will respond during normal business hours. If you end up needing immediate assistance, you can engage `{oncall_name}` by typing and sending the command `{engage_oncall_command}` within this channel, and, in the resulting dialog box, selecting the "Page" option."""
+                "text": f"""Event reported. Team will respond during business hours. For urgent assistance, type `{engage_oncall_command}` in this channel and select "Page" to contact `{oncall_name}`."""
             },
         },
     ]


### PR DESCRIPTION
This PR provides extra clarity in the Slack message method to engage the oncall for a Case Type.