### PR TITLE
fix(email_templates): disallow creation for non admins

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -183,7 +183,7 @@ idna==3.10
     #   yarl
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements-base.in
     #   spacy

--- a/src/dispatch/email_templates/views.py
+++ b/src/dispatch/email_templates/views.py
@@ -43,7 +43,11 @@ def get_email_template(db_session: DbSession, email_template_id: PrimaryKey):
     return email_template
 
 
-@router.post("", response_model=EmailTemplatesRead)
+@router.post(
+    "",
+    response_model=EmailTemplatesRead,
+    dependencies=[Depends(PermissionsDependency([SensitiveProjectActionPermission]))],
+)
 def create_email_template(
     db_session: DbSession,
     email_template_in: EmailTemplatesCreate,


### PR DESCRIPTION
This PR restricts email template creation to users with the appropriate admin permission and updates the Jinja2 dependency.

- Enforce `SensitiveProjectActionPermission` on the `create_email_template` endpoint
- Bump Jinja2 from 3.1.5 to 3.1.6