### PR TITLE
(slack) show case add entities button even if no entities currently

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -760,19 +760,20 @@ def snooze_button_click(
 
     if entity_select_block:
         blocks.append(entity_select_block)
-        if case_url:
-            blocks.append(
-                Actions(
-                    elements=[
-                        Button(
-                            text="➕   Add entities",
-                            action_id="button-link",
-                            style="primary",
-                            url=case_url,
-                        )
-                    ]
-                ),
-            )
+
+    if case_url:
+        blocks.append(
+            Actions(
+                elements=[
+                    Button(
+                        text="➕   Add entities",
+                        action_id="button-link",
+                        style="primary",
+                        url=case_url,
+                    )
+                ]
+            ),
+        )
         blocks.append(
             Context(
                 elements=[


### PR DESCRIPTION
The option to add entities doesn't currently show up unless some entities currently exist. This pulls out the conditional to display the option to add entities regardless of whether entities already exist in the signal. 