### PR TITLE
enhancement(events): prompt assignee for triage in Slack

### DIFF
--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -42,6 +42,7 @@ from .messaging import (
     send_case_rating_feedback_message,
     send_case_update_notifications,
     send_event_paging_message,
+    send_event_update_prompt_reminder
 )
 from .models import Case
 from .service import get
@@ -308,6 +309,9 @@ def case_new_create_flow(
             )
 
         send_event_paging_message(case, db_session, oncall_name)
+
+    # send reminder to assignee to update the security event
+    send_event_update_prompt_reminder(case, db_session)
 
     if case and case.case_type.auto_close:
         # we transition the case to the closed state if its case type has auto close enabled

--- a/src/dispatch/case/messaging.py
+++ b/src/dispatch/case/messaging.py
@@ -36,6 +36,7 @@ from dispatch.config import DISPATCH_UI_URL
 from dispatch.email_templates.models import EmailTemplates
 from dispatch.plugin import service as plugin_service
 from dispatch.plugins.dispatch_slack.models import SubjectMetadata
+from dispatch.plugins.dispatch_slack.case.enums import CaseNotificationActions
 from dispatch.event import service as event_service
 from dispatch.notification import service as notification_service
 
@@ -409,7 +410,7 @@ def send_event_update_prompt_reminder(case: Case, db_session: Session) -> None:
                 "type": "section",
                 "text": {
                     "type": "plain_text",
-                    "text": f"Update the title, priority and visibility during triage of this security event.",  # noqa
+                    "text": f"Update the title, priority, case type and visibility during triage of this security event.",  # noqa
                 },
             },
             {
@@ -418,7 +419,7 @@ def send_event_update_prompt_reminder(case: Case, db_session: Session) -> None:
                     {
                         "type": "button",
                         "text": {"type": "plain_text", "text": "Update Case"},
-                        "action_id": "case-update",
+                        "action_id": CaseNotificationActions.update,
                         "style": "primary",
                         "value": button_metadata
                     }

--- a/src/dispatch/case/messaging.py
+++ b/src/dispatch/case/messaging.py
@@ -419,6 +419,7 @@ def send_event_update_prompt_reminder(case: Case, db_session: Session) -> None:
                         "type": "button",
                         "text": {"type": "plain_text", "text": "Update Case"},
                         "action_id": "case-update",
+                        "style": "primary",
                         "value": button_metadata
                     }
                 ],

--- a/src/dispatch/conversation/enums.py
+++ b/src/dispatch/conversation/enums.py
@@ -10,6 +10,7 @@ class ConversationCommands(DispatchEnum):
     report_incident = "report-incident"
     tactical_report = "tactical-report"
     update_incident = "update-incident"
+    escalate_case = "escalate-case"
 
 
 class ConversationButtonActions(DispatchEnum):

--- a/src/dispatch/plugins/dispatch_slack/case/enums.py
+++ b/src/dispatch/plugins/dispatch_slack/case/enums.py
@@ -15,6 +15,7 @@ class CaseNotificationActions(DispatchEnum):
     resolve = "case-notification-resolve"
     triage = "case-notification-triage"
     user_mfa = "case-notification-user-mfa"
+    update = "case-update"
 
 
 class CasePaginateActions(DispatchEnum):

--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -73,6 +73,7 @@ from dispatch.plugins.dispatch_slack.fields import (
     case_resolution_reason_select,
     case_status_select,
     case_type_select,
+    case_visibility_select,
     description_input,
     entity_select,
     extension_request_checkbox,
@@ -265,7 +266,11 @@ def handle_update_case_command(
         Context(
             elements=[
                 MarkdownText(
-                    text=f"Note: Cases cannot be escalated here. Please use the `{context['config'].slack_command_escalate_case}` slash command."
+                    text=(
+                        "Note: Cases cannot be escalated here. Please use the "
+                        f"{SlackConversationConfiguration.model_json_schema()['properties']['slack_command_escalate_case']['default']} "
+                        "slash command."
+                    )
                 )
             ]
         ),
@@ -280,6 +285,11 @@ def handle_update_case_command(
             project_id=case.project.id,
             optional=True,
         ),
+        case_visibility_select(
+            db_session=db_session,
+            initial_option={"text": case.visibility, "value": case.visibility},
+            project_id=case.project.id,
+        )
     ]
 
     modal = Modal(
@@ -1640,6 +1650,26 @@ def create_channel_button_click(
 
 
 @app.action(
+    CaseNotificationActions.update,
+    middleware=[button_context_middleware, db_middleware, user_middleware],
+)
+def update_case_button_click(
+    ack: Ack,
+    body: dict,
+    client: WebClient,
+    context: BoltContext,
+    db_session: Session,
+):
+    return handle_update_case_command(
+        ack=ack,
+        body=body,
+        client=client,
+        context=context,
+        db_session=db_session,
+    )
+
+
+@app.action(
     CaseNotificationActions.user_mfa,
     middleware=[button_context_middleware, db_middleware, user_middleware],
 )
@@ -2007,6 +2037,10 @@ def handle_edit_submission_event(
     if form_data.get(DefaultBlockIds.case_type_select):
         case_type = {"name": form_data[DefaultBlockIds.case_type_select]["name"]}
 
+    case_visibility = case.visibility
+    if form_data.get(DefaultBlockIds.case_visibility_select):
+        case_visibility = form_data[DefaultBlockIds.case_visibility_select]["name"]
+
     assignee_email = None
     if form_data.get(DefaultBlockIds.case_assignee_select):
         assignee_email = client.users_info(
@@ -2023,7 +2057,7 @@ def handle_edit_submission_event(
         resolution=form_data[DefaultBlockIds.resolution_input],
         resolution_reason=resolution_reason,
         status=form_data[DefaultBlockIds.case_status_select]["name"],
-        visibility=case.visibility,
+        visibility=case_visibility,
         case_priority=case_priority,
         case_type=case_type,
     )

--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -286,9 +286,7 @@ def handle_update_case_command(
             optional=True,
         ),
         case_visibility_select(
-            db_session=db_session,
             initial_option={"text": case.visibility, "value": case.visibility},
-            project_id=case.project.id,
         )
     ]
 

--- a/src/dispatch/plugins/dispatch_slack/fields.py
+++ b/src/dispatch/plugins/dispatch_slack/fields.py
@@ -687,12 +687,10 @@ def case_type_select(
 
 
 def case_visibility_select(
-    db_session: Session,
     action_id: str = DefaultActionIds.case_visibility_select,
     block_id: str = DefaultBlockIds.case_visibility_select,
     label: str = "Case Visibility",
     initial_option: dict | None = None,
-    project_id: int = None,
     **kwargs,
 ):
     """Creates a case visibility select."""

--- a/src/dispatch/plugins/dispatch_slack/fields.py
+++ b/src/dispatch/plugins/dispatch_slack/fields.py
@@ -55,6 +55,7 @@ class DefaultBlockIds(DispatchEnum):
     case_status_select = "case-status-select"
     case_severity_select = "case-severity-select"
     case_type_select = "case-type-select"
+    case_visibility_select = "case-visibility-select"
     case_assignee_select = "case-assignee-select"
 
     # entities
@@ -94,6 +95,7 @@ class DefaultActionIds(DispatchEnum):
     case_status_select = "case-status-select"
     case_severity_select = "case-severity-select"
     case_type_select = "case-type-select"
+    case_visibility_select = "case-visibility-select"
 
     # entities
     entity_select = "entity-select"
@@ -676,6 +678,32 @@ def case_type_select(
     return static_select_block(
         placeholder="Select Type",
         options=types,
+        initial_option=initial_option,
+        action_id=action_id,
+        block_id=block_id,
+        label=label,
+        **kwargs,
+    )
+
+
+def case_visibility_select(
+    db_session: Session,
+    action_id: str = DefaultActionIds.case_visibility_select,
+    block_id: str = DefaultBlockIds.case_visibility_select,
+    label: str = "Case Visibility",
+    initial_option: dict | None = None,
+    project_id: int = None,
+    **kwargs,
+):
+    """Creates a case visibility select."""
+    visibility = [
+        {"text": "Restricted", "value": "Restricted"},
+        {"text": "Open", "value": "Open"}
+    ]
+
+    return static_select_block(
+        placeholder="Select Visibility",
+        options=visibility,
         initial_option=initial_option,
         action_id=action_id,
         block_id=block_id,

--- a/src/dispatch/plugins/dispatch_slack/fields.py
+++ b/src/dispatch/plugins/dispatch_slack/fields.py
@@ -18,7 +18,7 @@ from dispatch.case.priority import service as case_priority_service
 from dispatch.case.severity import service as case_severity_service
 from dispatch.case.type import service as case_type_service
 from dispatch.entity import service as entity_service
-from dispatch.enums import DispatchEnum
+from dispatch.enums import DispatchEnum, Visibility
 from dispatch.incident.enums import IncidentStatus
 from dispatch.incident.priority import service as incident_priority_service
 from dispatch.incident.severity import service as incident_severity_service
@@ -695,8 +695,8 @@ def case_visibility_select(
 ):
     """Creates a case visibility select."""
     visibility = [
-        {"text": "Restricted", "value": "Restricted"},
-        {"text": "Open", "value": "Open"}
+        {"text": Visibility.restricted, "value": Visibility.restricted},
+        {"text": Visibility.open, "value": Visibility.open}
     ]
 
     return static_select_block(

--- a/src/dispatch/plugins/dispatch_slack/plugin.py
+++ b/src/dispatch/plugins/dispatch_slack/plugin.py
@@ -412,6 +412,7 @@ class SlackConversationPlugin(ConversationPlugin):
             ConversationCommands.list_participants: self.configuration.slack_command_list_participants,
             ConversationCommands.list_tasks: self.configuration.slack_command_list_tasks,
             ConversationCommands.tactical_report: self.configuration.slack_command_report_tactical,
+            ConversationCommands.escalate_case: self.configuration.slack_command_escalate_case,
         }
         return command_mappings.get(command, [])
 


### PR DESCRIPTION
This pull request includes adding functionality to prompt assignees to update security events and adds a "visibility" field for case updates in Slack.

### Workflow Enhancements:
* Added `send_event_update_prompt_reminder` to `case_new_create_flow` in `src/dispatch/case/flows.py` and in `src/dispatch/case/messaging.py` to remind assignees to update security event details during triage, which sends an ephemeral Slack message to the assignee with a button to update case details.

### Slack Integration Updates:
* Added a new `escalate_case` command to `ConversationCommands` in `src/dispatch/conversation/enums.py` and mapped it to Slack configurations. [[1]](diffhunk://#diff-0b22c4658daba0172305b641f45a570e4b8380bab60073dac357fcab245338d9R13) [[2]](diffhunk://#diff-84bac68ba28c626f61114b432a7c5b163f03541682e3efeb6d0dddc250a7caa8R415)
* Added `update_case_button_click` handler in `src/dispatch/plugins/dispatch_slack/case/interactive.py` to process the "Update Case" button click and open the update modal.

### Case Visibility Field:
* Added `case_visibility_select` functionality in `src/dispatch/plugins/dispatch_slack/fields.py` to allow users to choose "Restricted" or "Open" visibility for cases.
* Updated `handle_edit_submission_event` in `src/dispatch/plugins/dispatch_slack/case/interactive.py` to process the visibility field and save changes.
<img width="566" alt="image" src="https://github.com/user-attachments/assets/81fd354b-ef43-4c60-a4ba-bcfbafbfda8f" />
