### PR TITLE
feat(events): send slack reminder for Security Events with default title

### DIFF
--- a/src/dispatch/messaging/strings.py
+++ b/src/dispatch/messaging/strings.py
@@ -319,7 +319,7 @@ You can use `{{command}}` in the <{{conversation_weblink}}|conversation> to clos
 ).strip()
 
 CASE_TRIAGE_REMINDER_DESCRIPTION = """The status of this case hasn't been updated recently.
-Please ensure you triage the case based on its priority.""".replace(
+Please ensure you triage the case based on its priority and update its title, priority, severity and tags.""".replace(
     "\n", " "
 ).strip()
 


### PR DESCRIPTION
This pull request includes updates to the `case_triage_reminder` function, enhancements to query logic, and an update to a user-facing message for case triage reminders.

### Enhancements to query logic:
* [`src/dispatch/case/scheduled.py`](diffhunk://#diff-c4ead482871d2d0cbc5bc308fbbdb3d29f63761f0446670c5b06e9e9a7cc400fL55-R69): Updated the `case_triage_reminder` function to use a more complex query with the `or_` condition, allowing cases to be filtered by either title (`"Security Event Triage"`) or status (`CaseStatus.new`). This replaces the previous call to `get_all_by_status`.

### User-facing message update:
* [`src/dispatch/messaging/strings.py`](diffhunk://#diff-5b4ba4d921b37036555202d14216c0928a188ec021b6e368b334904578511f80L322-R322): Enhanced the `CASE_TRIAGE_REMINDER_DESCRIPTION` message to include instructions for updating the case title, priority, severity, and tags, providing clearer guidance to users.