### PR TITLE
fix(case): escalated cases shouldn't update incident channel topic

### DIFF
--- a/src/dispatch/case/flows.py
+++ b/src/dispatch/case/flows.py
@@ -534,7 +534,7 @@ def case_update_flow(
         # we send the case updated notification
         update_conversation(case, db_session)
 
-    if case.has_channel and not case.has_thread and case.status != CaseStatus.closed:
+    if case.has_channel and not case.has_thread and case.status not in [CaseStatus.escalated, CaseStatus.closed]:
         # determine if case channel topic needs to be updated
         if case_details_changed(case, previous_case):
             conversation_flows.set_conversation_topic(case, db_session)


### PR DESCRIPTION
This pull request introduces a small change to the `case_update_flow` function in `src/dispatch/case/flows.py`. The logic for handling case channels has been updated to account for cases with an `escalated` status.