### PR TITLE
fix(cases): use separate email template for cases

### DIFF
--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -138,7 +138,7 @@ def case_add_or_reactivate_participant_flow(
             welcome_template = email_template_service.get_by_type(
                 db_session=db_session,
                 project_id=case.project_id,
-                email_template_type=EmailTemplateTypes.welcome,
+                email_template_type=EmailTemplateTypes.case_welcome,
             )
 
             send_case_welcome_participant_message(
@@ -303,7 +303,9 @@ def case_new_create_flow(
                 )
                 oncall_name = oncall_service.name
         except Exception as e:
-            log.error(f"Failed to get oncall service: {e}. Falling back to default oncall_name string.")
+            log.error(
+                f"Failed to get oncall service: {e}. Falling back to default oncall_name string."
+            )
 
         send_event_paging_message(case, db_session, oncall_name)
 
@@ -1073,7 +1075,7 @@ def case_create_resources_flow(
         welcome_template = email_template_service.get_by_type(
             db_session=db_session,
             project_id=case.project_id,
-            email_template_type=EmailTemplateTypes.welcome,
+            email_template_type=EmailTemplateTypes.case_welcome,
         )
 
         for user_email in set(individual_participants):

--- a/src/dispatch/email_templates/enums.py
+++ b/src/dispatch/email_templates/enums.py
@@ -2,4 +2,5 @@ from dispatch.enums import DispatchEnum
 
 
 class EmailTemplateTypes(DispatchEnum):
-    welcome = "Incident Welcome Email"
+    case_welcome = "Case Welcome Email"
+    incident_welcome = "Incident Welcome Email"

--- a/src/dispatch/incident/messaging.py
+++ b/src/dispatch/incident/messaging.py
@@ -296,7 +296,7 @@ def send_incident_welcome_participant_messages(
     welcome_template = email_template_service.get_by_type(
         db_session=db_session,
         project_id=incident.project_id,
-        email_template_type=EmailTemplateTypes.welcome,
+        email_template_type=EmailTemplateTypes.incident_welcome,
     )
 
     # we send the welcome ephemeral message

--- a/src/dispatch/static/dispatch/src/email_templates/NewEditSheet.vue
+++ b/src/dispatch/static/dispatch/src/email_templates/NewEditSheet.vue
@@ -34,7 +34,7 @@
               <v-col cols="12">
                 <v-select
                   v-model="email_template_type"
-                  :items="['Incident Welcome Email']"
+                  :items="['Incident Welcome Email', 'Case Welcome Email']"
                   :menu-props="{ maxHeight: '400' }"
                   label="Email template type"
                   clearable
@@ -46,7 +46,7 @@
                 <v-textarea
                   v-model="welcome_text"
                   label="Welcome text"
-                  hint="To insert the name of the incident, use {{name}}"
+                  hint="To insert the name of the case/incident, use {{name}}"
                   clearable
                   name="Welcome text"
                 />
@@ -55,7 +55,7 @@
                 <v-textarea
                   v-model="welcome_body"
                   label="Welcome body"
-                  hint="To insert the name of the incident, use {{name}}"
+                  hint="To insert the name of the case/incident, use {{name}}"
                   clearable
                   name="Welcome body"
                 />

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1256,7 +1256,7 @@ class EmailTemplateFactory(BaseFactory):
     """Email Template Factory."""
 
     # Columns
-    email_template_type = EmailTemplateTypes.welcome
+    email_template_type = EmailTemplateTypes.incident_welcome
     welcome_text = "Welcome to Incident {{title}} "
     welcome_body = "{{title}} Incident\n{{description}}"
     components = ["title", "description"]


### PR DESCRIPTION
This PR separates case-specific welcome emails from incident ones by introducing a new `case_welcome` template type and updating all related code paths, UI, and tests.

- Added a new `case_welcome` enum and renamed the old welcome to `incident_welcome`
- Updated factories, messaging, and case flows to use the new template names
- Extended the Vue form to let users choose between incident and case welcome emails

<img width="474" alt="image" src="https://github.com/user-attachments/assets/d577d56f-6694-4bff-8ecd-66729b712335" />
