### PR TITLE
fix(slack): resolved by block error

### DIFF
--- a/src/dispatch/plugins/dispatch_slack/case/messages.py
+++ b/src/dispatch/plugins/dispatch_slack/case/messages.py
@@ -150,7 +150,7 @@ def create_case_message(case: Case, channel_id: str) -> list[Block]:
             ]
         )
         if case.resolved_by:
-            blocks.append(Section(text=f"*Resolved by* \n {case.resolved_by.individual.email}"))
+            blocks.append(Section(text=f"*Resolved by* \n {case.resolved_by.email}"))
         blocks.append(
             Actions(
                 elements=[


### PR DESCRIPTION
This PR fixes an error in the Slack block since `resolved_by` is an `IndividualContact`, we should remove the erroneous resolution to `individual`.