### PR TITLE
feat(ui): Adds icons for case and incident in table status column

### DIFF
--- a/src/dispatch/case/models.py
+++ b/src/dispatch/case/models.py
@@ -388,6 +388,7 @@ class CaseReadMinimal(CaseBase):
     project: ProjectRead
     assignee: ParticipantReadMinimal | None = None
     case_costs: list[CaseCostReadMinimal] = []
+    incidents: list[IncidentReadBasic] | None = []
 
 
 class CaseReadMinimalWithExtras(CaseBase):

--- a/src/dispatch/incident/models.py
+++ b/src/dispatch/incident/models.py
@@ -248,7 +248,7 @@ class ProjectRead(DispatchBase):
     display_name: str | None = None
 
 
-class CaseRead(DispatchBase):
+class CaseReadBasic(DispatchBase):
     """Pydantic model for reading a case resource."""
 
     id: PrimaryKey
@@ -353,12 +353,13 @@ class IncidentReadMinimal(IncidentBase):
     tags: list[TagRead] | None = []
     tasks: list[TaskReadMinimal] | None = []
     total_cost: float | None = None
+    cases: list[CaseReadBasic] | None = []
 
 
 class IncidentUpdate(IncidentBase):
     """Pydantic model for updating an incident resource."""
 
-    cases: list[CaseRead] | None = []
+    cases: list[CaseReadBasic] | None = []
     commander: ParticipantUpdate | None = None
     delay_executive_report_reminder: datetime | None = None
     delay_tactical_report_reminder: datetime | None = None
@@ -396,7 +397,7 @@ class IncidentRead(IncidentBase):
     """Pydantic model for reading an incident resource."""
 
     id: PrimaryKey
-    cases: list[CaseRead] | None = []
+    cases: list[CaseReadBasic] | None = []
     closed_at: datetime | None = None
     commander: ParticipantRead | None = None
     commanders_location: str | None = None

--- a/src/dispatch/static/dispatch/src/case/CaseStatus.vue
+++ b/src/dispatch/static/dispatch/src/case/CaseStatus.vue
@@ -26,7 +26,6 @@
             variant="text"
             density="comfortable"
             class="ml-1"
-            size="small"
             color="orange"
             @click.stop="navigateToIncident(incidents[0])"
           />

--- a/src/dispatch/static/dispatch/src/case/CaseStatus.vue
+++ b/src/dispatch/static/dispatch/src/case/CaseStatus.vue
@@ -17,6 +17,22 @@
         </template>
       </v-tooltip>
     </template>
+    <template v-if="incidents && incidents.length > 0">
+      <v-tooltip location="bottom" :text="`View incident`">
+        <template #activator="{ props }">
+          <v-btn
+            v-bind="props"
+            icon="mdi-fire"
+            variant="text"
+            density="comfortable"
+            class="ml-1"
+            size="small"
+            color="orange"
+            @click.stop="navigateToIncident(incidents[0])"
+          />
+        </template>
+      </v-tooltip>
+    </template>
   </div>
 </template>
 
@@ -43,6 +59,10 @@ export default {
       type: Boolean,
       required: true,
     },
+    incidents: {
+      type: Array,
+      default: () => [],
+    },
   },
 
   computed: {
@@ -61,6 +81,12 @@ export default {
 
   methods: {
     ...mapActions("case_management", ["joinCase"]),
+    navigateToIncident(incident) {
+      this.$router.push({
+        name: "IncidentTableEdit",
+        params: { name: incident.name },
+      })
+    },
   },
 }
 </script>

--- a/src/dispatch/static/dispatch/src/case/CaseSummaryTable.vue
+++ b/src/dispatch/static/dispatch/src/case/CaseSummaryTable.vue
@@ -4,7 +4,13 @@
       <case-priority :priority="value" :color="item.case_priority.color" />
     </template>
     <template #item.status="{ item, value }">
-      <case-status :status="value" :id="item.id" />
+      <case-status
+        :status="value"
+        :id="item.id"
+        :allowSelfJoin="item.project?.allow_self_join || false"
+        :dedicatedChannel="item.dedicated_channel || false"
+        :incidents="item.incidents"
+      />
     </template>
     <template #item.project.display_name="{ item, value }">
       <v-chip size="small" :color="item.project.color">

--- a/src/dispatch/static/dispatch/src/case/Table.vue
+++ b/src/dispatch/static/dispatch/src/case/Table.vue
@@ -77,6 +77,7 @@
                 :id="item.id"
                 :allowSelfJoin="item.project.allow_self_join"
                 :dedicatedChannel="item.dedicated_channel"
+                :incidents="item.incidents"
               />
             </template>
             <template #item.project.display_name="{ item }">

--- a/src/dispatch/static/dispatch/src/case/TableExportDialog.vue
+++ b/src/dispatch/static/dispatch/src/case/TableExportDialog.vue
@@ -90,7 +90,13 @@
                   />
                 </template>
                 <template #item.status="{ item }">
-                  <case-status :status="item.status" :id="item.id" />
+                  <case-status
+                    :status="item.status"
+                    :id="item.id"
+                    :allowSelfJoin="item.project?.allow_self_join || false"
+                    :dedicatedChannel="item.dedicated_channel || false"
+                    :incidents="item.incidents"
+                  />
                 </template>
                 <template #item.tags="{ item }">
                   <span v-for="tag in item.tags" :key="tag">

--- a/src/dispatch/static/dispatch/src/incident/IncidentSummaryTable.vue
+++ b/src/dispatch/static/dispatch/src/incident/IncidentSummaryTable.vue
@@ -4,7 +4,12 @@
       <incident-priority :priority="value" :color="item.incident_priority.color" />
     </template>
     <template #item.status="{ item, value }">
-      <incident-status :status="value" :id="item.id" />
+      <incident-status
+        :status="value"
+        :id="item.id"
+        :allowSelfJoin="item.project?.allow_self_join || false"
+        :cases="item.cases || []"
+      />
     </template>
     <template #item.commander="{ value }">
       <incident-participant :participant="value" />

--- a/src/dispatch/static/dispatch/src/incident/Table.vue
+++ b/src/dispatch/static/dispatch/src/incident/Table.vue
@@ -76,6 +76,7 @@
                 :status="value"
                 :id="item.id"
                 :allowSelfJoin="item.project.allow_self_join"
+                :cases="item.cases"
               />
             </template>
             <template #item.incident_costs="{ value }">

--- a/src/dispatch/static/dispatch/src/incident/TableExportDialog.vue
+++ b/src/dispatch/static/dispatch/src/incident/TableExportDialog.vue
@@ -91,7 +91,12 @@
                   />
                 </template>
                 <template #item.status="{ item }">
-                  <incident-status :status="item.status" :id="item.id" />
+                  <incident-status
+                    :status="item.status"
+                    :id="item.id"
+                    :allowSelfJoin="item.project?.allow_self_join || false"
+                    :cases="item.cases || []"
+                  />
                 </template>
                 <template #item.tags="{ item }">
                   <span v-for="tag in item.tags" :key="tag">

--- a/src/dispatch/static/dispatch/src/incident/status/IncidentStatus.vue
+++ b/src/dispatch/static/dispatch/src/incident/status/IncidentStatus.vue
@@ -37,7 +37,6 @@
             variant="text"
             density="comfortable"
             class="ml-1"
-            size="small"
             color="blue"
             @click.stop="navigateToCase(cases[0])"
           />

--- a/src/dispatch/static/dispatch/src/incident/status/IncidentStatus.vue
+++ b/src/dispatch/static/dispatch/src/incident/status/IncidentStatus.vue
@@ -28,6 +28,22 @@
         </template>
       </v-tooltip>
     </template>
+    <template v-if="cases && cases.length > 0">
+      <v-tooltip location="bottom" :text="`View case`">
+        <template #activator="{ props }">
+          <v-btn
+            v-bind="props"
+            icon="mdi-briefcase"
+            variant="text"
+            density="comfortable"
+            class="ml-1"
+            size="small"
+            color="blue"
+            @click.stop="navigateToCase(cases[0])"
+          />
+        </template>
+      </v-tooltip>
+    </template>
   </div>
 </template>
 
@@ -50,6 +66,10 @@ export default {
       type: Boolean,
       required: true,
     },
+    cases: {
+      type: Array,
+      default: () => [],
+    },
   },
 
   computed: {
@@ -66,6 +86,12 @@ export default {
 
   methods: {
     ...mapActions("incident", ["joinIncident", "subscribeToIncident"]),
+    navigateToCase(caseItem) {
+      this.$router.push({
+        name: "CaseTableEdit",
+        params: { name: caseItem.name },
+      })
+    },
   },
 }
 </script>

--- a/src/dispatch/static/dispatch/src/search/SearchFilterCreateDialog.vue
+++ b/src/dispatch/static/dispatch/src/search/SearchFilterCreateDialog.vue
@@ -152,7 +152,12 @@
                     />
                   </template>
                   <template #item.status="{ item }">
-                    <incident-status :status="item.status" :id="item.id" />
+                    <incident-status
+                      :status="item.status"
+                      :id="item.id"
+                      :allowSelfJoin="item.project?.allow_self_join || false"
+                      :cases="item.cases || []"
+                    />
                   </template>
                 </v-data-table>
               </v-card-text>

--- a/src/dispatch/static/dispatch/src/signal/Table.vue
+++ b/src/dispatch/static/dispatch/src/signal/Table.vue
@@ -49,7 +49,13 @@
               <v-checkbox-btn :model-value="value" disabled />
             </template>
             <template #item.status="{ item, value }">
-              <case-status :status="value" :id="item.id" />
+              <case-status
+                :status="value"
+                :id="item.id"
+                :allowSelfJoin="false"
+                :dedicatedChannel="false"
+                :incidents="[]"
+              />
             </template>
             <template #item.project.display_name="{ item }">
               <v-chip size="small" :color="item.project.color">

--- a/src/dispatch/static/dispatch/src/task/TableExportDialog.vue
+++ b/src/dispatch/static/dispatch/src/task/TableExportDialog.vue
@@ -78,7 +78,12 @@
                   </div>
                 </template>
                 <template #item.incident.status="{ item }">
-                  <incident-status :status="item.incident.status" :id="item.id" />
+                  <incident-status
+                    :status="item.incident.status"
+                    :id="item.id"
+                    :allowSelfJoin="false"
+                    :cases="[]"
+                  />
                 </template>
                 <template #item.incident_priority.name="{ item }">
                   <incident-priority


### PR DESCRIPTION
This PR adds an incident icon to the status column in the case table and a case icon to status column in the incident able when a case is escalated to an incident.

<img width="744" height="167" alt="Screenshot 2025-07-24 at 12 35 15 PM" src="https://github.com/user-attachments/assets/4d71b13c-bf40-4790-ac76-e0d5cac6f5d9" />
<img width="831" height="169" alt="Screenshot 2025-07-24 at 12 35 35 PM" src="https://github.com/user-attachments/assets/27a8b1c3-ba45-4e7e-8c18-1f101459f593" />
