### PR TITLE
(refactor) surface signal tags in case model

### DIFF
--- a/src/dispatch/case/models.py
+++ b/src/dispatch/case/models.py
@@ -266,6 +266,7 @@ class SignalRead(DispatchBase):
     external_id: str
     external_url: str | None = None
     workflow_instances: list[WorkflowInstanceRead] | None = []
+    tags: list[TagRead] | None = []
 
 
 class SignalInstanceRead(DispatchBase):

--- a/src/dispatch/database/service.py
+++ b/src/dispatch/database/service.py
@@ -7,7 +7,6 @@ from itertools import chain
 
 from fastapi import Depends, Query
 from pydantic import StringConstraints
-from pydantic import ValidationError
 from pydantic import Json
 from six import string_types
 from sortedcontainers import SortedSet
@@ -721,24 +720,9 @@ def search_filter_sort_paginate(
             sort_spec = create_sort_spec(model, sort_by, descending)
             query = apply_sort(query, sort_spec)
 
-    except FieldNotFound as e:
-        raise ValidationError(
-            [
-                {
-                    "msg": str(e),
-                    "loc": "filter",
-                }
-            ]
-        ) from None
-    except BadFilterFormat as e:
-        raise ValidationError(
-            [
-                {
-                    "msg": str(e),
-                    "loc": "filter",
-                }
-            ]
-        ) from None
+    except (FieldNotFound, BadFilterFormat) as e:
+        log.error(f"Error building or applying filters: {str(e)}")
+        raise e
 
     if items_per_page == -1:
         items_per_page = None


### PR DESCRIPTION
Surfaces signal tags in addition to signal instance tags in the case model, for accessibility and use in search filter functionality. 

Additionally replaces an incorrect construction of the Pydantic ValidationError that prevented proper error message propagation: since this error is not caught and should be surfaced to the UI, I don't believe it needs to be a ValidationError specifically. 