### PR TITLE
fix(slack): PlainOption requires string values

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/fields.py
+++ b/src/dispatch/plugins/dispatch_slack/fields.py
@@ -262,11 +262,27 @@ def static_select_block(
     **kwargs,
 ):
     """Builds a static select block."""
+    # Ensure all values in options are strings
+    processed_options = []
+    if options:
+        for x in options:
+            option_dict = {k: str(v) if k == "value" else v for k, v in x.items()}
+            processed_options.append(option_dict)
+
+    # Ensure value in initial_option is a string
+    processed_initial_option = None
+    if initial_option:
+        processed_initial_option = {
+            k: str(v) if k == "value" else v for k, v in initial_option.items()
+        }
+
     return Input(
         element=StaticSelect(
             placeholder=placeholder,
-            options=[PlainOption(**x) for x in options] if options else None,
-            initial_option=PlainOption(**initial_option) if initial_option else None,
+            options=[PlainOption(**x) for x in processed_options] if processed_options else None,
+            initial_option=(
+                PlainOption(**processed_initial_option) if processed_initial_option else None
+            ),
             action_id=action_id,
         ),
         block_id=block_id,
@@ -284,10 +300,17 @@ def multi_select_block(
     **kwargs,
 ):
     """Builds a multi select block."""
+    # Ensure all values in options are strings
+    processed_options = []
+    if options:
+        for x in options:
+            option_dict = {k: str(v) if k == "value" else v for k, v in x.items()}
+            processed_options.append(option_dict)
+
     return Input(
         element=MultiStaticSelect(
             placeholder=placeholder,
-            options=[PlainOption(**x) for x in options] if options else None,
+            options=[PlainOption(**x) for x in processed_options] if processed_options else None,
             action_id=action_id,
         ),
         block_id=block_id,

--- a/src/dispatch/plugins/dispatch_slack/fields.py
+++ b/src/dispatch/plugins/dispatch_slack/fields.py
@@ -253,11 +253,11 @@ def datetime_picker_block(
 
 
 def static_select_block(
-    options: list[str],
+    options: list[dict[str, str]],
     placeholder: str,
     action_id: str = None,
     block_id: str = None,
-    initial_option: dict = None,
+    initial_option: dict[str, str] = None,
     label: str = None,
     **kwargs,
 ):
@@ -292,7 +292,7 @@ def static_select_block(
 
 
 def multi_select_block(
-    options: list[str],
+    options: list[dict[str, str]],
     placeholder: str,
     action_id: str = None,
     block_id: str = None,


### PR DESCRIPTION
This PR fixes an issue where PlainOption in Slack blocks requires string values by explicitly converting the "value" keys in options and initial_option dictionaries to strings.