### PR TITLE
fix: allow GET on incidents/cases to include participants & other fields

### DIFF
--- a/src/dispatch/case/models.py
+++ b/src/dispatch/case/models.py
@@ -305,7 +305,6 @@ class CaseReadMinimal(CaseBase):
     project: ProjectRead
     assignee: ParticipantReadMinimal | None
     case_costs: list[CaseCostReadMinimal] = []
-    participants: Optional[List[ParticipantRead]] = []
 
 
 CaseReadMinimal.update_forward_refs()

--- a/src/dispatch/case/models.py
+++ b/src/dispatch/case/models.py
@@ -305,6 +305,7 @@ class CaseReadMinimal(CaseBase):
     project: ProjectRead
     assignee: ParticipantReadMinimal | None
     case_costs: list[CaseCostReadMinimal] = []
+    participants: Optional[List[ParticipantRead]] = []
 
 
 CaseReadMinimal.update_forward_refs()

--- a/src/dispatch/case/views.py
+++ b/src/dispatch/case/views.py
@@ -132,7 +132,7 @@ def get_cases(
             "page": ...,
             "total": ...,
         }
-        return json.loads(CasePagination(**pagination).json(include=include_fields))
+        return json.loads(CaseExpandedPagination(**pagination).json(include=include_fields))
     return json.loads(CasePagination(**pagination).json())
 
 

--- a/src/dispatch/incident/views.py
+++ b/src/dispatch/incident/views.py
@@ -92,7 +92,7 @@ def get_incidents(
             "page": ...,
             "total": ...,
         }
-        return json.loads(IncidentPagination(**pagination).json(include=include_fields))
+        return json.loads(IncidentExpandedPagination(**pagination).json(include=include_fields))
     return json.loads(IncidentPagination(**pagination).json())
 
 


### PR DESCRIPTION
A user reported that `include[]=participants` hasn't been working for a few months. We currently are using the [`CasePagination`](https://github.com/Netflix/dispatch/blob/main/src/dispatch/case/models.py#L386-L391) for [`get_cases`](https://github.com/Netflix/dispatch/blob/main/src/dispatch/case/views.py#L135) but I think we should use `CaseExpandedPagination` to support all `include[]` options.