### PR TITLE
fix(entity_type): send channel notification once

### DIFF
--- a/src/dispatch/entity_type/flows.py
+++ b/src/dispatch/entity_type/flows.py
@@ -1,14 +1,10 @@
-import logging
 from sqlalchemy.orm import Session
-from dispatch.case.messaging import send_entity_update_notification
 from dispatch.entity_type.models import EntityScopeEnum
 from dispatch.signal.models import SignalInstance
 from dispatch.entity_type import service as entity_type_service
 
 from dispatch.entity_type.models import EntityType
 from dispatch.entity import service as entity_service
-
-log = logging.getLogger(__file__)
 
 
 def recalculate_entity_flow(
@@ -37,14 +33,5 @@ def recalculate_entity_flow(
         )
         signal_instance.entities = entities
         db_session.commit()
-
-    try:
-        send_entity_update_notification(
-            db_session=db_session,
-            entity_type=entity_type,
-            case=signal_instance.case,
-        )
-    except Exception as e:
-        log.warning(f"Failed to send entity update notification: {e}")
 
     return signal_instance

--- a/src/dispatch/entity_type/views.py
+++ b/src/dispatch/entity_type/views.py
@@ -1,8 +1,10 @@
+import logging
 
 from fastapi import APIRouter, HTTPException, status
 from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 
+from dispatch.case.messaging import send_entity_update_notification
 from dispatch.case.service import get as get_case
 from dispatch.database.core import DbSession
 from dispatch.database.service import CommonParameters, search_filter_sort_paginate
@@ -18,6 +20,7 @@ from .models import (
 from .flows import recalculate_entity_flow
 from .service import create, delete, get, update
 
+log = logging.getLogger(__file__)
 router = APIRouter()
 
 
@@ -112,6 +115,15 @@ def recalculate(db_session: DbSession, entity_type_id: PrimaryKey, case_id: Prim
             signal_instance=signal_instance,
         )
         updated_signal_instances.append(updated_signal_instance)
+
+    try:
+        send_entity_update_notification(
+            db_session=db_session,
+            entity_type=entity_type,
+            case=signal_instance[0].case,
+        )
+    except Exception as e:
+        log.warning(f"Failed to send entity update notification: {e}")
 
     return updated_signal_instances
 


### PR DESCRIPTION
Fixes a bug where the entity_type notification was being repeatedly sent in the channel due to multiple signal instances in one case.