### PR TITLE
fix(signal): set to None to allow missing parameters

### DIFF
--- a/src/dispatch/project/models.py
+++ b/src/dispatch/project/models.py
@@ -132,7 +132,7 @@ class ProjectUpdate(ProjectBase):
 
 
 class ProjectRead(ProjectBase):
-    id: PrimaryKey | None
+    id: PrimaryKey | None = None
     stable_priority: IncidentPriorityRead | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/src/dispatch/signal/models.py
+++ b/src/dispatch/signal/models.py
@@ -387,21 +387,21 @@ class SignalStats(DispatchBase):
 
 class SignalInstanceBase(DispatchBase):
     project: ProjectRead | None
-    case: CaseReadMinimal | None
+    case: CaseReadMinimal | None = None
     canary: bool | None = False
     entities: list[EntityRead] | None = []
     raw: dict[str, Any]
-    external_id: str | None
+    external_id: str | None = None
     filter_action: SignalFilterAction | None = None
     created_at: datetime | None = None
 
 
 class SignalInstanceCreate(SignalInstanceBase):
-    signal: SignalRead | None
-    case_priority: CasePriorityRead | None
-    case_type: CaseTypeRead | None
-    conversation_target: str | None
-    oncall_service: ServiceRead | None
+    signal: SignalRead | None = None
+    case_priority: CasePriorityRead | None = None
+    case_type: CaseTypeRead | None = None
+    conversation_target: str | None = None
+    oncall_service: ServiceRead | None = None
 
 
 class SignalInstanceRead(SignalInstanceBase):


### PR DESCRIPTION
This PR adds default None values to several optional fields in signal and project models to allow missing parameters without validation errors.