### PR TITLE
fix(signal): remove redundant `db_session.commit()` in `create_signal_instance`

### DIFF
--- a/src/dispatch/signal/service.py
+++ b/src/dispatch/signal/service.py
@@ -193,7 +193,6 @@ def create_signal_instance(*, db_session: Session, signal_instance_in: SignalIns
 
     signal_instance = create_instance(db_session=db_session, signal_instance_in=signal_instance_in)
     signal_instance.signal = signal_definition
-    db_session.commit()
 
     return signal_instance
 


### PR DESCRIPTION
This PR fixes a potential transaction issue by removing a redundant commit in the create_signal_instance function, since commit behavior is already managed by the nested context manager.

### Context:
[This context manager](https://github.com/Netflix/dispatch/blob/main/src/dispatch/plugins/dispatch_aws/plugin.py#L112-L116) calls `create_signal_instance`
```
for message in response["Messages"]:
    ...
                    with db_session.begin_nested():
                        signal_instance = signal_service.create_signal_instance(
                            db_session=db_session,
                            signal_instance_in=signal_instance_in,
                        )
```
but at the end of [that function](https://github.com/Netflix/dispatch/blob/main/src/dispatch/signal/service.py#L196) we commit the transaction
```
def create_signal_instance(*, db_session: Session, signal_instance_in: SignalInstanceCreate):
    ...
    db_session.commit()

    return signal_instance 
```
but with `being_nested()`, the committing should be handled by the context manager so this `commit()` leaves the session in an undefined state and could close the transaction.