### PR TITLE
fix(db): fixes joined model comparison error

### DIFF
--- a/src/dispatch/database/service.py
+++ b/src/dispatch/database/service.py
@@ -483,9 +483,11 @@ def apply_filter_specific_joins(model: Base, filter_spec: dict, query: orm.query
         if model_map.get((model, filter_model)):
             joined_model, is_outer = model_map[(model, filter_model)]
             try:
-                if joined_model not in joined_models:
+                # Use the model or table itself for tracking joins
+                model_or_table = getattr(joined_model, "parent", joined_model)
+                if model_or_table not in joined_models:
                     query = query.join(joined_model, isouter=is_outer)
-                    joined_models.append(joined_model)
+                    joined_models.append(model_or_table)
             except Exception as e:
                 log.exception(e)
 


### PR DESCRIPTION
In our current implementation, we encountered an error when attempting to join models within our query construction logic. The error message indicated: 

```plaintext
Mapped instance expected for relationship comparison to object. Classes, queries and other SQL elements are not accepted in this context; for comparison with a subquery, use Case.assignee.has(**criteria).
```

This issue arose because our logic was attempting to track joined models using `InstrumentedAttribute` objects, which led to incorrect comparisons based on object identity rather than logical identity.

**Changes Made:**

1. **Tracking Models Directly:**
   - Modified the logic to track the actual model or table objects instead of `InstrumentedAttribute` objects. This is done by using the `parent` attribute when available, and defaulting to the `joined_model` itself when `parent` is not present. This ensures that we are consistently tracking the logical entities being joined, regardless of whether they are accessed via ORM attributes or directly as tables.

2. **Avoiding Duplicate Joins:**
   - Implemented a check to determine whether a model or table has already been joined. This is achieved by maintaining a list of joined models or tables (`joined_models`) and checking for membership before appending new joins. This prevents redundant joins and helps maintain query efficiency.