### PR TITLE
fix(slack): change positional to named arguments

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -433,7 +433,9 @@ class SlackConversationPlugin(ConversationPlugin):
             plugin_event = plugin_service.get_plugin_event_by_id(
                 db_session=db_session, plugin_event_id=plugin_event_id
             )
-            return self.get_event(plugin_event).fetch_activity(client, subject, oldest=oldest)
+            return self.get_event(plugin_event).fetch_activity(
+                client=client, subject=subject, oldest=oldest
+            )
         except Exception as e:
             logger.exception(e)
             raise e


### PR DESCRIPTION
This PR updates the `fetch_activity` call in the Slack plugin to use named arguments instead of positional ones for improved readability and to solve ordering problems.