### PR TITLE
fix(slack): values must be str type

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/incident/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/incident/interactive.py
@@ -2196,7 +2196,7 @@ def handle_update_incident_command(
         ),
         tag_multi_select(
             optional=True,
-            initial_options=[{"text": t.name, "value": t.id} for t in incident.tags],
+            initial_options=[{"text": t.name, "value": str(t.id)} for t in incident.tags],
         ),
     ]
 


### PR DESCRIPTION
This PR fixes the Slack integration for incident updates by ensuring that tag IDs are provided as strings in the interactive message options.