### PR TITLE
fix(ui): force wrap on timeline events

### DIFF
--- a/src/dispatch/static/dispatch/src/incident/TimelineTab.vue
+++ b/src/dispatch/static/dispatch/src/incident/TimelineTab.vue
@@ -44,7 +44,7 @@
           </template>
           <v-row justify="space-between">
             <v-col cols="7">
-              {{ event.description }}
+              <span class="force-wrap">{{ event.description }}</span>
               <transition-group name="slide" v-if="showDetails">
                 <template v-for="(value, key) in event.details" :key="key">
                   <v-card>

--- a/src/dispatch/static/dispatch/src/styles/timeline.css
+++ b/src/dispatch/static/dispatch/src/styles/timeline.css
@@ -1,13 +1,13 @@
 .wavy-underline {
-    text-decoration: underline;
-    text-decoration-style: dotted;
-    text-decoration-color: silver;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 3px;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: silver;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
 }
 
 .pre-formatted {
-    white-space: pre;
+  white-space: pre;
 }
 
 .time-zone-notice {
@@ -121,6 +121,10 @@
   font-style: italic;
 }
 
-.signal-timeline{
+.signal-timeline {
   padding-bottom: 50px;
+}
+
+.force-wrap {
+  word-break: break-all;
 }


### PR DESCRIPTION
This PR ensures that timeline events wrap even if the text does not have any whitespace.

## Before
<img width="836" alt="image" src="https://github.com/user-attachments/assets/b8e5befc-c8d4-4c75-b4b3-5528a5c82902" />

## After
<img width="811" alt="image" src="https://github.com/user-attachments/assets/82ff61cd-8c98-48c7-81b6-0a5bdfc59706" />
