### PR TITLE
fix(case): escalation priority not persisting

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -1534,7 +1534,8 @@ def handle_escalation_submission_event(
 ):
     """Handles the escalation submission event."""
 
-    from dispatch.incident.type.service import get_by_name
+    from dispatch.incident.type.service import get_by_name as get_type_by_name
+    from dispatch.incident.priority.service import get_by_name as get_priority_by_name
 
     case = case_service.get(db_session=db_session, case_id=int(context["subject"].id))
     ack_handle_escalation_submission_event(ack=ack, case=case)
@@ -1556,7 +1557,7 @@ def handle_escalation_submission_event(
 
     incident_type = None
     if form_data.get(DefaultBlockIds.incident_type_select):
-        incident_type = get_by_name(
+        incident_type = get_type_by_name(
             db_session=db_session,
             project_id=case.project.id,
             name=form_data[DefaultBlockIds.incident_type_select]["name"],
@@ -1564,7 +1565,7 @@ def handle_escalation_submission_event(
 
     incident_priority = None
     if form_data.get(DefaultBlockIds.incident_priority_select):
-        incident_priority = get_by_name(
+        incident_priority = get_priority_by_name(
             db_session=db_session,
             project_id=case.project.id,
             name=form_data[DefaultBlockIds.incident_priority_select]["name"],

--- a/src/dispatch/plugins/dispatch_slack/case/interactive.py
+++ b/src/dispatch/plugins/dispatch_slack/case/interactive.py
@@ -37,6 +37,8 @@ from dispatch.entity import service as entity_service
 from dispatch.enums import EventType, SubjectNames, UserRoles, Visibility
 from dispatch.event import service as event_service
 from dispatch.exceptions import ExistsError
+from dispatch.incident.type.service import get_by_name as get_type_by_name
+from dispatch.incident.priority.service import get_by_name as get_priority_by_name
 from dispatch.individual.models import IndividualContactRead
 from dispatch.participant import flows as participant_flows
 from dispatch.participant import service as participant_service
@@ -1533,9 +1535,6 @@ def handle_escalation_submission_event(
     user: DispatchUser,
 ):
     """Handles the escalation submission event."""
-
-    from dispatch.incident.type.service import get_by_name as get_type_by_name
-    from dispatch.incident.priority.service import get_by_name as get_priority_by_name
 
     case = case_service.get(db_session=db_session, case_id=int(context["subject"].id))
     ack_handle_escalation_submission_event(ack=ack, case=case)


### PR DESCRIPTION
This pull request refactors the `handle_escalation_submission_event` function in `src/dispatch/plugins/dispatch_slack/case/interactive.py` to improve code clarity by renaming imported functions and using the correct one for `priority`.