### PR TITLE
fix(case): fixing case filtering

### DIFF
--- a/src/dispatch/database/service.py
+++ b/src/dispatch/database/service.py
@@ -461,13 +461,7 @@ def apply_filter_specific_joins(model: Base, filter_spec: dict, query: orm.query
         (SignalInstance, "EntityType"): (SignalInstance.entities, True),
         (Tag, "TagType"): (TagType, False),
         (Tag, "Project"): (Project, False),
-        (CaseType, "Project"): (Project, False),
-        (CaseSeverity, "Project"): (Project, False),
-        (CasePriority, "Project"): (Project, False),
         (IndividualContact, "Project"): (Project, False),
-        (Case, "IndividualContact"): (Case.assignee, False),  # noqa: F601
-        (Case, "Assignee"): (Case.assignee, False),
-        (Case, "Project"): (Case.project, False),
     }
     filters = build_filters(filter_spec)
 

--- a/src/dispatch/database/service.py
+++ b/src/dispatch/database/service.py
@@ -22,9 +22,6 @@ from .core import Base, get_class_by_tablename, get_model_name_by_tablename
 from dispatch.auth.models import DispatchUser
 from dispatch.auth.service import CurrentUser, get_current_role
 from dispatch.case.models import Case
-from dispatch.case.type.models import CaseType
-from dispatch.case.severity.models import CaseSeverity
-from dispatch.case.priority.models import CasePriority
 from dispatch.data.query.models import Query as QueryModel
 from dispatch.data.source.models import Source
 from dispatch.database.core import DbSession


### PR DESCRIPTION
This PR refines the `apply_filter_specific_joins` mapping by removing several unused case-related entries to fix case filtering behavior.

- Removed redundant `CaseType`, `CaseSeverity`, `CasePriority` mappings to `Project`
- Dropped explicit `Case` joins for `IndividualContact`, `Assignee`, and `Project`
- Kept only necessary entity-to-project relations for cleanup