### PR TITLE
fix(slack): case escalation should preserve title

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -186,7 +186,7 @@ def handle_escalate_case_command(
             view=modal,
         )
 
-    default_title = case.name
+    default_title = case.title
     default_description = case.description
     default_project = {"text": case.project.display_name, "value": case.project.id}
 


### PR DESCRIPTION
This pull request includes a small change to the `handle_escalate_case_command` function in `src/dispatch/plugins/dispatch_slack/case/interactive.py`. The change updates the variable `default_title` to use `case.title` instead of `case.name`, ensuring consistency with the `case` object attributes. This matches what happens if you escalate a case in the UI.