### PR TITLE
fix(auth): adding missing default

### DIFF
--- a/src/dispatch/auth/models.py
+++ b/src/dispatch/auth/models.py
@@ -202,7 +202,7 @@ class UserRead(UserBase):
 
     id: PrimaryKey
     role: str | None = None
-    experimental_features: bool | None
+    experimental_features: bool | None = None
 
 
 class UserUpdate(DispatchBase):


### PR DESCRIPTION
This PR fixes an issue with the auth models by setting a missing default value for the `experimental_features` field in the `UserRead` model.