### PR TITLE
fix(ui): tooltip props get unique name

### DIFF
--- a/src/dispatch/static/dispatch/src/case/ClosedDialog.vue
+++ b/src/dispatch/static/dispatch/src/case/ClosedDialog.vue
@@ -24,9 +24,9 @@
                       <div class="d-flex align-center justify-space-between">
                         {{ item.title }}
                         <v-tooltip location="right">
-                          <template #activator="{ props }">
+                          <template #activator="{ props: tooltipProps }">
                             <v-icon
-                              v-bind="props"
+                              v-bind="tooltipProps"
                               icon="mdi-information"
                               size="small"
                               class="ml-2"

--- a/src/dispatch/static/dispatch/src/case/DetailsTab.vue
+++ b/src/dispatch/static/dispatch/src/case/DetailsTab.vue
@@ -37,8 +37,13 @@
                 <div class="d-flex align-center justify-space-between">
                   {{ item.title }}
                   <v-tooltip location="right">
-                    <template #activator="{ props }">
-                      <v-icon v-bind="props" icon="mdi-information" size="small" class="ml-2" />
+                    <template #activator="{ props: tooltipProps }">
+                      <v-icon
+                        v-bind="tooltipProps"
+                        icon="mdi-information"
+                        size="small"
+                        class="ml-2"
+                      />
                     </template>
                     <span>{{ $store.state.case_management.resolutionTooltips[item.title] }}</span>
                   </v-tooltip>


### PR DESCRIPTION
This PR updates the tooltip activator templates by renaming the destructured binding from "props" to "tooltipProps" to ensure unique naming for tooltip properties.

- Renames the tooltip property in DetailsTab.vue
- Applies the same renaming in ClosedDialog.vue